### PR TITLE
feat: add WS2812B addressable LED strip driver

### DIFF
--- a/src/evo_hl/ws2812b/__init__.py
+++ b/src/evo_hl/ws2812b/__init__.py
@@ -1,0 +1,5 @@
+"""WS2812B addressable LED strip driver."""
+
+from evo_hl.ws2812b.base import LedMode, LedStrip
+
+__all__ = ["LedMode", "LedStrip"]

--- a/src/evo_hl/ws2812b/adafruit.py
+++ b/src/evo_hl/ws2812b/adafruit.py
@@ -1,0 +1,114 @@
+"""WS2812B LED strip driver — Adafruit NeoPixel implementation."""
+
+from __future__ import annotations
+
+import logging
+from threading import Event, Lock, Thread
+from time import sleep
+
+from evo_hl.ws2812b.base import (
+    LOADING_LED_COUNT,
+    MODE_REFRESH,
+    LedMode,
+    LedStrip,
+)
+
+log = logging.getLogger(__name__)
+
+# Common colors (R, G, B)
+_BLACK = (0, 0, 0)
+_GREEN = (0, 255, 0)
+_RED = (255, 0, 0)
+_ORANGE = (255, 50, 0)
+_BLUE = (0, 0, 255)
+
+
+class LedStripAdafruit(LedStrip):
+    """WS2812B NeoPixel strip using Adafruit CircuitPython (any blinka-supported SBC)."""
+
+    def __init__(self, pin, **kwargs):
+        super().__init__(**kwargs)
+        self._pin = pin
+        self._strip = None
+        self._lock = Lock()
+        self._stop_event = Event()
+        self._loading_color = _BLUE
+        self._current_led = 0
+        self._blink_state = False
+
+    def init(self) -> None:
+        import neopixel
+
+        self._strip = neopixel.NeoPixel(
+            self._pin, self.nb_leds, brightness=self.brightness, auto_write=False,
+        )
+        log.info("WS2812B initialized: %d LEDs", self.nb_leds)
+
+    def set_pixel(self, index: int, r: int, g: int, b: int) -> None:
+        self._strip[index] = (r, g, b)
+
+    def fill(self, r: int, g: int, b: int) -> None:
+        self._strip.fill((r, g, b))
+
+    def show(self) -> None:
+        self._strip.show()
+
+    def set_mode(self, mode: LedMode) -> None:
+        with self._lock:
+            self.mode = mode
+            self.fill(*_BLACK)
+            if mode == LedMode.Loading:
+                self._current_led = self.nb_leds - 1
+                for i in range(min(LOADING_LED_COUNT, self.nb_leds)):
+                    self.set_pixel(i, *self._loading_color)
+            elif mode in (LedMode.Disabled, LedMode.Error):
+                self._blink_state = False
+            self.show()
+        log.info("WS2812B mode: %s", mode.value)
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        Thread(target=self._run, daemon=True).start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            with self._lock:
+                if self.mode == LedMode.Disabled:
+                    for i in range(self.nb_leds):
+                        color = _ORANGE if (self._blink_state ^ (i % 2 == 0)) else _BLACK
+                        self.set_pixel(i, *color)
+                    self._blink_state = not self._blink_state
+
+                elif self.mode == LedMode.Error:
+                    color = _RED if self._blink_state else _BLACK
+                    self.fill(*color)
+                    self._blink_state = not self._blink_state
+
+                elif self.mode == LedMode.Loading:
+                    self.set_pixel(self._current_led, *_BLACK)
+                    next_led = (self._current_led + LOADING_LED_COUNT) % self.nb_leds
+                    self.set_pixel(next_led, *self._loading_color)
+                    self._current_led = (self._current_led + 1) % self.nb_leds
+
+                elif self.mode == LedMode.Running:
+                    self.fill(*_GREEN)
+
+                self.show()
+
+            sleep(MODE_REFRESH[self.mode])
+
+        with self._lock:
+            self.fill(*_BLACK)
+            self.show()
+        log.info("WS2812B animation stopped")
+
+    def close(self) -> None:
+        self.stop()
+        if self._strip is not None:
+            self._strip.fill(_BLACK)
+            self._strip.show()
+            self._strip = None
+        log.info("WS2812B closed")

--- a/src/evo_hl/ws2812b/base.py
+++ b/src/evo_hl/ws2812b/base.py
@@ -1,0 +1,66 @@
+"""Abstract base class for WS2812B addressable LED strip."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+class LedMode(Enum):
+    """LED strip display mode."""
+    Disabled = "disabled"
+    Error = "error"
+    Loading = "loading"
+    Running = "running"
+# Refresh interval per mode (seconds)
+MODE_REFRESH: dict[LedMode, float] = {
+    LedMode.Disabled: 0.25,
+    LedMode.Error: 0.5,
+    LedMode.Loading: 0.05,
+    LedMode.Running: 1.0,
+}
+
+# Number of lit LEDs in loading animation
+LOADING_LED_COUNT = 10
+class LedStrip(ABC):
+    """Controls a WS2812B addressable LED strip.
+
+    Supports multiple display modes (loading, running, error, disabled)
+    with a background animation thread.
+    """
+
+    def __init__(self, nb_leds: int, brightness: float = 0.5):
+        self.nb_leds = nb_leds
+        self.brightness = brightness
+        self.mode = LedMode.Loading
+
+    @abstractmethod
+    def init(self) -> None:
+        """Initialize the LED strip hardware."""
+
+    @abstractmethod
+    def set_mode(self, mode: LedMode) -> None:
+        """Switch display mode."""
+
+    @abstractmethod
+    def set_pixel(self, index: int, r: int, g: int, b: int) -> None:
+        """Set a single pixel color."""
+
+    @abstractmethod
+    def fill(self, r: int, g: int, b: int) -> None:
+        """Fill all pixels with a color."""
+
+    @abstractmethod
+    def show(self) -> None:
+        """Push pixel buffer to the strip."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start the background animation thread."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop animation and turn off LEDs."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release hardware resources."""

