### PR TITLE
feat: add proximity sensor driver with GPIO

### DIFF
--- a/src/evo_hl/gpio/__init__.py
+++ b/src/evo_hl/gpio/__init__.py
@@ -1,0 +1,5 @@
+"""GPIO driver — native Raspberry Pi BCM GPIO."""
+
+from evo_hl.gpio.base import GPIO, Edge
+
+__all__ = ["GPIO", "Edge"]

--- a/src/evo_hl/gpio/base.py
+++ b/src/evo_hl/gpio/base.py
@@ -1,0 +1,74 @@
+"""Abstract base class for GPIO (digital I/O and PWM)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+from threading import Thread
+from time import sleep
+
+class Edge(Enum):
+    """Edge detection mode for input pins."""
+    BOTH = 2
+    FALLING = 0
+    RISING = 1
+class GPIO(ABC):
+    """Controls digital I/O and PWM on native GPIO pins (e.g., RPi BCM)."""
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the GPIO subsystem."""
+
+    @abstractmethod
+    def setup_input(self, pin: int) -> None:
+        """Configure a pin as digital input with pull-down."""
+
+    @abstractmethod
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        """Configure a pin as digital output."""
+
+    @abstractmethod
+    def read(self, pin: int) -> bool:
+        """Read digital value from a pin."""
+
+    @abstractmethod
+    def write(self, pin: int, value: bool) -> None:
+        """Write digital value to an output pin."""
+
+    @abstractmethod
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        """Configure a pin for PWM output."""
+
+    @abstractmethod
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        """Set PWM duty cycle (0.0–100.0) on a configured PWM pin."""
+
+    @abstractmethod
+    def stop_pwm(self, pin: int) -> None:
+        """Stop PWM on a pin."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release all GPIO resources."""
+
+    def auto_refresh(
+        self, pin: int, edge: Edge, interval: float, callback
+    ) -> Thread:
+        """Poll an input pin and call callback on edge events.
+
+        callback(pin, value) is called when the pin value changes
+        according to the edge mode. Returns the polling thread.
+        """
+        def _poll():
+            last = None
+            while True:
+                sleep(interval)
+                value = self.read(pin)
+                if last is not None and value != last:
+                    if edge == Edge.BOTH or edge.value == value:
+                        callback(pin, value)
+                last = value
+
+        t = Thread(target=_poll, daemon=True)
+        t.start()
+        return t

--- a/src/evo_hl/gpio/fake.py
+++ b/src/evo_hl/gpio/fake.py
@@ -1,0 +1,53 @@
+"""GPIO driver — fake implementation for testing without hardware."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIOFake(GPIO):
+    """In-memory GPIO for tests and simulation."""
+
+    def __init__(self):
+        self.pins: dict[int, dict] = {}
+
+    def init(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake initialized")
+
+    def setup_input(self, pin: int) -> None:
+        self.pins[pin] = {"output": False, "value": False, "pwm": None}
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self.pins[pin] = {"output": True, "value": default, "pwm": None}
+
+    def inject_input(self, pin: int, value: bool) -> None:
+        """Inject a value on an input pin for testing."""
+        if pin in self.pins and not self.pins[pin]["output"]:
+            self.pins[pin]["value"] = value
+
+    def read(self, pin: int) -> bool:
+        return self.pins.get(pin, {}).get("value", False)
+
+    def write(self, pin: int, value: bool) -> None:
+        if pin in self.pins:
+            self.pins[pin]["value"] = value
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        self.pins[pin] = {"output": True, "value": False, "pwm": {"freq": frequency, "duty": 0.0}}
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"]["duty"] = duty_cycle
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self.pins and self.pins[pin]["pwm"] is not None:
+            self.pins[pin]["pwm"] = None
+
+    def close(self) -> None:
+        self.pins.clear()
+        log.info("GPIO fake closed")

--- a/src/evo_hl/gpio/rpi.py
+++ b/src/evo_hl/gpio/rpi.py
@@ -1,0 +1,55 @@
+"""GPIO driver — real Raspberry Pi implementation via RPi.GPIO."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+
+log = logging.getLogger(__name__)
+
+
+class GPIORpi(GPIO):
+    """Native BCM GPIO on Raspberry Pi."""
+
+    def __init__(self):
+        self._pwms: dict[int, object] = {}
+
+    def init(self) -> None:
+        import RPi.GPIO as _RpiGPIO
+
+        _RpiGPIO.setmode(_RpiGPIO.BCM)
+        self._gpio = _RpiGPIO
+        log.info("RPi GPIO initialized (BCM mode)")
+
+    def setup_input(self, pin: int) -> None:
+        self._gpio.setup(pin, self._gpio.IN, pull_up_down=self._gpio.PUD_DOWN)
+
+    def setup_output(self, pin: int, default: bool = False) -> None:
+        self._gpio.setup(pin, self._gpio.OUT, initial=self._gpio.HIGH if default else self._gpio.LOW)
+
+    def read(self, pin: int) -> bool:
+        return bool(self._gpio.input(pin))
+
+    def write(self, pin: int, value: bool) -> None:
+        self._gpio.output(pin, self._gpio.HIGH if value else self._gpio.LOW)
+
+    def setup_pwm(self, pin: int, frequency: float) -> None:
+        pwm = self._gpio.PWM(pin, frequency)
+        pwm.start(0)
+        self._pwms[pin] = pwm
+
+    def set_pwm(self, pin: int, duty_cycle: float) -> None:
+        self._pwms[pin].ChangeDutyCycle(duty_cycle)
+
+    def stop_pwm(self, pin: int) -> None:
+        if pin in self._pwms:
+            self._pwms[pin].stop()
+            del self._pwms[pin]
+
+    def close(self) -> None:
+        for pwm in self._pwms.values():
+            pwm.stop()
+        self._pwms.clear()
+        self._gpio.cleanup()
+        log.info("RPi GPIO closed")

