### PR TITLE
feat: add GPIO driver with Edge enum and polling

### DIFF
--- a/src/evo_hl/gpio/__init__.py
+++ b/src/evo_hl/gpio/__init__.py
@@ -1,0 +1,5 @@
+"""GPIO driver — native Raspberry Pi BCM GPIO."""
+
+from evo_hl.gpio.base import GPIO, Edge
+
+__all__ = ["GPIO", "Edge"]

--- a/src/evo_hl/gpio/base.py
+++ b/src/evo_hl/gpio/base.py
@@ -1,0 +1,74 @@
+"""Abstract base class for GPIO (digital I/O and PWM)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from threading import Thread
+from time import sleep
+
+class Edge(Enum):
+    """Edge detection mode for input pins."""
+    BOTH = 2
+    FALLING = 0
+    RISING = 1
+class GPIO(ABC):
+    """Controls digital I/O and PWM on native GPIO pins (e.g., RPi BCM)."""
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the GPIO subsystem."""
+
+    @abstractmethod
+    def setup_input(self, pin: int) -> None:
+        """Configure a pin as digital input with pull-down."""
+
+    @abstractmethod
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        """Configure a pin as digital output."""
+
+    @abstractmethod
+    def read(self, pin: int) -> bool:
+        """Read digital value from a pin."""
+
+    @abstractmethod
+    def write(self, pin: int, value: bool) -> None:
+        """Write digital value to an output pin."""
+
+    @abstractmethod
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        """Configure a pin for PWM output."""
+
+    @abstractmethod
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        """Set PWM duty cycle (0.0–100.0) on a configured PWM pin."""
+
+    @abstractmethod
+    def stop_pwm(self, pin: int) -> None:
+        """Stop PWM on a pin."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release all GPIO resources."""
+
+    def auto_refresh(
+        self, pin: int, edge: Edge, interval: float, callback
+    ) -> Thread:
+        """Poll an input pin and call callback on edge events.
+
+        callback(pin, value) is called when the pin value changes
+        according to the edge mode. Returns the polling thread.
+        """
+        def _poll():
+            last = None
+            while True:
+                sleep(interval)
+                value = self.read(pin)
+                if last is not None and value != last:
+                    if edge == Edge.BOTH or edge.value == value:
+                        callback(pin, value)
+                last = value
+
+        t = Thread(target=_poll, daemon=True)
+        t.start()
+        return t

--- a/src/evo_hl/gpio/fake.py
+++ b/src/evo_hl/gpio/fake.py
@@ -1,0 +1,53 @@
+"""GPIO driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIOFake(GPIO):
+    """In-memory GPIO for tests and simulation."""
+
+    def __init__(self):
+        self.pins: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake initialized")
+
+    def setup_input(self, pin: int) -> None:
+        self.pins[pin] = {"output": False, "value": False, "pwm": None}
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self.pins[pin] = {"output": True, "value": default, "pwm": None}
+
+    def inject_input(self, pin: int, value: bool) -> None:
+        """Inject a value on an input pin for testing."""
+        if pin in self.pins and not self.pins[pin]["output"]:
+            self.pins[pin]["value"] = value
+
+    def read(self, pin: int) -> bool:
+        return self.pins.get(pin, {}).get("value", False)
+
+    def write(self, pin: int, value: bool) -> None:
+        if pin in self.pins:
+            self.pins[pin]["value"] = value
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        self.pins[pin] = {"output": True, "value": False, "pwm": {"freq": frequency, "duty": 0.0}}
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"]["duty"] = duty_cycle
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"] = None
+
+    def close(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake closed")

--- a/src/evo_hl/gpio/rpi.py
+++ b/src/evo_hl/gpio/rpi.py
@@ -1,0 +1,55 @@
+"""GPIO driver — real Raspberry Pi implementation via RPi.GPIO."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIORpi(GPIO):
+    """Native BCM GPIO on Raspberry Pi."""
+
+    def __init__(self):
+        self._pwms: dict[int, object] = {}
+
+    def init(self) -> None:
+        import RPi.GPIO as _RpiGPIO
+
+        _RpiGPIO.setmode(_RpiGPIO.BCM)
+        self._gpio = _RpiGPIO
+        log.info("RPi GPIO initialized (BCM mode)")
+
+    def setup_input(self, pin: int) -> None:
+        self._gpio.setup(pin, self._gpio.IN, pull_up_down=self._gpio.PUD_DOWN)
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self._gpio.setup(pin, self._gpio.OUT, initial=self._gpio.HIGH if default else self._gpio.LOW)
+
+    def read(self, pin: int) -> bool:
+        return bool(self._gpio.input(pin))
+
+    def write(self, pin: int, value: bool) -> None:
+        self._gpio.output(pin, self._gpio.HIGH if value else self._gpio.LOW)
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        pwm = self._gpio.PWM(pin, frequency)
+        pwm.start(0)
+        self._pwms[pin] = pwm
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        self._pwms[pin].ChangeDutyCycle(duty_cycle)
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self._pwms:
+            self._pwms[pin].stop()
+            del self._pwms[pin]
+
+    def close(self) -> None:
+        for pwm in self._pwms.values():
+            pwm.stop()
+        self._pwms.clear()
+        self._gpio.cleanup()
+        log.info("RPi GPIO closed")

