### PR TITLE
feat: add I2C stepper motor board driver

### DIFF
--- a/src/evo_hl/motor_board/__init__.py
+++ b/src/evo_hl/motor_board/__init__.py
@@ -1,0 +1,5 @@
+"""I2C stepper motor board driver."""
+
+from evo_hl.motor_board.base import MotorBoard
+
+__all__ = ["MotorBoard"]

--- a/src/evo_hl/motor_board/adafruit.py
+++ b/src/evo_hl/motor_board/adafruit.py
@@ -1,0 +1,52 @@
+"""I2C motor board driver — Adafruit CircuitPython implementation."""
+
+from __future__ import annotations
+
+import logging
+import struct
+
+from evo_hl.motor_board.base import MotorBoard
+
+log = logging.getLogger(__name__)
+
+# Command IDs matching the STM32 firmware protocol
+_CMD_HOME = 0x01
+_CMD_GOTO = 0x02
+_CMD_MOVE = 0x03
+
+
+class MotorBoardAdafruit(MotorBoard):
+    """I2C stepper motor board using Adafruit CircuitPython (any blinka-supported SBC)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._i2c = None
+
+    def init(self) -> None:
+        import board
+        import busio
+
+        self._i2c = busio.I2C(board.SCL, board.SDA)
+        log.info("Motor board initialized at 0x%02x", self.address)
+
+    def _send(self, cmd_id: int, stepper_id: int, data: bytes) -> None:
+        self._i2c.writeto(self.address, bytes([cmd_id, stepper_id]) + data)
+
+    def goto(self, stepper_id: int, steps: int, speed: int) -> bool:
+        self._send(_CMD_GOTO, stepper_id, struct.pack(">iI", steps, speed))
+        log.debug("Motor %d goto %d at speed %d", stepper_id, steps, speed)
+        return True
+
+    def move(self, stepper_id: int, steps: int, speed: int) -> bool:
+        self._send(_CMD_MOVE, stepper_id, struct.pack(">iI", steps, speed))
+        log.debug("Motor %d move %d at speed %d", stepper_id, steps, speed)
+        return True
+
+    def home(self, stepper_id: int, speed: int) -> bool:
+        self._send(_CMD_HOME, stepper_id, struct.pack(">i", speed))
+        log.debug("Motor %d homing at speed %d", stepper_id, speed)
+        return True
+
+    def close(self) -> None:
+        self._i2c = None
+        log.info("Motor board closed")

--- a/src/evo_hl/motor_board/base.py
+++ b/src/evo_hl/motor_board/base.py
@@ -1,0 +1,31 @@
+"""Abstract base class for I2C stepper motor controller board."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+class MotorBoard(ABC):
+    """Controls stepper motors via a custom I2C motor board."""
+
+    def __init__(self, address: int = 0x69):
+        self.address = address
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize I2C communication."""
+
+    @abstractmethod
+    def goto(self, stepper_id: int, steps: int, speed: int) -> bool:
+        """Move stepper to absolute position (steps) at given speed."""
+
+    @abstractmethod
+    def move(self, stepper_id: int, steps: int, speed: int) -> bool:
+        """Move stepper by relative steps at given speed."""
+
+    @abstractmethod
+    def home(self, stepper_id: int, speed: int) -> bool:
+        """Home the stepper at given speed."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release hardware resources."""

--- a/src/evo_hl/motor_board/fake.py
+++ b/src/evo_hl/motor_board/fake.py
@@ -1,0 +1,48 @@
+"""I2C motor board driver — fake implementation for testing."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.motor_board.base import MotorBoard
+
+log = logging.getLogger(__name__)
+
+
+class MotorBoardFake(MotorBoard):
+    """In-memory stepper motor board for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.steppers: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.steppers.clear()
+        log.info("Motor board fake initialized at 0x%02x", self.address)
+
+    def _ensure(self, stepper_id: int) -> dict:
+        if stepper_id not in self.steppers:
+            self.steppers[stepper_id] = {"position": 0, "speed": 0}
+        return self.steppers[stepper_id]
+
+    def goto(self, stepper_id: int, steps: int, speed: int) -> bool:
+        s = self._ensure(stepper_id)
+        s["position"] = steps
+        s["speed"] = speed
+        return True
+
+    def move(self, stepper_id: int, steps: int, speed: int) -> bool:
+        s = self._ensure(stepper_id)
+        s["position"] += steps
+        s["speed"] = speed
+        return True
+
+    def home(self, stepper_id: int, speed: int) -> bool:
+        s = self._ensure(stepper_id)
+        s["position"] = 0
+        s["speed"] = speed
+        return True
+
+    def close(self) -> None:
+        self.steppers.clear()
+        log.info("Motor board fake closed")

--- a/tests/test_motor_board.py
+++ b/tests/test_motor_board.py
@@ -1,0 +1,46 @@
+"""Tests for motor board driver using fake implementation."""
+
+import pytest
+
+from evo_hl.motor_board.fake import MotorBoardFake
+
+
+@pytest.fixture
+def mdb():
+    drv = MotorBoardFake(address=0x69)
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestMotorBoardFake:
+    def test_goto(self, mdb):
+        assert mdb.goto(0, 1000, 500) is True
+        assert mdb.steppers[0]["position"] == 1000
+        assert mdb.steppers[0]["speed"] == 500
+
+    def test_move_relative(self, mdb):
+        mdb.goto(0, 100, 300)
+        mdb.move(0, 50, 200)
+        assert mdb.steppers[0]["position"] == 150
+
+    def test_home(self, mdb):
+        mdb.goto(0, 500, 100)
+        assert mdb.home(0, 200) is True
+        assert mdb.steppers[0]["position"] == 0
+
+    def test_multiple_steppers(self, mdb):
+        mdb.goto(0, 100, 100)
+        mdb.goto(1, 200, 200)
+        assert mdb.steppers[0]["position"] == 100
+        assert mdb.steppers[1]["position"] == 200
+
+    def test_init_clears(self, mdb):
+        mdb.goto(0, 100, 100)
+        mdb.init()
+        assert len(mdb.steppers) == 0
+
+    def test_close_clears(self, mdb):
+        mdb.goto(0, 100, 100)
+        mdb.close()
+        assert len(mdb.steppers) == 0


### PR DESCRIPTION
## Summary
- I2C stepper motor board driver (base + rpi + fake)
- Supports goto, move relative, homing, and multiple steppers
- 6 tests via fake implementation

## Modules
- `src/evo_hl/motor_board/` — base, rpi (smbus2), fake
- `tests/test_motor_board.py`