### PR TITLE
feat: add vacuum pump driver with GPIO

### DIFF
--- a/src/evo_hl/gpio/__init__.py
+++ b/src/evo_hl/gpio/__init__.py
@@ -1,0 +1,5 @@
+"""GPIO driver — native Raspberry Pi BCM GPIO."""
+
+from evo_hl.gpio.base import GPIO, Edge
+
+__all__ = ["GPIO", "Edge"]

--- a/src/evo_hl/gpio/base.py
+++ b/src/evo_hl/gpio/base.py
@@ -1,0 +1,74 @@
+"""Abstract base class for GPIO (digital I/O and PWM)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from threading import Thread
+from time import sleep
+
+class Edge(Enum):
+    """Edge detection mode for input pins."""
+    BOTH = 2
+    FALLING = 0
+    RISING = 1
+class GPIO(ABC):
+    """Controls digital I/O and PWM on native GPIO pins (e.g., RPi BCM)."""
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the GPIO subsystem."""
+
+    @abstractmethod
+    def setup_input(self, pin: int) -> None:
+        """Configure a pin as digital input with pull-down."""
+
+    @abstractmethod
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        """Configure a pin as digital output."""
+
+    @abstractmethod
+    def read(self, pin: int) -> bool:
+        """Read digital value from a pin."""
+
+    @abstractmethod
+    def write(self, pin: int, value: bool) -> None:
+        """Write digital value to an output pin."""
+
+    @abstractmethod
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        """Configure a pin for PWM output."""
+
+    @abstractmethod
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        """Set PWM duty cycle (0.0–100.0) on a configured PWM pin."""
+
+    @abstractmethod
+    def stop_pwm(self, pin: int) -> None:
+        """Stop PWM on a pin."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release all GPIO resources."""
+
+    def auto_refresh(
+        self, pin: int, edge: Edge, interval: float, callback
+    ) -> Thread:
+        """Poll an input pin and call callback on edge events.
+
+        callback(pin, value) is called when the pin value changes
+        according to the edge mode. Returns the polling thread.
+        """
+        def _poll():
+            last = None
+            while True:
+                sleep(interval)
+                value = self.read(pin)
+                if last is not None and value != last:
+                    if edge == Edge.BOTH or edge.value == value:
+                        callback(pin, value)
+                last = value
+
+        t = Thread(target=_poll, daemon=True)
+        t.start()
+        return t

--- a/src/evo_hl/gpio/fake.py
+++ b/src/evo_hl/gpio/fake.py
@@ -1,0 +1,53 @@
+"""GPIO driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIOFake(GPIO):
+    """In-memory GPIO for tests and simulation."""
+
+    def __init__(self):
+        self.pins: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake initialized")
+
+    def setup_input(self, pin: int) -> None:
+        self.pins[pin] = {"output": False, "value": False, "pwm": None}
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self.pins[pin] = {"output": True, "value": default, "pwm": None}
+
+    def inject_input(self, pin: int, value: bool) -> None:
+        """Inject a value on an input pin for testing."""
+        if pin in self.pins and not self.pins[pin]["output"]:
+            self.pins[pin]["value"] = value
+
+    def read(self, pin: int) -> bool:
+        return self.pins.get(pin, {}).get("value", False)
+
+    def write(self, pin: int, value: bool) -> None:
+        if pin in self.pins:
+            self.pins[pin]["value"] = value
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        self.pins[pin] = {"output": True, "value": False, "pwm": {"freq": frequency, "duty": 0.0}}
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"]["duty"] = duty_cycle
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"] = None
+
+    def close(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake closed")

--- a/src/evo_hl/gpio/rpi.py
+++ b/src/evo_hl/gpio/rpi.py
@@ -1,0 +1,55 @@
+"""GPIO driver — real Raspberry Pi implementation via RPi.GPIO."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIORpi(GPIO):
+    """Native BCM GPIO on Raspberry Pi."""
+
+    def __init__(self):
+        self._pwms: dict[int, object] = {}
+
+    def init(self) -> None:
+        import RPi.GPIO as _RpiGPIO
+
+        _RpiGPIO.setmode(_RpiGPIO.BCM)
+        self._gpio = _RpiGPIO
+        log.info("RPi GPIO initialized (BCM mode)")
+
+    def setup_input(self, pin: int) -> None:
+        self._gpio.setup(pin, self._gpio.IN, pull_up_down=self._gpio.PUD_DOWN)
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self._gpio.setup(pin, self._gpio.OUT, initial=self._gpio.HIGH if default else self._gpio.LOW)
+
+    def read(self, pin: int) -> bool:
+        return bool(self._gpio.input(pin))
+
+    def write(self, pin: int, value: bool) -> None:
+        self._gpio.output(pin, self._gpio.HIGH if value else self._gpio.LOW)
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        pwm = self._gpio.PWM(pin, frequency)
+        pwm.start(0)
+        self._pwms[pin] = pwm
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        self._pwms[pin].ChangeDutyCycle(duty_cycle)
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self._pwms:
+            self._pwms[pin].stop()
+            del self._pwms[pin]
+
+    def close(self) -> None:
+        for pwm in self._pwms.values():
+            pwm.stop()
+        self._pwms.clear()
+        self._gpio.cleanup()
+        log.info("RPi GPIO closed")

--- a/src/evo_hl/pump/__init__.py
+++ b/src/evo_hl/pump/__init__.py
@@ -1,0 +1,5 @@
+"""Vacuum pump + electrovalve driver."""
+
+from evo_hl.pump.base import Pump
+
+__all__ = ["Pump"]

