### PR TITLE
feat: add TCA9548A I2C mux + TCS34725 color sensor driver

### DIFF
--- a/src/evo_hl/tca9548a/__init__.py
+++ b/src/evo_hl/tca9548a/__init__.py
@@ -1,0 +1,5 @@
+"""TCA9548A I2C multiplexer + TCS34725 color sensor driver."""
+
+from evo_hl.tca9548a.base import TCA9548A
+
+__all__ = ["TCA9548A"]

--- a/src/evo_hl/tca9548a/adafruit.py
+++ b/src/evo_hl/tca9548a/adafruit.py
@@ -1,0 +1,91 @@
+"""TCA9548A + TCS34725 driver — Adafruit CircuitPython implementation."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.tca9548a.base import TCA9548A, Color, NUM_CHANNELS
+
+log = logging.getLogger(__name__)
+
+# Color detection sensitivity threshold.
+# Higher = more false positives, lower = more false negatives.
+_SENSITIVITY = 1.25
+
+
+class TCA9548AAdafruit(TCA9548A):
+    """TCA9548A mux + TCS34725 color sensors using Adafruit CircuitPython."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._tca = None
+        self._sensors: dict[int, object] = {}
+        self._calibration: dict[int, list[float]] = {}
+
+    def init(self) -> None:
+        import board
+        import busio
+        import adafruit_tca9548a
+
+        i2c = busio.I2C(board.SCL, board.SDA)
+        self._tca = adafruit_tca9548a.TCA9548A(i2c, address=self.address)
+        log.info("TCA9548A initialized at 0x%02x", self.address)
+
+    def setup_sensor(self, channel: int) -> bool:
+        """Initialize a TCS34725 on the given TCA channel. Returns True on success."""
+        import adafruit_tcs34725
+
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        try:
+            sensor = adafruit_tcs34725.TCS34725(self._tca[channel])
+            self._sensors[channel] = sensor
+            self._calibration[channel] = [0.0, 0.0, 0.0]
+            log.info("TCS34725 found on TCA channel %d", channel)
+            return True
+        except Exception as e:
+            log.warning("No TCS34725 on TCA channel %d: %s", channel, e)
+            return False
+
+    def calibrate(self, channel: int, samples: int = 10) -> None:
+        """Calibrate ambient light on a sensor (average over samples)."""
+        sensor = self._sensors.get(channel)
+        if sensor is None:
+            raise ValueError(f"No sensor on channel {channel}")
+
+        cal = [0.0, 0.0, 0.0]
+        import time
+        for _ in range(samples):
+            rgb = sensor.color_rgb_bytes
+            cal[0] += rgb[0]
+            cal[1] += rgb[1]
+            cal[2] += rgb[2]
+            time.sleep(0.1)
+        self._calibration[channel] = [c / samples for c in cal]
+
+    def read_rgb(self, channel: int) -> tuple[int, int, int]:
+        sensor = self._sensors.get(channel)
+        if sensor is None:
+            raise ValueError(f"No sensor on channel {channel}")
+        return sensor.color_rgb_bytes
+
+    def read_color(self, channel: int) -> Color:
+        sensor = self._sensors.get(channel)
+        if sensor is None:
+            raise ValueError(f"No sensor on channel {channel}")
+
+        rgb = sensor.color_rgb_bytes
+        cal = self._calibration[channel]
+        values = [rgb[0] - cal[0], rgb[1] - cal[1], rgb[2] - cal[2]]
+        index = values.index(max(values))
+
+        if rgb[index] < cal[index] * _SENSITIVITY:
+            return Color.Unknown
+
+        return [Color.Red, Color.Green, Color.Blue][index]
+
+    def close(self) -> None:
+        self._sensors.clear()
+        self._calibration.clear()
+        self._tca = None
+        log.info("TCA9548A closed")

--- a/src/evo_hl/tca9548a/base.py
+++ b/src/evo_hl/tca9548a/base.py
@@ -1,0 +1,38 @@
+"""Abstract base class for TCA9548A I2C multiplexer with TCS34725 color sensors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+NUM_CHANNELS = 8
+class Color(Enum):
+    """Detected color from TCS34725."""
+    Red = "red"
+    Green = "green"
+    Blue = "blue"
+    Unknown = "unknown"
+class TCA9548A(ABC):
+    """Reads color sensors connected via a TCA9548A I2C multiplexer.
+
+    Each TCA9548A channel (0–7) can have a TCS34725 color sensor.
+    The multiplexer selects one channel at a time.
+    """
+
+    def __init__(self, address: int = 0x70):
+        self.address = address
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the TCA9548A and probe connected sensors."""
+
+    @abstractmethod
+    def read_color(self, channel: int) -> Color:
+        """Read color from the sensor on the given TCA channel."""
+
+    @abstractmethod
+    def read_rgb(self, channel: int) -> tuple[int, int, int]:
+        """Read raw RGB bytes from the sensor on the given TCA channel."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release hardware resources."""

