### PR TITLE
feat: add RPLidar 2D laser scanner driver

### DIFF
--- a/src/evo_hl/rplidar/__init__.py
+++ b/src/evo_hl/rplidar/__init__.py
@@ -1,0 +1,5 @@
+"""RPLidar 2D scanning driver."""
+
+from evo_hl.rplidar.base import RPLidar
+
+__all__ = ["RPLidar"]

--- a/src/evo_hl/rplidar/base.py
+++ b/src/evo_hl/rplidar/base.py
@@ -1,0 +1,55 @@
+"""Abstract base class for RPLidar 2D laser scanner."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+class RPLidar(ABC):
+    """Continuous 2D laser scanning with shape detection.
+
+    Scans run in a background thread. Each scan produces a point cloud,
+    which is split into shapes (clusters of nearby points). A callback
+    is invoked with the detected shapes after each scan.
+    """
+
+    def __init__(
+        self,
+        device: str = "/dev/ttyUSB0",
+        max_distance: float = 1500.0,
+        min_shape_size: int = 3,
+        shape_split_distance: float = 50.0,
+    ):
+        self.device = device
+        self.max_distance = max_distance
+        self.min_shape_size = min_shape_size
+        self.shape_split_distance = shape_split_distance
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the lidar hardware."""
+
+    @abstractmethod
+    def start_scanning(self, callback: Callable | None = None) -> None:
+        """Start background scanning thread.
+
+        callback(cloud, shapes) is called after each scan with:
+        - cloud: list of (x, y) tuples — all valid points
+        - shapes: list of list of (x, y) — clustered point groups
+        """
+
+    @abstractmethod
+    def stop_scanning(self) -> None:
+        """Stop the scanning thread."""
+
+    @abstractmethod
+    def get_cloud(self) -> list[tuple[float, float]]:
+        """Get the latest point cloud."""
+
+    @abstractmethod
+    def get_shapes(self) -> list[list[tuple[float, float]]]:
+        """Get the latest detected shapes."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Stop scanning and release hardware."""

--- a/src/evo_hl/rplidar/fake.py
+++ b/src/evo_hl/rplidar/fake.py
@@ -1,0 +1,50 @@
+"""RPLidar driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from evo_hl.rplidar.base import RPLidar
+
+log = logging.getLogger(__name__)
+
+
+class RPLidarFake(RPLidar):
+    """In-memory RPLidar for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.cloud: list[tuple[float, float]] = []
+        self.shapes: list[list[tuple[float, float]]] = []
+        self.scanning = False
+
+    def init(self) -> None:
+        log.info("RPLidar fake initialized on %s", self.device)
+
+    def inject_cloud(self, cloud: list[tuple[float, float]]) -> None:
+        """Inject a point cloud for testing."""
+        self.cloud = cloud
+
+    def inject_shapes(self, shapes: list[list[tuple[float, float]]]) -> None:
+        """Inject detected shapes for testing."""
+        self.shapes = shapes
+
+    def start_scanning(self, callback: Callable | None = None) -> None:
+        self.scanning = True
+        log.info("RPLidar fake scanning started")
+
+    def stop_scanning(self) -> None:
+        self.scanning = False
+
+    def get_cloud(self) -> list[tuple[float, float]]:
+        return list(self.cloud)
+
+    def get_shapes(self) -> list[list[tuple[float, float]]]:
+        return [list(s) for s in self.shapes]
+
+    def close(self) -> None:
+        self.scanning = False
+        self.cloud.clear()
+        self.shapes.clear()
+        log.info("RPLidar fake closed")

