### PR TITLE
feat: add recalibration distance sensor driver

### DIFF
--- a/src/evo_hl/ads1115/__init__.py
+++ b/src/evo_hl/ads1115/__init__.py
@@ -1,0 +1,5 @@
+"""ADS1115 4-channel ADC driver."""
+
+from evo_hl.ads1115.base import ADS1115
+
+__all__ = ["ADS1115"]

--- a/src/evo_hl/ads1115/adafruit.py
+++ b/src/evo_hl/ads1115/adafruit.py
@@ -1,0 +1,43 @@
+"""ADS1115 driver — Adafruit CircuitPython implementation."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.ads1115.base import ADS1115, NUM_CHANNELS
+
+log = logging.getLogger(__name__)
+
+
+class ADS1115Adafruit(ADS1115):
+    """ADS1115 over I2C using Adafruit CircuitPython (any blinka-supported SBC)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._ads = None
+        self._channels = {}
+
+    def init(self) -> None:
+        import board
+        import busio
+        from adafruit_ads1x15.ads1115 import ADS1115 as _HwADS1115, P0, P1, P2, P3
+        from adafruit_ads1x15.analog_in import AnalogIn
+
+        i2c = busio.I2C(board.SCL, board.SDA)
+        self._ads = _HwADS1115(i2c, address=self.address)
+
+        pins = [P0, P1, P2, P3]
+        for ch in range(NUM_CHANNELS):
+            self._channels[ch] = AnalogIn(self._ads, pins[ch])
+
+        log.info("ADS1115 initialized at 0x%02x", self.address)
+
+    def read_voltage(self, channel: int) -> float:
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        return self._channels[channel].voltage
+
+    def close(self) -> None:
+        self._channels.clear()
+        self._ads = None
+        log.info("ADS1115 closed")

--- a/src/evo_hl/ads1115/base.py
+++ b/src/evo_hl/ads1115/base.py
@@ -1,0 +1,23 @@
+"""Abstract base class for ADS1115 4-channel 16-bit ADC."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+NUM_CHANNELS = 4
+class ADS1115(ABC):
+    """Reads analog voltages from an ADS1115 I2C ADC (4 single-ended channels)."""
+
+    def __init__(self, address: int = 0x48):
+        self.address = address
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the ADC hardware."""
+
+    @abstractmethod
+    def read_voltage(self, channel: int) -> float:
+        """Read voltage on a channel (0–3). Returns volts."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release hardware resources."""

--- a/src/evo_hl/ads1115/fake.py
+++ b/src/evo_hl/ads1115/fake.py
@@ -1,0 +1,34 @@
+"""ADS1115 driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.ads1115.base import ADS1115, NUM_CHANNELS
+
+log = logging.getLogger(__name__)
+
+
+class ADS1115Fake(ADS1115):
+    """In-memory ADS1115 for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.voltages: dict[int, float] = {}
+
+    def init(self) -> None:
+        self.voltages = {ch: 0.0 for ch in range(NUM_CHANNELS)}
+        log.info("ADS1115 fake initialized at 0x%02x", self.address)
+
+    def set_voltage(self, channel: int, voltage: float) -> None:
+        """Inject a voltage value for testing."""
+        self.voltages[channel] = voltage
+
+    def read_voltage(self, channel: int) -> float:
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        return self.voltages[channel]
+
+    def close(self) -> None:
+        self.voltages.clear()
+        log.info("ADS1115 fake closed")

--- a/src/evo_hl/recal/__init__.py
+++ b/src/evo_hl/recal/__init__.py
@@ -1,0 +1,5 @@
+"""Recalibration distance sensor (voltage-to-distance over ADC)."""
+
+from evo_hl.recal.base import Recal
+
+__all__ = ["Recal"]