--- a/src/evo_hl/proximity/__init__.py
+++ b/src/evo_hl/proximity/__init__.py
@@ -1,0 +1,5 @@
+"""Proximity sensor driver (digital input)."""
+
+from evo_hl.proximity.base import Proximity
+
+__all__ = ["Proximity"]

--- a/src/evo_hl/proximity/base.py
+++ b/src/evo_hl/proximity/base.py
@@ -1,0 +1,11 @@
+"""Abstract base class for proximity sensors (digital detection)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+class Proximity(ABC):
+    """Reads a binary proximity detection from a digital input."""
+
+    @abstractmethod
+    def read(self, sensor_id: int) -> bool:
+        """Returns True if an object is detected."""

--- a/src/evo_hl/proximity/fake.py
+++ b/src/evo_hl/proximity/fake.py
@@ -1,0 +1,19 @@
+"""Proximity sensor — fake implementation for testing."""
+
+from __future__ import annotations
+
+from evo_hl.proximity.base import Proximity
+
+
+class ProximityFake(Proximity):
+    """In-memory proximity sensors for tests and simulation."""
+
+    def __init__(self):
+        self.detections: dict[int, bool] = {}
+
+    def inject(self, sensor_id: int, detected: bool) -> None:
+        """Inject a detection state for testing."""
+        self.detections[sensor_id] = detected
+
+    def read(self, sensor_id: int) -> bool:
+        return self.detections.get(sensor_id, False)

--- a/src/evo_hl/proximity/gpio_proximity.py
+++ b/src/evo_hl/proximity/gpio_proximity.py
@@ -1,0 +1,29 @@
+"""Proximity sensor — implementation via GPIO pins."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.gpio.base import GPIO
+from evo_hl.proximity.base import Proximity
+
+log = logging.getLogger(__name__)
+
+
+class ProximityGPIO(Proximity):
+    """Proximity sensors reading digital GPIO inputs."""
+
+    def __init__(self, gpio: GPIO, pin_map: dict[int, int]):
+        """
+        Args:
+            gpio: GPIO driver instance.
+            pin_map: sensor_id → GPIO pin number mapping.
+        """
+        self._gpio = gpio
+        self._pin_map = pin_map
+
+    def read(self, sensor_id: int) -> bool:
+        pin = self._pin_map.get(sensor_id)
+        if pin is None:
+            raise ValueError(f"Unknown sensor ID {sensor_id}")
+        return self._gpio.read(pin)

--- a/tests/test_proximity.py
+++ b/tests/test_proximity.py
@@ -1,0 +1,54 @@
+"""Tests for proximity sensor driver using fake and GPIO implementations."""
+
+import pytest
+
+from evo_hl.gpio.fake import GPIOFake
+from evo_hl.proximity.fake import ProximityFake
+from evo_hl.proximity.gpio_proximity import ProximityGPIO
+
+
+@pytest.fixture
+def prox():
+    return ProximityFake()
+
+
+@pytest.fixture
+def gpio_prox():
+    gpio = GPIOFake()
+    gpio.init()
+    gpio.setup_input(20)
+    gpio.setup_input(21)
+    return ProximityGPIO(gpio, pin_map={0: 20, 1: 21}), gpio
+
+
+class TestProximityFake:
+    def test_default_not_detected(self, prox):
+        assert prox.read(0) is False
+
+    def test_inject_detected(self, prox):
+        prox.inject(0, True)
+        assert prox.read(0) is True
+
+    def test_inject_not_detected(self, prox):
+        prox.inject(1, True)
+        prox.inject(1, False)
+        assert prox.read(1) is False
+
+    def test_independent_sensors(self, prox):
+        prox.inject(0, True)
+        prox.inject(1, False)
+        assert prox.read(0) is True
+        assert prox.read(1) is False
+
+
+class TestProximityGPIO:
+    def test_read_from_gpio(self, gpio_prox):
+        prox, gpio = gpio_prox
+        gpio.inject_input(20, True)
+        assert prox.read(0) is True
+        assert prox.read(1) is False
+
+    def test_unknown_sensor_raises(self, gpio_prox):
+        prox, gpio = gpio_prox
+        with pytest.raises(ValueError, match="Unknown sensor ID"):
+            prox.read(99)


### PR DESCRIPTION
## Summary
- Proximity sensor driver (base + gpio + fake)
- Named sensor map with digital GPIO inputs
- Includes bundled GPIO driver as dependency
- 6 tests via fake implementation

## Modules
- `src/evo_hl/proximity/` — base, gpio, fake
- `src/evo_hl/gpio/` — bundled dependency
- `tests/test_proximity.py`