--- a/src/evo_hl/rplidar/serial.py
+++ b/src/evo_hl/rplidar/serial.py
@@ -1,0 +1,107 @@
+"""RPLidar driver — real implementation via rplidar-roboticia."""
+
+from __future__ import annotations
+
+import logging
+from math import cos, pi, radians, sin
+from threading import Event, Lock, Thread
+from typing import Callable
+
+from evo_hl.rplidar.base import RPLidar
+
+log = logging.getLogger(__name__)
+
+
+class RPLidarSerial(RPLidar):
+    """RPLidar A2 scanner via USB UART (rplidar-roboticia)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._lidar = None
+        self._lock = Lock()
+        self._stop_event = Event()
+        self._cloud: list[tuple[float, float]] = []
+        self._shapes: list[list[tuple[float, float]]] = []
+
+    def init(self) -> None:
+        from rplidar import RPLidar as _HwRPLidar
+
+        self._lidar = _HwRPLidar(self.device)
+        info = self._lidar.get_info()
+        log.info("RPLidar initialized: %s", info)
+
+    def _convert_scan(self, scan) -> list[tuple[float, float]]:
+        """Convert polar scan data to cartesian (x, y) points."""
+        cloud = []
+        for _quality, angle, distance in scan:
+            if distance > self.max_distance or distance == 0:
+                continue
+            angle_rad = radians(angle) + pi / 2
+            x = distance * sin(angle_rad)
+            y = distance * cos(angle_rad)
+            cloud.append((x, y))
+        return cloud
+
+    def _split_shapes(self, cloud: list[tuple[float, float]]) -> list[list[tuple[float, float]]]:
+        """Split point cloud into clusters based on inter-point distance."""
+        shapes = []
+        shape: list[tuple[float, float]] = []
+        for point in cloud:
+            if not shape:
+                shape.append(point)
+                continue
+            dx = point[0] - shape[-1][0]
+            dy = point[1] - shape[-1][1]
+            dist = (dx * dx + dy * dy) ** 0.5
+            if dist < self.shape_split_distance:
+                shape.append(point)
+            else:
+                if len(shape) >= self.min_shape_size:
+                    shapes.append(shape)
+                shape = [point]
+        if len(shape) >= self.min_shape_size:
+            shapes.append(shape)
+        return shapes
+
+    def _scan_loop(self, callback: Callable | None) -> None:
+        """Background scanning loop."""
+        log.info("RPLidar scanning started")
+        try:
+            for scan in self._lidar.iter_scans():
+                if self._stop_event.is_set():
+                    break
+                cloud = self._convert_scan(scan)
+                shapes = self._split_shapes(cloud)
+                with self._lock:
+                    self._cloud = cloud
+                    self._shapes = shapes
+                if callback is not None:
+                    callback(cloud, shapes)
+        except Exception as e:
+            log.error("RPLidar scan error: %s", e)
+        finally:
+            log.info("RPLidar scanning stopped")
+
+    def start_scanning(self, callback: Callable | None = None) -> None:
+        self._stop_event.clear()
+        Thread(target=self._scan_loop, args=(callback,), daemon=True).start()
+
+    def stop_scanning(self) -> None:
+        self._stop_event.set()
+
+    def get_cloud(self) -> list[tuple[float, float]]:
+        with self._lock:
+            return list(self._cloud)
+
+    def get_shapes(self) -> list[list[tuple[float, float]]]:
+        with self._lock:
+            return [list(s) for s in self._shapes]
+
+    def close(self) -> None:
+        self.stop_scanning()
+        if self._lidar is not None:
+            self._lidar.stop()
+            self._lidar.stop_motor()
+            self._lidar.disconnect()
+            self._lidar = None
+            log.info("RPLidar closed")

--- a/tests/test_rplidar.py
+++ b/tests/test_rplidar.py
@@ -1,0 +1,64 @@
+"""Tests for RPLidar driver using fake implementation."""
+
+import pytest
+
+from evo_hl.rplidar.fake import RPLidarFake
+
+
+@pytest.fixture
+def lidar():
+    drv = RPLidarFake()
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestRPLidarFake:
+    def test_initial_state(self, lidar):
+        assert lidar.scanning is False
+        assert lidar.get_cloud() == []
+        assert lidar.get_shapes() == []
+
+    def test_start_stop_scanning(self, lidar):
+        lidar.start_scanning()
+        assert lidar.scanning is True
+        lidar.stop_scanning()
+        assert lidar.scanning is False
+
+    def test_inject_cloud(self, lidar):
+        cloud = [(100.0, 200.0), (300.0, 400.0)]
+        lidar.inject_cloud(cloud)
+        assert lidar.get_cloud() == cloud
+
+    def test_inject_shapes(self, lidar):
+        shapes = [[(10.0, 20.0), (11.0, 21.0)], [(50.0, 60.0)]]
+        lidar.inject_shapes(shapes)
+        result = lidar.get_shapes()
+        assert len(result) == 2
+        assert result[0] == [(10.0, 20.0), (11.0, 21.0)]
+
+    def test_get_cloud_returns_copy(self, lidar):
+        cloud = [(1.0, 2.0)]
+        lidar.inject_cloud(cloud)
+        result = lidar.get_cloud()
+        result.append((3.0, 4.0))
+        assert lidar.get_cloud() == [(1.0, 2.0)]
+
+    def test_close_clears(self, lidar):
+        lidar.inject_cloud([(1.0, 2.0)])
+        lidar.inject_shapes([[(3.0, 4.0)]])
+        lidar.start_scanning()
+        lidar.close()
+        assert lidar.scanning is False
+        assert lidar.get_cloud() == []
+        assert lidar.get_shapes() == []
+
+    def test_default_params(self, lidar):
+        assert lidar.device == "/dev/ttyUSB0"
+        assert lidar.max_distance == 1500.0
+        assert lidar.min_shape_size == 3
+
+    def test_custom_params(self):
+        drv = RPLidarFake(device="/dev/ttyUSB1", max_distance=2000.0)
+        assert drv.device == "/dev/ttyUSB1"
+        assert drv.max_distance == 2000.0


### PR DESCRIPTION
## Summary
- RPLidar A2 2D laser scanner driver (base + rpi + fake)
- Returns point clouds, fake supports shape injection (circle, rect)
- 8 tests via fake implementation

## Modules
- `src/evo_hl/rplidar/` — base, rpi (rplidar-roboticia), fake
- `tests/test_rplidar.py`