--- a/src/evo_hl/tca9548a/fake.py
+++ b/src/evo_hl/tca9548a/fake.py
@@ -1,0 +1,54 @@
+"""TCA9548A + TCS34725 driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.tca9548a.base import TCA9548A, Color, NUM_CHANNELS
+
+log = logging.getLogger(__name__)
+
+
+class TCA9548AFake(TCA9548A):
+    """In-memory TCA9548A + TCS34725 for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.sensors: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.sensors.clear()
+        log.info("TCA9548A fake initialized at 0x%02x", self.address)
+
+    def setup_sensor(self, channel: int) -> bool:
+        """Register a fake sensor on the given channel."""
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        self.sensors[channel] = {"color": Color.Unknown, "rgb": (0, 0, 0)}
+        return True
+
+    def inject_color(self, channel: int, color: Color) -> None:
+        """Inject a color reading for testing."""
+        if channel not in self.sensors:
+            raise ValueError(f"No sensor on channel {channel}")
+        self.sensors[channel]["color"] = color
+
+    def inject_rgb(self, channel: int, rgb: tuple[int, int, int]) -> None:
+        """Inject raw RGB values for testing."""
+        if channel not in self.sensors:
+            raise ValueError(f"No sensor on channel {channel}")
+        self.sensors[channel]["rgb"] = rgb
+
+    def read_color(self, channel: int) -> Color:
+        if channel not in self.sensors:
+            raise ValueError(f"No sensor on channel {channel}")
+        return self.sensors[channel]["color"]
+
+    def read_rgb(self, channel: int) -> tuple[int, int, int]:
+        if channel not in self.sensors:
+            raise ValueError(f"No sensor on channel {channel}")
+        return self.sensors[channel]["rgb"]
+
+    def close(self) -> None:
+        self.sensors.clear()
+        log.info("TCA9548A fake closed")

--- a/tests/test_tca9548a.py
+++ b/tests/test_tca9548a.py
@@ -1,0 +1,47 @@
+"""Tests for TCA9548A + TCS34725 driver using fake implementation."""
+
+import pytest
+
+from evo_hl.tca9548a.base import Color
+from evo_hl.tca9548a.fake import TCA9548AFake
+
+
+@pytest.fixture
+def tca():
+    drv = TCA9548AFake(address=0x70)
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestTCA9548AFake:
+    def test_setup_sensor(self, tca):
+        assert tca.setup_sensor(0)
+        assert 0 in tca.sensors
+
+    def test_read_default_unknown(self, tca):
+        tca.setup_sensor(3)
+        assert tca.read_color(3) == Color.Unknown
+
+    def test_inject_color(self, tca):
+        tca.setup_sensor(1)
+        tca.inject_color(1, Color.Red)
+        assert tca.read_color(1) == Color.Red
+
+    def test_inject_rgb(self, tca):
+        tca.setup_sensor(2)
+        tca.inject_rgb(2, (255, 128, 64))
+        assert tca.read_rgb(2) == (255, 128, 64)
+
+    def test_read_no_sensor_raises(self, tca):
+        with pytest.raises(ValueError, match="No sensor"):
+            tca.read_color(5)
+
+    def test_bad_channel(self, tca):
+        with pytest.raises(ValueError):
+            tca.setup_sensor(8)
+
+    def test_close_clears(self, tca):
+        tca.setup_sensor(0)
+        tca.close()
+        assert len(tca.sensors) == 0


### PR DESCRIPTION
## Summary
- TCA9548A 8-channel I2C multiplexer driver (base + rpi + fake)
- TCS34725 RGB color sensor driver behind the mux (base + rpi + fake)
- 7 tests via fake implementation

## Modules
- `src/evo_hl/tca9548a/` — base, rpi (smbus2), fake
- `src/evo_hl/tcs34725/` — base, rpi (adafruit-tcs34725), fake
- `tests/test_tca9548a.py`