--- a/src/evo_hl/recal/base.py
+++ b/src/evo_hl/recal/base.py
@@ -1,0 +1,38 @@
+"""Abstract base class for recalibration distance sensors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+# Default voltage-to-distance conversion parameters
+DEFAULT_MIN_VOLTAGE = 0.6
+DEFAULT_MAX_VOLTAGE = 3.0
+DEFAULT_MIN_DISTANCE_MM = 100.0
+DEFAULT_MAX_DISTANCE_MM = 1250.0
+class Recal(ABC):
+    """Reads distance from analog recalibration sensors.
+
+    Converts ADC voltage to distance (mm) with optional piecewise
+    linear calibration.
+    """
+
+    def __init__(
+        self,
+        min_voltage: float = DEFAULT_MIN_VOLTAGE,
+        max_voltage: float = DEFAULT_MAX_VOLTAGE,
+        min_distance: float = DEFAULT_MIN_DISTANCE_MM,
+        max_distance: float = DEFAULT_MAX_DISTANCE_MM,
+    ):
+        self.min_voltage = min_voltage
+        self.max_voltage = max_voltage
+        self.min_distance = min_distance
+        self.max_distance = max_distance
+
+    @abstractmethod
+    def read_distance(self, channel: int, samples: int = 1) -> float:
+        """Read distance in mm from an ADC channel, averaged over samples."""
+
+    def voltage_to_distance(self, voltage: float) -> float:
+        """Convert voltage to distance using linear interpolation."""
+        voltage = max(self.min_voltage, min(voltage, self.max_voltage))
+        alpha = (voltage - self.min_voltage) / (self.max_voltage - self.min_voltage)
+        return (self.max_distance - self.min_distance) * alpha + self.min_distance

--- a/src/evo_hl/recal/fake.py
+++ b/src/evo_hl/recal/fake.py
@@ -1,0 +1,24 @@
+"""Recalibration sensor — fake implementation for testing."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.recal.base import Recal
+
+log = logging.getLogger(__name__)
+
+
+class RecalFake(Recal):
+    """In-memory recal sensor for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.distances: dict[int, float] = {}
+
+    def inject_distance(self, channel: int, distance: float) -> None:
+        """Inject a distance value for testing."""
+        self.distances[channel] = distance
+
+    def read_distance(self, channel: int, samples: int = 1) -> float:
+        return self.distances.get(channel, self.min_distance)

--- a/src/evo_hl/recal/sensor.py
+++ b/src/evo_hl/recal/sensor.py
@@ -1,0 +1,59 @@
+"""Recalibration sensor — reads distance via an ADC driver."""
+
+from __future__ import annotations
+
+import logging
+from time import sleep
+
+from evo_hl.ads1115.base import ADS1115
+from evo_hl.recal.base import Recal
+
+log = logging.getLogger(__name__)
+
+
+class RecalSensor(Recal):
+    """Recal sensor that reads from an ADS1115 ADC channel."""
+
+    def __init__(self, adc: ADS1115, **kwargs):
+        super().__init__(**kwargs)
+        self._adc = adc
+        self._calibration: list[tuple[float, float]] = []
+
+    def calibrate(self, points: list[tuple[float, float]]) -> None:
+        """Set piecewise linear calibration points [(raw_dist, true_dist), ...]."""
+        self._calibration = sorted(points, key=lambda p: p[0])
+
+    def read_distance(self, channel: int, samples: int = 1) -> float:
+        total = 0.0
+        for i in range(samples):
+            voltage = self._adc.read_voltage(channel)
+            total += self.voltage_to_distance(voltage)
+            if i < samples - 1:
+                sleep(0.05)
+        raw_dist = total / samples
+
+        if len(self._calibration) < 2:
+            return raw_dist
+
+        return self._apply_calibration(raw_dist)
+
+    def _apply_calibration(self, raw: float) -> float:
+        """Apply piecewise linear calibration."""
+        pts = self._calibration
+        if raw <= pts[0][0]:
+            x1, y1 = pts[0]
+            x2, y2 = pts[1]
+        elif raw >= pts[-1][0]:
+            x1, y1 = pts[-2]
+            x2, y2 = pts[-1]
+        else:
+            x1, y1 = pts[0]
+            x2, y2 = pts[1]
+            for i in range(len(pts) - 1):
+                if pts[i][0] <= raw <= pts[i + 1][0]:
+                    x1, y1 = pts[i]
+                    x2, y2 = pts[i + 1]
+                    break
+        if x2 == x1:
+            return y1
+        return ((raw - x1) / (x2 - x1)) * (y2 - y1) + y1

--- a/tests/test_recal.py
+++ b/tests/test_recal.py
@@ -1,0 +1,49 @@
+"""Tests for recalibration sensor driver using fake implementation."""
+
+import pytest
+
+from evo_hl.recal.base import Recal
+from evo_hl.recal.fake import RecalFake
+
+
+@pytest.fixture
+def recal():
+    return RecalFake()
+
+
+class TestRecalFake:
+    def test_default_distance(self, recal):
+        # Default is min_distance when no injection
+        assert recal.read_distance(0) == recal.min_distance
+
+    def test_inject_distance(self, recal):
+        recal.inject_distance(0, 500.0)
+        assert recal.read_distance(0) == 500.0
+
+    def test_independent_channels(self, recal):
+        recal.inject_distance(0, 100.0)
+        recal.inject_distance(1, 900.0)
+        assert recal.read_distance(0) == 100.0
+        assert recal.read_distance(1) == 900.0
+
+
+class TestVoltageToDistance:
+    def test_min_voltage(self):
+        r = RecalFake(min_voltage=0.6, max_voltage=3.0, min_distance=100.0, max_distance=1250.0)
+        assert r.voltage_to_distance(0.6) == pytest.approx(100.0)
+
+    def test_max_voltage(self):
+        r = RecalFake(min_voltage=0.6, max_voltage=3.0, min_distance=100.0, max_distance=1250.0)
+        assert r.voltage_to_distance(3.0) == pytest.approx(1250.0)
+
+    def test_mid_voltage(self):
+        r = RecalFake(min_voltage=0.0, max_voltage=2.0, min_distance=0.0, max_distance=1000.0)
+        assert r.voltage_to_distance(1.0) == pytest.approx(500.0)
+
+    def test_clamp_below(self):
+        r = RecalFake(min_voltage=1.0, max_voltage=3.0, min_distance=100.0, max_distance=500.0)
+        assert r.voltage_to_distance(0.0) == pytest.approx(100.0)
+
+    def test_clamp_above(self):
+        r = RecalFake(min_voltage=1.0, max_voltage=3.0, min_distance=100.0, max_distance=500.0)
+        assert r.voltage_to_distance(5.0) == pytest.approx(500.0)


### PR DESCRIPTION
## Summary
- Recalibration distance sensor driver (base + rpi + fake)
- Converts analog voltage (via ADS1115) to distance using linear interpolation
- Includes bundled ADS1115 driver as dependency
- 8 tests via fake implementation

## Modules
- `src/evo_hl/recal/` — base, rpi, fake
- `src/evo_hl/ads1115/` — bundled dependency
- `tests/test_recal.py`