--- a/src/evo_hl/ws2812b/fake.py
+++ b/src/evo_hl/ws2812b/fake.py
@@ -1,0 +1,47 @@
+"""WS2812B LED strip driver — fake implementation for testing."""
+
+from __future__ import annotations
+
+import logging
+
+from evo_hl.ws2812b.base import LedMode, LedStrip
+
+log = logging.getLogger(__name__)
+
+
+class LedStripFake(LedStrip):
+    """In-memory LED strip for tests and simulation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.pixels: list[tuple[int, int, int]] = []
+        self.running = False
+
+    def init(self) -> None:
+        self.pixels = [(0, 0, 0)] * self.nb_leds
+        log.info("WS2812B fake initialized: %d LEDs", self.nb_leds)
+
+    def set_pixel(self, index: int, r: int, g: int, b: int) -> None:
+        if 0 <= index < self.nb_leds:
+            self.pixels[index] = (r, g, b)
+
+    def fill(self, r: int, g: int, b: int) -> None:
+        self.pixels = [(r, g, b)] * self.nb_leds
+
+    def show(self) -> None:
+        pass  # no-op in fake
+
+    def set_mode(self, mode: LedMode) -> None:
+        self.mode = mode
+        self.fill(0, 0, 0)
+
+    def start(self) -> None:
+        self.running = True
+
+    def stop(self) -> None:
+        self.running = False
+
+    def close(self) -> None:
+        self.running = False
+        self.pixels = [(0, 0, 0)] * self.nb_leds
+        log.info("WS2812B fake closed")

--- a/tests/test_ws2812b.py
+++ b/tests/test_ws2812b.py
@@ -1,0 +1,77 @@
+"""Tests for WS2812B LED strip driver using fake implementation."""
+
+import pytest
+
+from evo_hl.ws2812b.base import LedMode, LOADING_LED_COUNT, MODE_REFRESH
+from evo_hl.ws2812b.fake import LedStripFake
+
+
+@pytest.fixture
+def strip():
+    drv = LedStripFake(nb_leds=30, brightness=0.5)
+    drv.init()
+    yield drv
+    drv.close()
+
+
+class TestLedStripFake:
+    def test_init_pixels(self, strip):
+        assert len(strip.pixels) == 30
+        assert all(p == (0, 0, 0) for p in strip.pixels)
+
+    def test_set_pixel(self, strip):
+        strip.set_pixel(0, 255, 0, 0)
+        assert strip.pixels[0] == (255, 0, 0)
+        assert strip.pixels[1] == (0, 0, 0)
+
+    def test_set_pixel_bounds(self, strip):
+        strip.set_pixel(-1, 255, 0, 0)  # out of bounds, no-op
+        strip.set_pixel(30, 0, 255, 0)  # out of bounds, no-op
+        assert all(p == (0, 0, 0) for p in strip.pixels)
+
+    def test_fill(self, strip):
+        strip.fill(0, 255, 0)
+        assert all(p == (0, 255, 0) for p in strip.pixels)
+
+    def test_set_mode(self, strip):
+        strip.set_mode(LedMode.Running)
+        assert strip.mode == LedMode.Running
+
+    def test_set_mode_clears(self, strip):
+        strip.fill(255, 0, 0)
+        strip.set_mode(LedMode.Error)
+        assert all(p == (0, 0, 0) for p in strip.pixels)
+
+    def test_start_stop(self, strip):
+        strip.start()
+        assert strip.running is True
+        strip.stop()
+        assert strip.running is False
+
+    def test_close_resets(self, strip):
+        strip.fill(255, 255, 255)
+        strip.start()
+        strip.close()
+        assert strip.running is False
+        assert all(p == (0, 0, 0) for p in strip.pixels)
+
+    def test_default_mode_loading(self, strip):
+        assert strip.mode == LedMode.Loading
+
+    def test_brightness_stored(self, strip):
+        assert strip.brightness == 0.5
+
+
+class TestLedMode:
+    def test_all_modes_have_refresh(self):
+        for mode in LedMode:
+            assert mode in MODE_REFRESH
+
+    def test_loading_led_count(self):
+        assert LOADING_LED_COUNT > 0
+
+    def test_mode_values(self):
+        assert LedMode.Loading.value == "loading"
+        assert LedMode.Running.value == "running"
+        assert LedMode.Error.value == "error"
+        assert LedMode.Disabled.value == "disabled"


### PR DESCRIPTION
## Summary
- WS2812B NeoPixel addressable LED strip driver (base + rpi + fake)
- 4 display modes: Loading (rotating), Running (solid green), Error (red blink), Disabled (orange checkerboard)
- Background animation thread with per-mode refresh rate
- 13 tests via fake implementation

## Modules
- `src/evo_hl/ws2812b/` — base, rpi (adafruit-neopixel), fake
- `tests/test_ws2812b.py`