### PR TITLE
feat: add MCP23017 I2C GPIO expander driver

### DIFF
--- a/src/evo_hl/mcp23017/__init__.py
+++ b/src/evo_hl/mcp23017/__init__.py
@@ -1,0 +1,5 @@
+"""MCP23017 I2C GPIO expander driver."""
+
+from evo_hl.mcp23017.base import MCP23017
+
+__all__ = ["MCP23017"]

--- a/src/evo_hl/mcp23017/adafruit.py
+++ b/src/evo_hl/mcp23017/adafruit.py
@@ -1,0 +1,55 @@
+"""MCP23017 driver — Adafruit CircuitPython implementation."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.mcp23017.base import MCP23017, NUM_PINS
+
+log = logging.getLogger(__name__)
+
+
+class MCP23017Adafruit(MCP23017):
+    """MCP23017 over I2C using Adafruit CircuitPython (any blinka-supported SBC)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._mcp = None
+        self._pins = {}
+
+    def init(self) -> None:
+        import board
+        import busio
+        from adafruit_mcp230xx.mcp23017 import MCP23017 as _HwMCP23017
+
+        i2c = busio.I2C(board.SCL, board.SDA)
+        self._mcp = _HwMCP23017(i2c, address=self.address)
+        log.info("MCP23017 initialized at 0x%02x", self.address)
+
+    def setup_pin(self, pin: int, output: bool, default: bool = False) -> None:
+        if not 0 <= pin < NUM_PINS:
+            raise ValueError(f"Pin {pin} out of range (0-{NUM_PINS - 1})")
+
+        from digitalio import Direction
+
+        mcp_pin = self._mcp.get_pin(pin)
+        mcp_pin.direction = Direction.OUTPUT if output else Direction.INPUT
+        if output:
+            mcp_pin.value = default
+        self._pins[pin] = mcp_pin
+        log.debug("MCP pin%d → %s", pin, "output" if output else "input")
+
+    def read(self, pin: int) -> bool:
+        if pin not in self._pins:
+            raise ValueError(f"Pin {pin} not configured — call setup_pin first")
+        return self._pins[pin].value
+
+    def write(self, pin: int, value: bool) -> None:
+        if pin not in self._pins:
+            raise ValueError(f"Pin {pin} not configured — call setup_pin first")
+        self._pins[pin].value = value
+
+    def close(self) -> None:
+        self._pins.clear()
+        self._mcp = None
+        log.info("MCP23017 closed")

--- a/src/evo_hl/mcp23017/base.py
+++ b/src/evo_hl/mcp23017/base.py
@@ -1,0 +1,34 @@
+"""Abstract base class for MCP23017 16-pin I2C GPIO expander."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+NUM_PINS = 16
+class MCP23017(ABC):
+    """Controls digital I/O via an MCP23017 I2C GPIO expander.
+
+    Pins are numbered 0–15 (GPA0–GPA7 = 0–7, GPB0–GPB7 = 8–15).
+    """
+
+    def __init__(self, address: int = 0x20):
+        self.address = address
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the MCP23017 hardware."""
+
+    @abstractmethod
+    def setup_pin(self, pin: int, output: bool, default: bool = False) -> None:
+        """Configure a pin as input (output=False) or output (output=True)."""
+
+    @abstractmethod
+    def read(self, pin: int) -> bool:
+        """Read pin state. Works for both input and output pins."""
+
+    @abstractmethod
+    def write(self, pin: int, value: bool) -> None:
+        """Set output pin state. Raises if pin is configured as input."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release hardware resources."""

--- a/src/evo_hl/mcp23017/fake.py
+++ b/src/evo_hl/mcp23017/fake.py
@@ -1,0 +1,47 @@
+"""MCP23017 driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.mcp23017.base import MCP23017, NUM_PINS
+
+log = logging.getLogger(__name__)
+
+
+class MCP23017Fake(MCP23017):
+    """In-memory MCP23017 for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.pins: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.pins.clear()
+        log.info("MCP23017 fake initialized at 0x%02x", self.address)
+
+    def setup_pin(self, pin: int, output: bool, default: bool = False) -> None:
+        if not 0 <= pin < NUM_PINS:
+            raise ValueError(f"Pin {pin} out of range (0-{NUM_PINS - 1})")
+        self.pins[pin] = {"output": output, "value": default if output else False}
+
+    def inject_input(self, pin: int, value: bool) -> None:
+        """Inject a value on an input pin for testing."""
+        if pin in self.pins and not self.pins[pin]["output"]:
+            self.pins[pin]["value"] = value
+
+    def read(self, pin: int) -> bool:
+        if pin not in self.pins:
+            raise ValueError(f"Pin {pin} not configured — call setup_pin first")
+        return self.pins[pin]["value"]
+
+    def write(self, pin: int, value: bool) -> None:
+        if pin not in self.pins:
+            raise ValueError(f"Pin {pin} not configured — call setup_pin first")
+        if not self.pins[pin]["output"]:
+            raise ValueError(f"Pin {pin} is configured as input")
+        self.pins[pin]["value"] = value
+
+    def close(self) -> None:
+        self.pins.clear()
+        log.info("MCP23017 fake closed")

--- a/tests/test_mcp23017.py
+++ b/tests/test_mcp23017.py
@@ -1,0 +1,51 @@
+"""Tests for MCP23017 driver using fake implementation."""
+
+import pytest
+
+from evo_hl.mcp23017.fake import MCP23017Fake
+
+
+@pytest.fixture
+def gpio():
+    drv = MCP23017Fake(address=0x20)
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestMCP23017Fake:
+    def test_setup_output(self, gpio):
+        gpio.setup_pin(0, output=True, default=True)
+        assert gpio.read(0) is True
+
+    def test_setup_input(self, gpio):
+        gpio.setup_pin(5, output=False)
+        assert gpio.read(5) is False
+
+    def test_write_output(self, gpio):
+        gpio.setup_pin(3, output=True)
+        gpio.write(3, True)
+        assert gpio.read(3) is True
+
+    def test_write_input_raises(self, gpio):
+        gpio.setup_pin(7, output=False)
+        with pytest.raises(ValueError, match="input"):
+            gpio.write(7, True)
+
+    def test_inject_input(self, gpio):
+        gpio.setup_pin(10, output=False)
+        gpio.inject_input(10, True)
+        assert gpio.read(10) is True
+
+    def test_read_unconfigured_raises(self, gpio):
+        with pytest.raises(ValueError, match="not configured"):
+            gpio.read(0)
+
+    def test_bad_pin(self, gpio):
+        with pytest.raises(ValueError):
+            gpio.setup_pin(16, output=True)
+
+    def test_close_clears(self, gpio):
+        gpio.setup_pin(0, output=True)
+        gpio.close()
+        assert len(gpio.pins) == 0


### PR DESCRIPTION
## Summary
- MCP23017 16-pin I2C GPIO expander driver (base + rpi + fake)
- Supports pin direction, read, write, and pull-up configuration
- 8 tests via fake implementation

## Modules
- `src/evo_hl/mcp23017/` — base, rpi (adafruit-mcp230xx), fake
- `tests/test_mcp23017.py`