--- a/tests/test_gpio.py
+++ b/tests/test_gpio.py
@@ -1,0 +1,73 @@
+"""Tests for GPIO driver using fake implementation."""
+
+import pytest
+
+from evo_hl.gpio.base import Edge
+from evo_hl.gpio.fake import GPIOFake
+
+
+@pytest.fixture
+def gpio():
+    drv = GPIOFake()
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestGPIOFake:
+    def test_setup_input(self, gpio):
+        gpio.setup_input(17)
+        assert 17 in gpio.pins
+        assert gpio.pins[17]["output"] is False
+
+    def test_setup_output(self, gpio):
+        gpio.setup_output(18, default=True)
+        assert gpio.pins[18]["output"] is True
+        assert gpio.pins[18]["value"] is True
+
+    def test_read_default_false(self, gpio):
+        gpio.setup_input(5)
+        assert gpio.read(5) is False
+
+    def test_write_output(self, gpio):
+        gpio.setup_output(12)
+        gpio.write(12, True)
+        assert gpio.read(12) is True
+
+    def test_inject_input(self, gpio):
+        gpio.setup_input(7)
+        gpio.inject_input(7, True)
+        assert gpio.read(7) is True
+
+    def test_inject_ignored_on_output(self, gpio):
+        gpio.setup_output(8, default=False)
+        gpio.inject_input(8, True)
+        assert gpio.read(8) is False
+
+    def test_read_unknown_pin(self, gpio):
+        assert gpio.read(99) is False
+
+    def test_pwm_setup_and_set(self, gpio):
+        gpio.setup_pwm(13, 1000.0)
+        assert gpio.pins[13]["pwm"]["freq"] == 1000.0
+        gpio.set_pwm(13, 50.0)
+        assert gpio.pins[13]["pwm"]["duty"] == 50.0
+
+    def test_pwm_stop(self, gpio):
+        gpio.setup_pwm(13, 1000.0)
+        gpio.set_pwm(13, 75.0)
+        gpio.stop_pwm(13)
+        assert gpio.pins[13]["pwm"] is None
+
+    def test_close_clears(self, gpio):
+        gpio.setup_output(1)
+        gpio.setup_input(2)
+        gpio.close()
+        assert len(gpio.pins) == 0
+
+
+class TestEdgeEnum:
+    def test_values(self):
+        assert Edge.FALLING.value == 0
+        assert Edge.RISING.value == 1
+        assert Edge.BOTH.value == 2


### PR DESCRIPTION
## Summary
- GPIO driver abstraction (base + rpi + fake)
- Supports digital I/O, PWM, edge detection with auto-refresh polling
- 11 tests via fake implementation

## Modules
- `src/evo_hl/gpio/` — base, rpi (RPi.GPIO), fake
- `tests/test_gpio.py`