--- a/src/evo_hl/pump/base.py
+++ b/src/evo_hl/pump/base.py
@@ -1,0 +1,25 @@
+"""Abstract base class for vacuum pump with optional electrovalve."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+class Pump(ABC):
+    """Controls a vacuum pump with an optional electrovalve (EV).
+
+    - grab(): pump ON, EV closed → suction
+    - release(): pump OFF, EV open → release
+    - stop_ev(): EV closed (after release delay)
+    """
+
+    @abstractmethod
+    def grab(self) -> None:
+        """Activate pump (suction), close electrovalve."""
+
+    @abstractmethod
+    def release(self) -> None:
+        """Deactivate pump, open electrovalve to release."""
+
+    @abstractmethod
+    def stop_ev(self) -> None:
+        """Close electrovalve (call after release delay)."""

--- a/src/evo_hl/pump/fake.py
+++ b/src/evo_hl/pump/fake.py
@@ -1,0 +1,28 @@
+"""Pump driver — fake implementation for testing."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.pump.base import Pump
+
+log = logging.getLogger(__name__)
+
+
+class PumpFake(Pump):
+    """In-memory pump for tests and simulation."""
+
+    def __init__(self):
+        self.pump_on = False
+        self.ev_open = False
+
+    def grab(self) -> None:
+        self.pump_on = True
+        self.ev_open = False
+
+    def release(self) -> None:
+        self.pump_on = False
+        self.ev_open = True
+
+    def stop_ev(self) -> None:
+        self.ev_open = False

--- a/src/evo_hl/pump/gpio_pump.py
+++ b/src/evo_hl/pump/gpio_pump.py
@@ -1,0 +1,35 @@
+"""Pump driver — implementation via GPIO pins."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+from evo_hl.pump.base import Pump
+
+log = logging.getLogger(__name__)
+
+
+class PumpGPIO(Pump):
+    """Pump controlled via two GPIO pins (pump + electrovalve)."""
+
+    def __init__(self, gpio: GPIO, pump_pin: int, ev_pin: int | None = None):
+        self._gpio = gpio
+        self._pump_pin = pump_pin
+        self._ev_pin = ev_pin
+
+    def grab(self) -> None:
+        self._gpio.write(self._pump_pin, True)
+        if self._ev_pin is not None:
+            self._gpio.write(self._ev_pin, False)
+        log.debug("Pump pin%d ON", self._pump_pin)
+
+    def release(self) -> None:
+        self._gpio.write(self._pump_pin, False)
+        if self._ev_pin is not None:
+            self._gpio.write(self._ev_pin, True)
+        log.debug("Pump pin%d OFF, EV open", self._pump_pin)
+
+    def stop_ev(self) -> None:
+        if self._ev_pin is not None:
+            self._gpio.write(self._ev_pin, False)

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -1,0 +1,82 @@
+"""Tests for pump driver using fake and GPIO implementations."""
+
+import pytest
+
+from evo_hl.gpio.fake import GPIOFake
+from evo_hl.pump.fake import PumpFake
+from evo_hl.pump.gpio_pump import PumpGPIO
+
+
+@pytest.fixture
+def pump():
+    return PumpFake()
+
+
+@pytest.fixture
+def gpio_pump():
+    gpio = GPIOFake()
+    gpio.init()
+    gpio.setup_output(10)
+    gpio.setup_output(11)
+    return PumpGPIO(gpio, pump_pin=10, ev_pin=11), gpio
+
+
+class TestPumpFake:
+    def test_initial_state(self, pump):
+        assert pump.pump_on is False
+        assert pump.ev_open is False
+
+    def test_grab(self, pump):
+        pump.grab()
+        assert pump.pump_on is True
+        assert pump.ev_open is False
+
+    def test_release(self, pump):
+        pump.grab()
+        pump.release()
+        assert pump.pump_on is False
+        assert pump.ev_open is True
+
+    def test_stop_ev(self, pump):
+        pump.release()
+        pump.stop_ev()
+        assert pump.ev_open is False
+
+    def test_grab_release_cycle(self, pump):
+        pump.grab()
+        pump.release()
+        pump.stop_ev()
+        assert pump.pump_on is False
+        assert pump.ev_open is False
+
+
+class TestPumpGPIO:
+    def test_grab_sets_pins(self, gpio_pump):
+        pump, gpio = gpio_pump
+        pump.grab()
+        assert gpio.read(10) is True
+        assert gpio.read(11) is False
+
+    def test_release_sets_pins(self, gpio_pump):
+        pump, gpio = gpio_pump
+        pump.grab()
+        pump.release()
+        assert gpio.read(10) is False
+        assert gpio.read(11) is True
+
+    def test_stop_ev(self, gpio_pump):
+        pump, gpio = gpio_pump
+        pump.release()
+        pump.stop_ev()
+        assert gpio.read(11) is False
+
+    def test_no_ev_pin(self):
+        gpio = GPIOFake()
+        gpio.init()
+        gpio.setup_output(10)
+        pump = PumpGPIO(gpio, pump_pin=10, ev_pin=None)
+        pump.grab()
+        assert gpio.read(10) is True
+        pump.release()
+        assert gpio.read(10) is False
+        pump.stop_ev()  # no-op, should not raise


### PR DESCRIPTION
## Summary
- Vacuum pump driver (base + gpio + fake)
- Supports pump + optional electrovalve control
- Includes bundled GPIO driver as dependency
- 9 tests via fake implementation

## Modules
- `src/evo_hl/pump/` — base, gpio, fake
- `src/evo_hl/gpio/` — bundled dependency
- `tests/test_pump.py`