### PR TITLE
feat: add PWM and Servo drivers (PCA9685 + adapter)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,11 @@ dependencies = [
 # Hardware libs for Raspberry Pi (and any blinka-supported SBC).
 # Install on the robot: uv sync --extra rpi
 rpi = [
-    "adafruit-blinka>=8.0",
+    # I2C via smbus2 (pure Python, wraps the kernel ioctl interface).
+    "smbus2>=0.4",
+    # GPIO via gpiod (libgpiod v2 Python bindings). Single GPIO backend in
+    # the stack; no Blinka / RPi.GPIO shim needed since RpiI2C no longer
+    # goes through busio. See #67.
     "gpiod>=2.0",
     "pyserial>=3.5",
     "rplidar-roboticia>=0.9",

--- a/src/evo_lib/drivers/gpio/mcp23017.py
+++ b/src/evo_lib/drivers/gpio/mcp23017.py
@@ -86,7 +86,7 @@ class MCP23017Pin(GPIO):
         val = self._chip.read_register(self._gpio_reg)
         return ImmediateResultTask(bool(val & (1 << self._bit)))
 
-    def write(self, state: bool) -> Task[None]:
+    def write(self, state: bool) -> Task[()]:
         """Set the pin output state via the chip's I2C connection."""
         if self._direction != GPIODirection.OUTPUT:
             return ImmediateErrorTask(NotImplementedError("write() requires OUTPUT direction"))
@@ -156,23 +156,24 @@ class MCP23017Chip(InterfaceHolder):
     def read_register(self, register: int) -> int:
         """Read a single byte from a MCP23017 register."""
         with self._lock:
-            data = self._bus.write_then_read(self._address, bytes([register]), 1)
+            (data,) = self._bus.write_then_read(self._address, bytes([register]), 1).wait()
         return data[0]
 
     def write_register(self, register: int, value: int) -> None:
         """Write a single byte to a MCP23017 register."""
         with self._lock:
-            self._bus.write_to(self._address, bytes([register, value]))
+            self._bus.write_to(self._address, bytes([register, value])).wait()
 
     def set_bit(self, register: int, bit: int, value: bool) -> None:
         """Read-modify-write a single bit in a register (atomic)."""
         with self._lock:
-            current = self._bus.write_then_read(self._address, bytes([register]), 1)[0]
+            (data,) = self._bus.write_then_read(self._address, bytes([register]), 1).wait()
+            current = data[0]
             if value:
                 current |= 1 << bit
             else:
                 current &= ~(1 << bit)
-            self._bus.write_to(self._address, bytes([register, current]))
+            self._bus.write_to(self._address, bytes([register, current])).wait()
 
 
 class MCP23017ChipDefinition(DriverDefinition):
@@ -189,12 +190,11 @@ class MCP23017ChipDefinition(DriverDefinition):
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("name", ArgTypes.String())
         defn.add_optional("address", ArgTypes.U8(), 0x20)
         return defn
 
     def create(self, args: DriverInitArgs) -> MCP23017Chip:
-        name = args.get("name")
+        name = args.get_name()
         return MCP23017Chip(
             name=name,
             bus=self._bus,

--- a/src/evo_lib/drivers/i2c/__init__.py
+++ b/src/evo_lib/drivers/i2c/__init__.py
@@ -1,11 +1,22 @@
 """I2C drivers: real and virtual implementations."""
 
-from evo_lib.drivers.i2c.rpi import RpiI2C
-from evo_lib.drivers.i2c.tca9548a import TCA9548A
+from evo_lib.drivers.i2c.rpi import RpiI2C, RpiI2CDefinition, RpiI2CVirtual, RpiI2CVirtualDefinition
+from evo_lib.drivers.i2c.tca9548a import (
+    TCA9548A,
+    TCA9548ADefinition,
+    TCA9548AVirtual,
+    TCA9548AVirtualDefinition,
+)
 from evo_lib.drivers.i2c.virtual import I2CVirtual
 
 __all__ = [
     "I2CVirtual",
     "RpiI2C",
+    "RpiI2CDefinition",
+    "RpiI2CVirtual",
+    "RpiI2CVirtualDefinition",
     "TCA9548A",
+    "TCA9548ADefinition",
+    "TCA9548AVirtual",
+    "TCA9548AVirtualDefinition",
 ]

--- a/src/evo_lib/drivers/i2c/rpi.py
+++ b/src/evo_lib/drivers/i2c/rpi.py
@@ -1,4 +1,4 @@
-"""I2C driver: real Raspberry Pi implementation via Adafruit Blinka."""
+"""I2C driver: real Raspberry Pi implementation via smbus2 / i2c_rdwr."""
 
 import threading
 
@@ -11,16 +11,15 @@ from evo_lib.task import ImmediateResultTask, Task
 
 
 class RpiI2C(I2C):
-    """Real I2C bus on a Raspberry Pi (or any Blinka-supported SBC).
+    """Real I2C bus on a Raspberry Pi via smbus2.
 
-    Wraps busio.I2C with the board's default SCL/SDA pins for the given
-    bus number. Hardware libraries are lazily imported in init() so that
-    this module can be imported on dev machines without Blinka installed.
+    Opens /dev/i2c-N through smbus2.SMBus and uses i2c_rdwr for the three
+    raw transaction flavours (write, read, write-then-read). smbus2 is a
+    pure-Python wrapper on the kernel ioctl interface, so no GPIO-backend
+    library is needed at import time.
 
     All operations are serialized with a threading.Lock so that multiple
     threads sharing the same bus block properly instead of spin-waiting.
-    Each I/O returns an ImmediateResultTask wrapping the synchronous busio
-    call, matching the library-wide Task-returning driver contract.
     """
 
     def __init__(self, name: str, logger: Logger, bus: int = 1):
@@ -32,17 +31,16 @@ class RpiI2C(I2C):
 
     def init(self) -> Task[()]:
         """Open the I2C bus. Must be called before any read/write."""
-        import busio
+        from smbus2 import SMBus
 
-        scl, sda = self._get_i2c_pins(self._bus_number)
-        self._i2c = busio.I2C(scl, sda)
+        self._i2c = SMBus(self._bus_number)
         self._log.info(f"I2C bus {self._bus_number} opened")
         return ImmediateResultTask()
 
     def close(self) -> None:
         """Release the I2C bus."""
         if self._i2c is not None:
-            self._i2c.deinit()
+            self._i2c.close()
             self._i2c = None
             self._log.info(f"I2C bus {self._bus_number} closed")
 
@@ -50,43 +48,48 @@ class RpiI2C(I2C):
         if self._i2c is None:
             raise RuntimeError("I2C bus not opened, call init() first")
 
-    def write_to(self, address: int, data: bytes) -> Task[None]:
+    def write_to(self, address: int, data: bytes) -> Task[()]:
+        from smbus2 import i2c_msg
         self._check_ready()
         with self._lock:
-            self._i2c.writeto(address, data)
+            self._i2c.i2c_rdwr(i2c_msg.write(address, data))
         return ImmediateResultTask(None)
 
     def read_from(self, address: int, count: int) -> Task[bytes]:
+        from smbus2 import i2c_msg
         self._check_ready()
-        buf = bytearray(count)
+        msg = i2c_msg.read(address, count)
         with self._lock:
-            self._i2c.readfrom_into(address, buf)
-        return ImmediateResultTask(bytes(buf))
+            self._i2c.i2c_rdwr(msg)
+        return ImmediateResultTask(bytes(msg))
 
     def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
+        from smbus2 import i2c_msg
         self._check_ready()
-        buf = bytearray(in_count)
+        write = i2c_msg.write(address, out_data)
+        read = i2c_msg.read(address, in_count)
         with self._lock:
-            self._i2c.writeto_then_readfrom(address, out_data, buf)
-        return ImmediateResultTask(bytes(buf))
+            # Combined write+read in one transaction (repeated-START between).
+            self._i2c.i2c_rdwr(write, read)
+        return ImmediateResultTask(bytes(read))
 
     def scan(self) -> Task[list[int]]:
+        """Probe each valid 7-bit I2C address and return the ones that ACK.
+
+        smbus2 has no built-in scan; we iterate the standard range 0x03-0x77
+        and count a write_quick ACK as "device present". Reserved addresses
+        (0x00-0x02, 0x78-0x7F) are skipped per the I2C spec.
+        """
         self._check_ready()
+        found: list[int] = []
         with self._lock:
-            return ImmediateResultTask(self._i2c.scan())
-
-    @staticmethod
-    def _get_i2c_pins(bus: int) -> tuple:
-        """Return (SCL, SDA) board pins for the given I2C bus number."""
-        import board
-
-        if bus == 1:
-            return board.SCL, board.SDA
-        scl_attr = f"SCL{bus}"
-        sda_attr = f"SDA{bus}"
-        if hasattr(board, scl_attr) and hasattr(board, sda_attr):
-            return getattr(board, scl_attr), getattr(board, sda_attr)
-        raise ValueError(f"I2C bus {bus} not supported: board has no {scl_attr}/{sda_attr} pins")
+            for addr in range(0x03, 0x78):
+                try:
+                    self._i2c.write_quick(addr)
+                    found.append(addr)
+                except OSError:
+                    pass
+        return ImmediateResultTask(found)
 
 
 class RpiI2CDefinition(DriverDefinition):
@@ -131,7 +134,7 @@ class RpiI2CVirtual(I2C):
         self._inner.close()
         self._log.info(f"RpiI2CVirtual '{self.name}' closed")
 
-    def write_to(self, address: int, data: bytes) -> Task[None]:
+    def write_to(self, address: int, data: bytes) -> Task[()]:
         return self._inner.write_to(address, data)
 
     def read_from(self, address: int, count: int) -> Task[bytes]:

--- a/src/evo_lib/drivers/i2c/rpi.py
+++ b/src/evo_lib/drivers/i2c/rpi.py
@@ -1,11 +1,13 @@
 """I2C driver: real Raspberry Pi implementation via Adafruit Blinka."""
 
-import logging
 import threading
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.drivers.i2c.virtual import I2CDeviceVirtual, I2CVirtual
 from evo_lib.interfaces.i2c import I2C
-
-log = logging.getLogger(__name__)
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
 
 
 class RpiI2C(I2C):
@@ -17,58 +19,61 @@ class RpiI2C(I2C):
 
     All operations are serialized with a threading.Lock so that multiple
     threads sharing the same bus block properly instead of spin-waiting.
+    Each I/O returns an ImmediateResultTask wrapping the synchronous busio
+    call, matching the library-wide Task-returning driver contract.
     """
 
-    def __init__(self, name: str, bus: int = 1):
+    def __init__(self, name: str, logger: Logger, bus: int = 1):
         super().__init__(name)
+        self._log = logger
         self._bus_number = bus
         self._i2c = None
         self._lock = threading.Lock()
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         """Open the I2C bus. Must be called before any read/write."""
         import busio
 
         scl, sda = self._get_i2c_pins(self._bus_number)
         self._i2c = busio.I2C(scl, sda)
-        log.info("I2C bus %d opened", self._bus_number)
+        self._log.info(f"I2C bus {self._bus_number} opened")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         """Release the I2C bus."""
         if self._i2c is not None:
             self._i2c.deinit()
             self._i2c = None
-            log.info("I2C bus %d closed", self._bus_number)
+            self._log.info(f"I2C bus {self._bus_number} closed")
 
     def _check_ready(self) -> None:
         if self._i2c is None:
             raise RuntimeError("I2C bus not opened, call init() first")
 
-    def write_to(self, address: int, data: bytes) -> None:
+    def write_to(self, address: int, data: bytes) -> Task[None]:
         self._check_ready()
         with self._lock:
             self._i2c.writeto(address, data)
+        return ImmediateResultTask(None)
 
-    def read_from(self, address: int, count: int) -> bytes:
+    def read_from(self, address: int, count: int) -> Task[bytes]:
         self._check_ready()
         buf = bytearray(count)
         with self._lock:
             self._i2c.readfrom_into(address, buf)
-        return bytes(buf)
+        return ImmediateResultTask(bytes(buf))
 
-    def write_then_read(
-        self, address: int, out_data: bytes, in_count: int
-    ) -> bytes:
+    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
         self._check_ready()
         buf = bytearray(in_count)
         with self._lock:
             self._i2c.writeto_then_readfrom(address, out_data, buf)
-        return bytes(buf)
+        return ImmediateResultTask(bytes(buf))
 
-    def scan(self) -> list[int]:
+    def scan(self) -> Task[list[int]]:
         self._check_ready()
         with self._lock:
-            return self._i2c.scan()
+            return ImmediateResultTask(self._i2c.scan())
 
     @staticmethod
     def _get_i2c_pins(bus: int) -> tuple:
@@ -81,6 +86,86 @@ class RpiI2C(I2C):
         sda_attr = f"SDA{bus}"
         if hasattr(board, scl_attr) and hasattr(board, sda_attr):
             return getattr(board, scl_attr), getattr(board, sda_attr)
-        raise ValueError(
-            f"I2C bus {bus} not supported: board has no {scl_attr}/{sda_attr} pins"
+        raise ValueError(f"I2C bus {bus} not supported: board has no {scl_attr}/{sda_attr} pins")
+
+
+class RpiI2CDefinition(DriverDefinition):
+    """Factory for RpiI2C from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(RpiI2C.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_optional("bus", ArgTypes.U8(), 1)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiI2C:
+        return RpiI2C(
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
+        )
+
+
+class RpiI2CVirtual(I2C):
+    """Virtual twin of RpiI2C: same constructor signature, pure in-memory.
+
+    Delegates to I2CVirtual for all I2C logic. Accepts the same arguments
+    as RpiI2C so the factory can swap them transparently in config.
+    Exposes add_device() / get_device() for simulation setups.
+    """
+
+    def __init__(self, name: str, logger: Logger, bus: int = 1):
+        super().__init__(name)
+        self._log = logger
+        self._bus_number = bus
+        self._inner = I2CVirtual(name)
+
+    def init(self) -> Task[()]:
+        self._log.info(f"RpiI2CVirtual '{self.name}' initialized (bus {self._bus_number})")
+        return self._inner.init()
+
+    def close(self) -> None:
+        self._inner.close()
+        self._log.info(f"RpiI2CVirtual '{self.name}' closed")
+
+    def write_to(self, address: int, data: bytes) -> Task[None]:
+        return self._inner.write_to(address, data)
+
+    def read_from(self, address: int, count: int) -> Task[bytes]:
+        return self._inner.read_from(address, count)
+
+    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
+        return self._inner.write_then_read(address, out_data, in_count)
+
+    def scan(self) -> Task[list[int]]:
+        return self._inner.scan()
+
+    def add_device(self, address: int) -> I2CDeviceVirtual:
+        """Register a virtual device for simulation (inject reads, observe writes)."""
+        return self._inner.add_device(address)
+
+    def get_device(self, address: int) -> I2CDeviceVirtual:
+        return self._inner.get_device(address)
+
+
+class RpiI2CVirtualDefinition(DriverDefinition):
+    """Factory for RpiI2CVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(RpiI2CVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_optional("bus", ArgTypes.U8(), 1)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiI2CVirtual:
+        return RpiI2CVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
         )

--- a/src/evo_lib/drivers/i2c/tca9548a.py
+++ b/src/evo_lib/drivers/i2c/tca9548a.py
@@ -5,13 +5,15 @@ Each channel is itself an I2C: selecting a channel writes a control byte
 to the TCA's address, then forwards operations on the parent bus.
 """
 
-import logging
 import threading
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
 from evo_lib.interfaces.i2c import I2C
+from evo_lib.logger import Logger
 from evo_lib.peripheral import InterfaceHolder, Peripheral
-
-log = logging.getLogger(__name__)
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
 
 NUM_CHANNELS = 8
 
@@ -26,19 +28,36 @@ class TCA9548A(InterfaceHolder):
     preventing race conditions when multiple threads use different channels.
     """
 
-    def __init__(self, name: str, parent_bus: I2C, address: int = 0x70):
+    def __init__(self, name: str, logger: Logger, parent_bus: I2C, address: int = 0x70):
         super().__init__(name)
+        self._log = logger
         self.parent_bus = parent_bus
         self.address = address
         self._lock = threading.Lock()
         self._current_channel: int | None = None
-        self._channels: dict[int, TCA9548AChannel] = {}
+        self._channels: dict[int, "TCA9548AChannel"] = {}
 
-    def init(self) -> None:
-        pass
+    def init(self) -> Task[()]:
+        # Deselect all channels (write 0x00) to start from a known state,
+        # even if a previous run left a channel active.
+        self.parent_bus.write_to(self.address, bytes([0x00])).wait()
+        self._current_channel = None
+        self._log.info(f"TCA9548A '{self.name}' initialized at 0x{self.address:02x}")
+        return ImmediateResultTask()
 
     def close(self) -> None:
-        pass
+        """Deselect all channels, close children, and reset internal state."""
+        try:
+            # Write 0x00 to the control register: deselects every channel,
+            # leaving the mux in a known state for the next consumer.
+            self.parent_bus.write_to(self.address, bytes([0x00])).wait()
+        except OSError:
+            self._log.warning(f"TCA9548A '{self.name}': I2C error during close")
+        for ch in self._channels.values():
+            ch.close()
+        self._channels.clear()
+        self._current_channel = None
+        self._log.info(f"TCA9548A '{self.name}' closed")
 
     def get_subcomponents(self) -> list[Peripheral]:
         return list(self._channels.values())
@@ -47,15 +66,17 @@ class TCA9548A(InterfaceHolder):
         """Write the channel bitmask to the TCA control register."""
         if self._current_channel == channel:
             return
-        self.parent_bus.write_to(self.address, bytes([1 << channel]))
+        self.parent_bus.write_to(self.address, bytes([1 << channel])).wait()
         self._current_channel = channel
+        self._log.debug(f"TCA9548A 0x{self.address:02x}: selected channel {channel}")
 
-    def get_channel(self, channel: int) -> TCA9548AChannel:
+    def get_channel(self, channel: int) -> "TCA9548AChannel":
         """Return an I2C for the given mux channel (0-7)."""
         if not 0 <= channel < NUM_CHANNELS:
             raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
         if channel not in self._channels:
             self._channels[channel] = TCA9548AChannel(self, channel)
+            self._log.info(f"TCA9548A 0x{self.address:02x}: created channel {channel}")
         return self._channels[channel]
 
 
@@ -73,8 +94,9 @@ class TCA9548AChannel(I2C):
         self._channel = channel
         self._opened = False
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         self._opened = True
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._opened = False
@@ -83,32 +105,111 @@ class TCA9548AChannel(I2C):
         if not self._opened:
             raise RuntimeError(f"TCA9548A channel '{self.name}' not opened, call init() first")
 
-    def write_to(self, address: int, data: bytes) -> None:
+    def write_to(self, address: int, data: bytes) -> Task[()]:
         self._check_ready()
         with self._mux._lock:
             self._mux.select_channel(self._channel)
-            self._mux.parent_bus.write_to(address, data)
+            self._mux.parent_bus.write_to(address, data).wait()
+        return ImmediateResultTask(None)
 
-    def read_from(self, address: int, count: int) -> bytes:
+    def read_from(self, address: int, count: int) -> Task[bytes]:
         self._check_ready()
         with self._mux._lock:
             self._mux.select_channel(self._channel)
-            return self._mux.parent_bus.read_from(address, count)
+            (data,) = self._mux.parent_bus.read_from(address, count).wait()
+        return ImmediateResultTask(data)
 
-    def write_then_read(
-        self, address: int, out_data: bytes, in_count: int
-    ) -> bytes:
+    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
         self._check_ready()
         with self._mux._lock:
             self._mux.select_channel(self._channel)
-            return self._mux.parent_bus.write_then_read(address, out_data, in_count)
+            (data,) = self._mux.parent_bus.write_then_read(address, out_data, in_count).wait()
+        return ImmediateResultTask(data)
 
-    def scan(self) -> list[int]:
+    def scan(self) -> Task[list[int]]:
         self._check_ready()
         with self._mux._lock:
             self._mux.select_channel(self._channel)
-            return [
-                addr
-                for addr in self._mux.parent_bus.scan()
-                if addr != self._mux.address
-            ]
+            (addresses,) = self._mux.parent_bus.scan().wait()
+        return ImmediateResultTask([addr for addr in addresses if addr != self._mux.address])
+
+
+class TCA9548ADefinition(DriverDefinition):
+    """Factory for TCA9548A from config args. Parent bus is resolved by name.
+
+    The mux itself is an InterfaceHolder, not a bus, so it exposes no
+    commands directly. Channels created via get_channel() are TCA9548AChannel
+    instances that inherit I2C.commands via class-attribute lookup.
+    """
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("address", ArgTypes.U8(), 0x70)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> TCA9548A:
+        return TCA9548A(
+            name=args.get_name(),
+            logger=self._logger,
+            parent_bus=args.get("bus"),
+            address=args.get("address"),
+        )
+
+
+class TCA9548AVirtual(TCA9548A):
+    """Virtual twin of TCA9548A: inherits the real driver and bypasses writes
+    to the mux control register.
+
+    Follows the TiretteVirtual pattern: TCA9548A is mostly glue over the
+    parent bus, so the virtual just overrides the 3 methods that touch the
+    mux hardware (init, close, select_channel) to track state without any
+    I2C write. Channel I/O still flows through parent_bus so downstream
+    devices (on a virtual bus) work as usual.
+    """
+
+    def init(self) -> Task[()]:
+        self._current_channel = None
+        self._log.info(f"TCA9548AVirtual '{self.name}' initialized at 0x{self.address:02x}")
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        for ch in self._channels.values():
+            ch.close()
+        self._channels.clear()
+        self._current_channel = None
+        self._log.info(f"TCA9548AVirtual '{self.name}' closed")
+
+    def select_channel(self, channel: int) -> None:
+        if self._current_channel == channel:
+            return
+        self._current_channel = channel
+        self._log.debug(f"TCA9548AVirtual 0x{self.address:02x}: selected channel {channel} (simulated)")
+
+
+class TCA9548AVirtualDefinition(DriverDefinition):
+    """Factory for TCA9548AVirtual from config args."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("address", ArgTypes.U8(), 0x70)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> TCA9548AVirtual:
+        return TCA9548AVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            parent_bus=args.get("bus"),
+            address=args.get("address"),
+        )

--- a/src/evo_lib/drivers/i2c/virtual.py
+++ b/src/evo_lib/drivers/i2c/virtual.py
@@ -1,10 +1,7 @@
 """I2C driver: in-memory virtual implementation for testing and simulation."""
 
-import logging
-
 from evo_lib.interfaces.i2c import I2C
-
-log = logging.getLogger(__name__)
+from evo_lib.task import ImmediateResultTask, Task
 
 
 class I2CDeviceVirtual:
@@ -49,8 +46,9 @@ class I2CVirtual(I2C):
         self._devices: dict[int, I2CDeviceVirtual] = {}
         self._opened = False
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         self._opened = True
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._opened = False
@@ -71,22 +69,23 @@ class I2CVirtual(I2C):
             raise OSError(f"No device at address 0x{address:02x}")
         return self._devices[address]
 
-    def write_to(self, address: int, data: bytes) -> None:
+    def write_to(self, address: int, data: bytes) -> Task[()]:
         self._check_ready()
         device = self.get_device(address)
         device.written.append(data)
+        return ImmediateResultTask(None)
 
-    def read_from(self, address: int, count: int) -> bytes:
+    def read_from(self, address: int, count: int) -> Task[bytes]:
         self._check_ready()
         device = self.get_device(address)
-        return device.consume_read(count)
+        return ImmediateResultTask(device.consume_read(count))
 
-    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> bytes:
+    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
         self._check_ready()
         device = self.get_device(address)
         device.written.append(out_data)
-        return device.consume_read(in_count)
+        return ImmediateResultTask(device.consume_read(in_count))
 
-    def scan(self) -> list[int]:
+    def scan(self) -> Task[list[int]]:
         self._check_ready()
-        return sorted(self._devices.keys())
+        return ImmediateResultTask(sorted(self._devices.keys()))

--- a/src/evo_lib/drivers/pwm/__init__.py
+++ b/src/evo_lib/drivers/pwm/__init__.py
@@ -1,0 +1,30 @@
+"""PWM drivers: real and virtual implementations."""
+
+from evo_lib.drivers.pwm.pca9685 import (
+    PCA9685Channel,
+    PCA9685ChannelDefinition,
+    PCA9685ChannelVirtualDefinition,
+    PCA9685Chip,
+    PCA9685ChipDefinition,
+    PCA9685ChipVirtual,
+    PCA9685ChipVirtualDefinition,
+)
+from evo_lib.drivers.pwm.rpi import RpiPWM, RpiPWMDefinition, RpiPWMVirtual, RpiPWMVirtualDefinition
+from evo_lib.drivers.pwm.virtual import PWMChipVirtual, PWMChipVirtualDefinition, PWMVirtual
+
+__all__ = [
+    "PCA9685Channel",
+    "PCA9685ChannelDefinition",
+    "PCA9685ChannelVirtualDefinition",
+    "PCA9685Chip",
+    "PCA9685ChipDefinition",
+    "PCA9685ChipVirtual",
+    "PCA9685ChipVirtualDefinition",
+    "PWMChipVirtual",
+    "PWMChipVirtualDefinition",
+    "PWMVirtual",
+    "RpiPWM",
+    "RpiPWMDefinition",
+    "RpiPWMVirtual",
+    "RpiPWMVirtualDefinition",
+]

--- a/src/evo_lib/drivers/pwm/pca9685.py
+++ b/src/evo_lib/drivers/pwm/pca9685.py
@@ -1,0 +1,351 @@
+"""PCA9685 driver: 16-channel PWM controller over I2C.
+
+The PCA9685 generates PWM signals at a configurable frequency (typically
+50 Hz for servos). This module exposes it as:
+- PCA9685Chip (ComponentHolder): manages I2C connection, frequency, prescaler
+- PCA9685Channel (PWM): one instance per physical output channel
+"""
+
+import threading
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.drivers.pwm.virtual import PWMChipVirtual, PWMVirtual
+from evo_lib.interfaces.i2c import I2C
+from evo_lib.interfaces.pwm import PWM
+from evo_lib.logger import Logger
+from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+
+NUM_CHANNELS = 16
+_OSC_CLOCK_HZ = 25_000_000
+
+# Register addresses
+_MODE1 = 0x00
+_PRESCALE = 0xFE
+_LED0_ON_L = 0x06
+_ALL_LED_ON_L = 0xFA  # broadcast registers: writing here affects all 16 channels
+
+# MODE1 bits
+_MODE1_SLEEP = 0x10  # bit 4
+_MODE1_AI = 0x20  # bit 5: auto-increment
+_MODE1_RESTART = 0x80  # bit 7
+
+# Channel control bits (in ON_H / OFF_H)
+_FULL_ON = 0x10  # bit 4 of ON_H
+_FULL_OFF = 0x10  # bit 4 of OFF_H
+
+
+class PCA9685Channel(PWM):
+    """A single PWM output channel on a PCA9685 chip.
+
+    Read-back commands (`get_duty_cycle`, `get_pulse_width_us`, `is_enabled`)
+    report the last-commanded value, not a hardware measurement: the PCA9685
+    output registers are technically readable but hold stale data on warm
+    reset, so we memorize the value on write instead.
+    """
+
+    commands = DriverCommands(parents=[PWM.commands])
+
+    def __init__(self, name: str, logger: Logger, chip: PCA9685Chip, channel: int):
+        super().__init__(name)
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        self._log = logger
+        self._chip = chip
+        self._channel = channel
+        self._base_reg = _LED0_ON_L + 4 * channel
+        self._last_duty_cycle: float = 0.0
+        self._last_pulse_width_us: float = 0.0
+
+    def init(self) -> Task[()]:
+        # Force the channel to full-off at init. PCA9685's RESTART bit
+        # preserves previous duty cycles across a sleep/wake cycle, so
+        # without this a servo could snap back to its pre-reset angle.
+        self.free().wait()
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self.free().wait()
+
+    def set_duty_cycle(self, duty: float) -> Task[()]:
+        """Set duty cycle as a fraction (0.0 to 1.0)."""
+        duty = max(0.0, min(1.0, duty))
+        if duty == 0.0:
+            # Full off: set bit 4 of OFF_H, clear ON
+            self._chip.write_channel(self._base_reg, 0, 0, 0, _FULL_OFF)
+        elif duty == 1.0:
+            # Full on: set bit 4 of ON_H, clear OFF
+            self._chip.write_channel(self._base_reg, 0, _FULL_ON, 0, 0)
+        else:
+            off_count = round(duty * 4096)
+            self._chip.write_channel(
+                self._base_reg, 0, 0, off_count & 0xFF, (off_count >> 8) & 0x0F
+            )
+        self._last_duty_cycle = duty
+        self._last_pulse_width_us = duty * 1_000_000.0 / self._chip.freq_hz
+        return ImmediateResultTask(None)
+
+    def set_pulse_width_us(self, width_us: float) -> Task[()]:
+        """Convert pulse width to duty cycle and apply."""
+        period_us = 1_000_000.0 / self._chip.freq_hz
+        duty = width_us / period_us
+        return self.set_duty_cycle(duty)
+
+    def free(self) -> Task[()]:
+        """Disable this channel (full off)."""
+        return self.set_duty_cycle(0.0)
+
+    @commands.register(
+        args=[],
+        result=[("duty", ArgTypes.F32(help="Last commanded duty cycle (0.0 to 1.0)"))],
+    )
+    def get_duty_cycle(self) -> Task[float]:
+        return ImmediateResultTask(self._last_duty_cycle)
+
+    @commands.register(
+        args=[],
+        result=[("width_us", ArgTypes.F32(help="Last commanded pulse width in microseconds"))],
+    )
+    def get_pulse_width_us(self) -> Task[float]:
+        return ImmediateResultTask(self._last_pulse_width_us)
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="True if a non-zero pulse is currently commanded"))],
+    )
+    def is_enabled(self) -> Task[bool]:
+        return ImmediateResultTask(self._last_duty_cycle > 0.0)
+
+
+class PCA9685Chip(InterfaceHolder):
+    """Manages the I2C connection to one PCA9685 chip.
+
+    Channels are numbered 0-15.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        address: int = 0x40,
+        freq_hz: float = 50.0,
+    ):
+        super().__init__(name)
+        self._bus = bus
+        self._address = address
+        self._freq_hz = freq_hz
+        self._log = logger
+        self._lock = threading.Lock()
+        self._channels: dict[int, PCA9685Channel] = {}
+
+    @property
+    def freq_hz(self) -> float:
+        return self._freq_hz
+
+    def init(self) -> Task[()]:
+        """Configure prescaler for the target frequency and start the chip."""
+        # Enter sleep mode (required to change prescaler)
+        mode1 = self._read_register(_MODE1)
+        self._write_register(_MODE1, (mode1 | _MODE1_SLEEP) & ~_MODE1_RESTART)
+
+        # Set prescaler
+        prescale = round(_OSC_CLOCK_HZ / (4096 * self._freq_hz)) - 1
+        prescale = max(3, min(255, prescale))
+        self._write_register(_PRESCALE, prescale)
+
+        # Wake up: clear sleep, set auto-increment
+        mode1 = (mode1 | _MODE1_AI) & ~_MODE1_SLEEP
+        self._write_register(_MODE1, mode1)
+
+        # Force every channel to full-off BEFORE setting RESTART. On a warm
+        # reset the output registers still hold the previous run's duty
+        # cycles; RESTART would then resume them and snap connected servos
+        # to stale positions. Writing to ALL_LED_{ON,OFF} is a broadcast
+        # that clears all 16 channels in a single I2C transaction.
+        with self._lock:
+            self._bus.write_to(
+                self._address,
+                bytes([_ALL_LED_ON_L, 0, 0, 0, _FULL_OFF]),
+            ).wait()
+
+        # Restart (must be set after clearing sleep)
+        self._write_register(_MODE1, mode1 | _MODE1_RESTART)
+
+        self._log.info(
+            f"PCA9685 '{self.name}' initialized at 0x{self._address:02x}, "
+            f"freq={self._freq_hz:.1f} Hz, prescale={prescale}"
+        )
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        try:
+            for ch in self._channels.values():
+                ch.free().wait()
+            mode1 = self._read_register(_MODE1)
+            self._write_register(_MODE1, mode1 | _MODE1_SLEEP)
+        except OSError:
+            self._log.warning(f"PCA9685 '{self.name}': I2C error during close")
+        self._channels.clear()
+        self._log.info(f"PCA9685 '{self.name}' closed")
+
+    def get_subcomponents(self) -> list[Peripheral]:
+        """Return all channels that have been created via get_channel."""
+        return list(self._channels.values())
+
+    def get_channel(self, channel: int, name: str) -> PCA9685Channel:
+        """Create or retrieve a PCA9685Channel for the given channel number."""
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        if channel in self._channels:
+            return self._channels[channel]
+        pwm_channel = PCA9685Channel(name, self._log, self, channel)
+        self._channels[channel] = pwm_channel
+        return pwm_channel
+
+    def write_channel(self, base_reg: int, on_l: int, on_h: int, off_l: int, off_h: int) -> None:
+        """Write the 4 channel registers using auto-increment."""
+        with self._lock:
+            self._bus.write_to(self._address, bytes([base_reg, on_l, on_h, off_l, off_h])).wait()
+
+    def _read_register(self, register: int) -> int:
+        with self._lock:
+            (data,) = self._bus.write_then_read(self._address, bytes([register]), 1).wait()
+        return data[0]
+
+    def _write_register(self, register: int, value: int) -> None:
+        with self._lock:
+            self._bus.write_to(self._address, bytes([register, value])).wait()
+
+
+class PCA9685ChipDefinition(DriverDefinition):
+    """Factory for PCA9685Chip from config args. Parent bus resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("address", ArgTypes.U8(), 0x40)
+        defn.add_optional("freq_hz", ArgTypes.F32(), 50.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PCA9685Chip:
+        return PCA9685Chip(
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
+            address=args.get("address"),
+            freq_hz=args.get("freq_hz"),
+        )
+
+
+class PCA9685ChannelDefinition(DriverDefinition):
+    """Factory for a PCA9685Channel on a parent PCA9685Chip.
+
+    The channel is created (or retrieved) via chip.get_channel(), so the
+    chip remains the single source of truth for its 16 channels and will
+    free/close them during its own close().
+    """
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PCA9685Channel.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("chip", ArgTypes.Component(PCA9685Chip, self._peripherals))
+        defn.add_required("channel", ArgTypes.U8(min_value=0, max_value=NUM_CHANNELS - 1))
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PCA9685Channel:
+        chip: PCA9685Chip = args.get("chip")
+        return chip.get_channel(args.get("channel"), args.get_name())
+
+
+class PCA9685ChipVirtual(PWMChipVirtual):
+    """Virtual twin of PCA9685Chip: same constructor signature, in-memory.
+
+    Delegates all PWM logic to PWMChipVirtual. Accepts bus and address for
+    drop-in config compatibility with PCA9685Chip, but ignores them (the
+    virtual has no real I2C transport).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        address: int = 0x40,
+        freq_hz: float = 50.0,
+    ):
+        super().__init__(name, logger, freq_hz)
+        self._bus = bus
+        self._address = address
+
+    def init(self) -> Task[()]:
+        self._log.info(
+            f"PCA9685ChipVirtual '{self.name}' initialized at 0x{self._address:02x}, "
+            f"freq={self._freq_hz:.1f} Hz"
+        )
+        return super().init()
+
+
+class PCA9685ChipVirtualDefinition(DriverDefinition):
+    """Factory for PCA9685ChipVirtual. Parent bus resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("address", ArgTypes.U8(), 0x40)
+        defn.add_optional("freq_hz", ArgTypes.F32(), 50.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PCA9685ChipVirtual:
+        return PCA9685ChipVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
+            address=args.get("address"),
+            freq_hz=args.get("freq_hz"),
+        )
+
+
+class PCA9685ChannelVirtualDefinition(DriverDefinition):
+    """Factory for a virtual PCA9685 channel on a PCA9685ChipVirtual.
+
+    Mirrors PCA9685ChannelDefinition: resolves the chip by name, delegates
+    channel creation to chip.get_channel() which returns a PWMVirtual (the
+    standard virtual drop-in for a PWM channel, with read-back commands).
+    """
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PWMVirtual.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("chip", ArgTypes.Component(PCA9685ChipVirtual, self._peripherals))
+        defn.add_required("channel", ArgTypes.U8(min_value=0, max_value=NUM_CHANNELS - 1))
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PWMVirtual:
+        chip: PCA9685ChipVirtual = args.get("chip")
+        return chip.get_channel(args.get("channel"), args.get_name())

--- a/src/evo_lib/drivers/pwm/rpi.py
+++ b/src/evo_lib/drivers/pwm/rpi.py
@@ -1,0 +1,166 @@
+"""PWM driver: Raspberry Pi hardware PWM via Linux sysfs.
+
+The RPi has 2 hardware PWM channels exposed at /sys/class/pwm/pwmchip0/:
+- Channel 0: GPIO 12 or 18
+- Channel 1: GPIO 13 or 19
+
+The GPIO pin must be set to ALT function first (via dtoverlay in config.txt).
+This driver writes period/duty_cycle in nanoseconds to sysfs files.
+"""
+
+from pathlib import Path
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.drivers.pwm.virtual import PWMVirtual
+from evo_lib.interfaces.pwm import PWM
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+
+_DEFAULT_CHIP = "/sys/class/pwm/pwmchip0"
+
+
+class RpiPWM(PWM):
+    """Hardware PWM on Raspberry Pi via sysfs."""
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        channel: int,
+        freq_hz: float = 50.0,
+        chip_path: str = _DEFAULT_CHIP,
+    ):
+        super().__init__(name)
+        if channel not in (0, 1):
+            raise ValueError(f"RPi PWM channel must be 0 or 1, got {channel}")
+        self._log = logger
+        self._channel = channel
+        self._freq_hz = freq_hz
+        self._period_ns = round(1_000_000_000 / freq_hz)
+        self._path = Path(chip_path) / f"pwm{channel}"
+        self._chip_path = Path(chip_path)
+        self._exported = False
+        self._initialized = False
+
+    def _check_init(self) -> None:
+        if not self._initialized:
+            raise RuntimeError("PWM not initialized, call init() first")
+
+    def init(self) -> Task[()]:
+        # Export the channel if not already present
+        if not self._path.exists():
+            (self._chip_path / "export").write_text(str(self._channel))
+            self._exported = True
+        # Set period (frequency)
+        (self._path / "period").write_text(str(self._period_ns))
+        # Start with output disabled
+        (self._path / "duty_cycle").write_text("0")
+        (self._path / "enable").write_text("1")
+        self._initialized = True
+        self._log.info(
+            f"RpiPWM '{self.name}' initialized on channel {self._channel}, "
+            f"freq={self._freq_hz:.1f} Hz"
+        )
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        if not self._initialized:
+            return
+        self._initialized = False
+        if self._path.exists():
+            (self._path / "enable").write_text("0")
+            if self._exported:
+                (self._chip_path / "unexport").write_text(str(self._channel))
+                self._exported = False
+        self._log.info(f"RpiPWM '{self.name}' closed")
+
+    def set_duty_cycle(self, duty: float) -> Task[()]:
+        self._check_init()
+        duty = max(0.0, min(1.0, duty))
+        duty_ns = round(duty * self._period_ns)
+        (self._path / "duty_cycle").write_text(str(duty_ns))
+        return ImmediateResultTask(None)
+
+    def set_pulse_width_us(self, width_us: float) -> Task[()]:
+        self._check_init()
+        duty_ns = round(width_us * 1000)
+        duty_ns = max(0, min(self._period_ns, duty_ns))
+        (self._path / "duty_cycle").write_text(str(duty_ns))
+        return ImmediateResultTask(None)
+
+    def free(self) -> Task[()]:
+        self._check_init()
+        (self._path / "duty_cycle").write_text("0")
+        return ImmediateResultTask(None)
+
+
+class RpiPWMDefinition(DriverDefinition):
+    """Factory for RpiPWM from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(RpiPWM.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("channel", ArgTypes.U8())
+        defn.add_optional("freq_hz", ArgTypes.F32(), 50.0)
+        defn.add_optional("chip_path", ArgTypes.String(), _DEFAULT_CHIP)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiPWM:
+        return RpiPWM(
+            name=args.get_name(),
+            logger=self._logger,
+            channel=args.get("channel"),
+            freq_hz=args.get("freq_hz"),
+            chip_path=args.get("chip_path"),
+        )
+
+
+class RpiPWMVirtual(PWMVirtual):
+    """Virtual twin of RpiPWM: same constructor signature, pure in-memory.
+
+    Accepts the same (name, logger, channel, freq_hz, chip_path) signature
+    as RpiPWM so the factory can swap them transparently in config. Channel
+    and chip_path are stored for introspection but no sysfs I/O happens.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        channel: int,
+        freq_hz: float = 50.0,
+        chip_path: str = _DEFAULT_CHIP,
+    ):
+        super().__init__(name, logger, freq_hz)
+        if channel not in (0, 1):
+            raise ValueError(f"RPi PWM channel must be 0 or 1, got {channel}")
+        self._channel = channel
+        self._chip_path = chip_path
+
+
+class RpiPWMVirtualDefinition(DriverDefinition):
+    """Factory for RpiPWMVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(RpiPWMVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("channel", ArgTypes.U8())
+        defn.add_optional("freq_hz", ArgTypes.F32(), 50.0)
+        defn.add_optional("chip_path", ArgTypes.String(), _DEFAULT_CHIP)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiPWMVirtual:
+        return RpiPWMVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            channel=args.get("channel"),
+            freq_hz=args.get("freq_hz"),
+            chip_path=args.get("chip_path"),
+        )

--- a/src/evo_lib/drivers/pwm/virtual.py
+++ b/src/evo_lib/drivers/pwm/virtual.py
@@ -1,0 +1,126 @@
+"""PWM drivers: virtual implementations for testing and simulation."""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands, DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.pwm import PWM
+from evo_lib.logger import Logger
+from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.task import ImmediateResultTask, Task
+
+NUM_CHANNELS = 16
+
+
+class PWMVirtual(PWM):
+    """In-memory PWM channel for tests and simulation.
+
+    Exposes read-back commands (get_duty_cycle, get_pulse_width_us, is_enabled)
+    on top of the real PWM commands so the REPL can observe simulated state.
+    """
+
+    commands = DriverCommands(parents=[PWM.commands])
+
+    def __init__(self, name: str, logger: Logger, freq_hz: float = 50.0):
+        super().__init__(name)
+        self._log = logger
+        self._freq_hz = freq_hz
+        self.duty_cycle: float = 0.0
+        self.pulse_width_us: float = 0.0
+        self.enabled: bool = False
+
+    def init(self) -> Task[()]:
+        self.enabled = True
+        self._log.info(f"PWMVirtual '{self.name}' initialized")
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self.enabled = False
+
+    def set_duty_cycle(self, duty: float) -> Task[()]:
+        self.duty_cycle = max(0.0, min(1.0, duty))
+        self.pulse_width_us = self.duty_cycle * 1_000_000.0 / self._freq_hz
+        return ImmediateResultTask(None)
+
+    def set_pulse_width_us(self, width_us: float) -> Task[()]:
+        period_us = 1_000_000.0 / self._freq_hz
+        self.duty_cycle = max(0.0, min(1.0, width_us / period_us))
+        self.pulse_width_us = self.duty_cycle * period_us
+        return ImmediateResultTask(None)
+
+    def free(self) -> Task[()]:
+        self.duty_cycle = 0.0
+        self.pulse_width_us = 0.0
+        return ImmediateResultTask(None)
+
+    @commands.register(
+        args=[],
+        result=[("duty", ArgTypes.F32(help="Current duty cycle (0.0 to 1.0)"))],
+    )
+    def get_duty_cycle(self) -> Task[float]:
+        """Read the last commanded duty cycle."""
+        return ImmediateResultTask(self.duty_cycle)
+
+    @commands.register(
+        args=[],
+        result=[("width_us", ArgTypes.F32(help="Current pulse width in microseconds"))],
+    )
+    def get_pulse_width_us(self) -> Task[float]:
+        """Read the last commanded pulse width."""
+        return ImmediateResultTask(self.pulse_width_us)
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="True if init() has been called and close() has not"))],
+    )
+    def is_enabled(self) -> Task[bool]:
+        """Read whether the simulated channel is enabled."""
+        return ImmediateResultTask(self.enabled)
+
+
+class PWMChipVirtual(InterfaceHolder):
+    """In-memory virtual for the PCA9685 chip, for tests and simulation."""
+
+    def __init__(self, name: str, logger: Logger, freq_hz: float = 50.0):
+        super().__init__(name)
+        self._log = logger
+        self._freq_hz = freq_hz
+        self._channels: dict[int, PWMVirtual] = {}
+
+    def init(self) -> Task[()]:
+        self._log.info(f"PWMChipVirtual '{self.name}' initialized")
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self._channels.clear()
+
+    def get_subcomponents(self) -> list[Peripheral]:
+        return list(self._channels.values())
+
+    def get_channel(self, channel: int, name: str) -> PWMVirtual:
+        """Create or retrieve a PWMVirtual for the given channel number."""
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        if channel in self._channels:
+            return self._channels[channel]
+        pwm = PWMVirtual(name, self._log, self._freq_hz)
+        self._channels[channel] = pwm
+        return pwm
+
+
+class PWMChipVirtualDefinition(DriverDefinition):
+    """Factory for PWMChipVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__()
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_optional("freq_hz", ArgTypes.F32(), 50.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PWMChipVirtual:
+        return PWMChipVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            freq_hz=args.get("freq_hz"),
+        )

--- a/src/evo_lib/drivers/servo/__init__.py
+++ b/src/evo_lib/drivers/servo/__init__.py
@@ -1,0 +1,18 @@
+"""Servo drivers: real and virtual implementations."""
+
+from evo_lib.drivers.servo.pwm_servo import (
+    PWMServo,
+    PWMServoDefinition,
+    PWMServoVirtual,
+    PWMServoVirtualDefinition,
+)
+from evo_lib.drivers.servo.virtual import ServoVirtual, ServoVirtualDefinition
+
+__all__ = [
+    "PWMServo",
+    "PWMServoDefinition",
+    "PWMServoVirtual",
+    "PWMServoVirtualDefinition",
+    "ServoVirtual",
+    "ServoVirtualDefinition",
+]

--- a/src/evo_lib/drivers/servo/pwm_servo.py
+++ b/src/evo_lib/drivers/servo/pwm_servo.py
@@ -1,0 +1,199 @@
+"""Servo driver: adapter that wraps a PWM channel into a Servo.
+
+Converts angles and fractions to pulse widths, delegating the actual
+signal generation to any PWM implementation (PCA9685, software PWM, virtual).
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.interfaces.pwm import PWM
+from evo_lib.interfaces.servo import Servo
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class PWMServo(Servo):
+    """Turns a PWM output into an angle-controlled servo.
+
+    The conversion is linear: angle 0 maps to min_pulse_us,
+    angle angle_range maps to max_pulse_us.
+
+    Read-back commands (`get_angle`, `get_fraction`, `is_enabled`) derive
+    their answer from the underlying PWM's last commanded pulse width, so
+    they require the PWM implementation to expose `get_pulse_width_us`.
+    """
+
+    commands = DriverCommands(parents=[Servo.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        pwm: PWM,
+        min_pulse_us: float = 500.0,
+        max_pulse_us: float = 2500.0,
+        angle_range: float = 180.0,
+        min_angle: float = 0.0,
+        max_angle: float | None = None,
+    ):
+        super().__init__(name)
+        self._log = logger
+        self._pwm = pwm
+        self._min_pulse_us = min_pulse_us
+        self._max_pulse_us = max_pulse_us
+        self._angle_range = angle_range
+        # Mechanical safety limits. Distinct from the electrical range defined
+        # by min/max_pulse_us: those calibrate "what pulse = 0°", while
+        # min/max_angle bound "which angles are safe to command physically".
+        # Default: no tighter clamp than the electrical range.
+        self._min_angle = min_angle
+        self._max_angle = angle_range if max_angle is None else max_angle
+
+    def init(self) -> Task[()]:
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        pass
+
+    def move_to_angle(self, angle: float) -> Task[()]:
+        """Move to the given angle. Clamped to [min_angle, max_angle]."""
+        return self.move_to_fraction(angle / self._angle_range)
+
+    def move_to_fraction(self, fraction: float) -> Task[()]:
+        """Set position as a fraction of the full range.
+
+        Clamped first to [0, 1] (electrical range), then the resulting angle
+        is clamped to [min_angle, max_angle] (mechanical safety).
+        """
+        fraction = max(0.0, min(1.0, fraction))
+        angle = fraction * self._angle_range
+        angle = max(self._min_angle, min(self._max_angle, angle))
+        fraction = angle / self._angle_range
+        pulse_us = self._min_pulse_us + fraction * (self._max_pulse_us - self._min_pulse_us)
+        return self._pwm.set_pulse_width_us(pulse_us)
+
+    def free(self) -> Task[()]:
+        """Disable PWM output (servo goes limp)."""
+        return self._pwm.free()
+
+    def _read_pulse_us(self) -> float:
+        (pulse_us,) = self._pwm.get_pulse_width_us().wait()
+        return pulse_us
+
+    @commands.register(
+        args=[],
+        result=[("angle", ArgTypes.F32(help="Current angle in degrees"))],
+    )
+    def get_angle(self) -> Task[float]:
+        pulse_us = self._read_pulse_us()
+        fraction = (pulse_us - self._min_pulse_us) / (self._max_pulse_us - self._min_pulse_us)
+        return ImmediateResultTask(fraction * self._angle_range)
+
+    @commands.register(
+        args=[],
+        result=[("fraction", ArgTypes.F32(help="Current position as fraction of full range"))],
+    )
+    def get_fraction(self) -> Task[float]:
+        pulse_us = self._read_pulse_us()
+        return ImmediateResultTask(
+            (pulse_us - self._min_pulse_us) / (self._max_pulse_us - self._min_pulse_us)
+        )
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="True if the servo is actively driving a position"))],
+    )
+    def is_enabled(self) -> Task[bool]:
+        # A servo is "enabled" when it has a non-zero pulse commanded, i.e. when
+        # it is actively holding a position. free() zeroes the pulse, so this
+        # naturally flips to False without any extra state tracking.
+        return ImmediateResultTask(self._read_pulse_us() > 0.0)
+
+
+class PWMServoDefinition(DriverDefinition):
+    """Factory for PWMServo from config args. PWM channel resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PWMServo.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("pwm", ArgTypes.Component(PWM, self._peripherals))
+        defn.add_optional("min_pulse_us", ArgTypes.F32(), 500.0)
+        defn.add_optional("max_pulse_us", ArgTypes.F32(), 2500.0)
+        defn.add_optional("angle_range", ArgTypes.F32(), 180.0)
+        defn.add_optional("min_angle", ArgTypes.F32(), 0.0)
+        # Sentinel -1 means "unset, default to angle_range". ArgTypes.F32 has
+        # no natural "None" default so we use a negative value which is
+        # guaranteed to be below any valid servo angle.
+        defn.add_optional("max_angle", ArgTypes.F32(), -1.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PWMServo:
+        max_angle_raw = args.get("max_angle")
+        max_angle = None if max_angle_raw < 0 else max_angle_raw
+        return PWMServo(
+            name=args.get_name(),
+            logger=self._logger,
+            pwm=args.get("pwm"),
+            min_pulse_us=args.get("min_pulse_us"),
+            max_pulse_us=args.get("max_pulse_us"),
+            angle_range=args.get("angle_range"),
+            min_angle=args.get("min_angle"),
+            max_angle=max_angle,
+        )
+
+
+class PWMServoVirtual(PWMServo):
+    """Drop-in twin of PWMServo for the `virtual_pwm_servo` registry slot.
+
+    Currently has no extra behaviour — PWMServo itself now hosts the read-back
+    commands, and the virtual-ness comes entirely from the injected PWM being
+    a PWMVirtual. Kept as a distinct class so that future debug/simulation
+    hooks (injected faults, latency, snapshots) have a natural place to live
+    without touching the real driver.
+    """
+
+    commands = DriverCommands(parents=[PWMServo.commands])
+
+
+class PWMServoVirtualDefinition(DriverDefinition):
+    """Factory for PWMServoVirtual from config args."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PWMServoVirtual.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("pwm", ArgTypes.Component(PWM, self._peripherals))
+        defn.add_optional("min_pulse_us", ArgTypes.F32(), 500.0)
+        defn.add_optional("max_pulse_us", ArgTypes.F32(), 2500.0)
+        defn.add_optional("angle_range", ArgTypes.F32(), 180.0)
+        defn.add_optional("min_angle", ArgTypes.F32(), 0.0)
+        defn.add_optional("max_angle", ArgTypes.F32(), -1.0)  # -1 = default to angle_range
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PWMServoVirtual:
+        max_angle_raw = args.get("max_angle")
+        max_angle = None if max_angle_raw < 0 else max_angle_raw
+        return PWMServoVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            pwm=args.get("pwm"),
+            min_pulse_us=args.get("min_pulse_us"),
+            max_pulse_us=args.get("max_pulse_us"),
+            angle_range=args.get("angle_range"),
+            min_angle=args.get("min_angle"),
+            max_angle=max_angle,
+        )

--- a/src/evo_lib/drivers/servo/virtual.py
+++ b/src/evo_lib/drivers/servo/virtual.py
@@ -1,0 +1,93 @@
+"""Servo driver: virtual implementation for testing and simulation."""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands, DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.servo import Servo
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class ServoVirtual(Servo):
+    """In-memory servo for tests and simulation.
+
+    Exposes read-back commands (get_angle, get_fraction, is_enabled) on top
+    of the real Servo commands so the REPL can observe simulated state.
+    """
+
+    commands = DriverCommands(parents=[Servo.commands])
+
+    def __init__(self, name: str, logger: Logger, angle_range: float = 180.0):
+        super().__init__(name)
+        self._log = logger
+        self._angle_range = angle_range
+        self.current_angle: float = 0.0
+        self.current_fraction: float = 0.0
+        self.enabled: bool = False
+
+    def init(self) -> Task[()]:
+        self.enabled = True
+        self._log.info(f"ServoVirtual '{self.name}' initialized")
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self.enabled = False
+
+    def move_to_angle(self, angle: float) -> Task[()]:
+        angle = max(0.0, min(self._angle_range, angle))
+        self.current_angle = angle
+        self.current_fraction = angle / self._angle_range
+        return ImmediateResultTask(None)
+
+    def move_to_fraction(self, fraction: float) -> Task[()]:
+        fraction = max(0.0, min(1.0, fraction))
+        self.current_fraction = fraction
+        self.current_angle = fraction * self._angle_range
+        return ImmediateResultTask(None)
+
+    def free(self) -> Task[()]:
+        self.enabled = False
+        return ImmediateResultTask(None)
+
+    @commands.register(
+        args=[],
+        result=[("angle", ArgTypes.F32(help="Current commanded angle in degrees"))],
+    )
+    def get_angle(self) -> Task[float]:
+        """Read the last commanded angle."""
+        return ImmediateResultTask(self.current_angle)
+
+    @commands.register(
+        args=[],
+        result=[("fraction", ArgTypes.F32(help="Current position as fraction of full range"))],
+    )
+    def get_fraction(self) -> Task[float]:
+        """Read the last commanded fraction."""
+        return ImmediateResultTask(self.current_fraction)
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="True if the servo is powered (init without subsequent free/close)"))],
+    )
+    def is_enabled(self) -> Task[bool]:
+        """Read whether the simulated servo is enabled."""
+        return ImmediateResultTask(self.enabled)
+
+
+class ServoVirtualDefinition(DriverDefinition):
+    """Factory for ServoVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(ServoVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_optional("angle_range", ArgTypes.F32(), 180.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> ServoVirtual:
+        return ServoVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            angle_range=args.get("angle_range"),
+        )

--- a/src/evo_lib/interfaces/__init__.py
+++ b/src/evo_lib/interfaces/__init__.py
@@ -16,6 +16,7 @@ from evo_lib.interfaces.pilot import (
     Pilot,
     PilotMoveStatus,
 )
+from evo_lib.interfaces.pwm import PWM
 from evo_lib.interfaces.serial import Serial
 from evo_lib.interfaces.servo import Servo
 from evo_lib.interfaces.smart_servo import SmartServo
@@ -33,6 +34,7 @@ __all__ = [
     "Lidar2D",
     "Pilot",
     "PilotMoveStatus",
+    "PWM",
     "Serial",
     "Servo",
     "SmartServo",

--- a/src/evo_lib/interfaces/i2c.py
+++ b/src/evo_lib/interfaces/i2c.py
@@ -1,8 +1,14 @@
 """Abstract interface for an I2C bus."""
 
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands
 from evo_lib.peripheral import Interface
+
+if TYPE_CHECKING:
+    from evo_lib.task import Task
 
 
 class I2C(Interface):
@@ -10,18 +16,47 @@ class I2C(Interface):
 
     Drivers receive an I2C instead of creating their own busio.I2C.
     This decouples drivers from the transport and enables bus-level simulation.
+
+    All methods return Task so the interface stays consistent with the rest
+    of the library (GPIO, PWM, Servo, ...) and can be exposed via
+    DriverCommands to the REPL. Real implementations wrap synchronous busio
+    calls in ImmediateResultTask, so there is no added latency.
     """
 
+    commands = DriverCommands()
+
     @abstractmethod
-    def write_to(self, address: int, data: bytes) -> None:
+    @commands.register(
+        args=[
+            ("address", ArgTypes.U8(help="7-bit I2C device address")),
+            ("data", ArgTypes.Bytes()),
+        ],
+        result=[],
+    )
+    def write_to(self, address: int, data: bytes) -> Task[()]:
         """Write raw bytes to a device at the given 7-bit address."""
 
     @abstractmethod
-    def read_from(self, address: int, count: int) -> bytes:
+    @commands.register(
+        args=[
+            ("address", ArgTypes.U8(help="7-bit I2C device address")),
+            ("count", ArgTypes.U16(help="Number of bytes to read")),
+        ],
+        result=[("data", ArgTypes.Bytes())],
+    )
+    def read_from(self, address: int, count: int) -> Task[bytes]:
         """Read count bytes from a device at the given 7-bit address."""
 
     @abstractmethod
-    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> bytes:
+    @commands.register(
+        args=[
+            ("address", ArgTypes.U8(help="7-bit I2C device address")),
+            ("out_data", ArgTypes.Bytes()),
+            ("in_count", ArgTypes.U16(help="Number of bytes to read after the write")),
+        ],
+        result=[("data", ArgTypes.Bytes())],
+    )
+    def write_then_read(self, address: int, out_data: bytes, in_count: int) -> Task[bytes]:
         """Write out_data then immediately read in_count bytes (repeated start).
 
         This is the most common I2C pattern: send a register address,
@@ -29,5 +64,9 @@ class I2C(Interface):
         """
 
     @abstractmethod
-    def scan(self) -> list[int]:
+    @commands.register(
+        args=[],
+        result=[("addresses", ArgTypes.Array(ArgTypes.U8()))],
+    )
+    def scan(self) -> Task[list[int]]:
         """Return the list of 7-bit addresses that ACK on the bus."""

--- a/src/evo_lib/interfaces/pwm.py
+++ b/src/evo_lib/interfaces/pwm.py
@@ -1,0 +1,46 @@
+"""Abstract interface for a single PWM output channel."""
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands
+from evo_lib.peripheral import Interface
+
+if TYPE_CHECKING:
+    from evo_lib.task import Task
+
+
+class PWM(Interface):
+    """A single PWM output (e.g. one channel on a PCA9685).
+
+    Abstracts away the underlying hardware so consumers (servos, LEDs, ESCs)
+    don't need to know which chip generates the signal.
+    """
+
+    commands = DriverCommands()
+
+    @abstractmethod
+    @commands.register(
+        args=[("duty", ArgTypes.F32(help="Duty cycle as a fraction (0.0 to 1.0)"))],
+        result=[],
+    )
+    def set_duty_cycle(self, duty: float) -> Task[()]:
+        """Set duty cycle as a fraction (0.0 to 1.0)."""
+
+    @abstractmethod
+    @commands.register(
+        args=[("width_us", ArgTypes.F32(help="Pulse width in microseconds"))],
+        result=[],
+    )
+    def set_pulse_width_us(self, width_us: float) -> Task[()]:
+        """Set pulse width in microseconds.
+
+        Requires a known frequency on the underlying hardware.
+        Typical servo range: 500-2500 us at 50 Hz.
+        """
+
+    @abstractmethod
+    @commands.register(args=[], result=[])
+    def free(self) -> Task[()]:
+        """Disable PWM output (full off)."""

--- a/src/evo_lib/interfaces/servo.py
+++ b/src/evo_lib/interfaces/servo.py
@@ -3,6 +3,8 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands
 from evo_lib.peripheral import Placable
 
 if TYPE_CHECKING:
@@ -15,14 +17,25 @@ class Servo(Placable):
     Abstracts away the underlying hardware (PCA9685 channel, direct PWM, etc.).
     """
 
+    commands = DriverCommands()
+
     @abstractmethod
-    def move_to_angle(self, angle: float) -> Task[None]:
+    @commands.register(
+        args=[("angle", ArgTypes.F32(help="Target angle in degrees"))],
+        result=[],
+    )
+    def move_to_angle(self, angle: float) -> Task[()]:
         """Move to the given angle (in degrees)."""
 
     @abstractmethod
-    def move_to_fraction(self, fraction: float) -> Task[None]:
+    @commands.register(
+        args=[("fraction", ArgTypes.F32(help="Target position as fraction of full range (0.0 to 1.0)"))],
+        result=[],
+    )
+    def move_to_fraction(self, fraction: float) -> Task[()]:
         """Set position as a fraction of the full range (0.0 to 1.0)."""
 
     @abstractmethod
-    def free(self) -> Task[None]:
+    @commands.register(args=[], result=[])
+    def free(self) -> Task[()]:
         """Disable PWM output (servo goes limp)."""

--- a/tests/test_i2c.py
+++ b/tests/test_i2c.py
@@ -2,8 +2,10 @@
 
 import pytest
 
-from evo_lib.drivers.i2c.tca9548a import TCA9548A
+from evo_lib.drivers.i2c.rpi import RpiI2CVirtual
+from evo_lib.drivers.i2c.tca9548a import TCA9548A, TCA9548AVirtual
 from evo_lib.drivers.i2c.virtual import I2CVirtual
+from evo_lib.logger import Logger
 
 
 class TestI2CVirtual:
@@ -13,8 +15,8 @@ class TestI2CVirtual:
         dev = bus.add_device(0x20)
         dev.inject_read(b"\x42\x43")
 
-        bus.write_to(0x20, b"\x01")
-        result = bus.read_from(0x20, 2)
+        bus.write_to(0x20, b"\x01").wait()
+        (result,) = bus.read_from(0x20, 2).wait()
 
         assert dev.written == [b"\x01"]
         assert result == b"\x42\x43"
@@ -25,7 +27,7 @@ class TestI2CVirtual:
         dev = bus.add_device(0x48)
         dev.inject_read(b"\xff")
 
-        result = bus.write_then_read(0x48, b"\x00", 1)
+        (result,) = bus.write_then_read(0x48, b"\x00", 1).wait()
 
         assert dev.written == [b"\x00"]
         assert result == b"\xff"
@@ -52,10 +54,10 @@ class TestTCA9548A:
         target_dev = bus.add_device(0x29)
         target_dev.inject_read(b"\xAB")
 
-        tca = TCA9548A("tca", bus, address=0x70)
+        tca = TCA9548A("tca", Logger("test"), bus, address=0x70)
         ch3 = tca.get_channel(3)
         ch3.init()
-        result = ch3.read_from(0x29, 1)
+        (result,) = ch3.read_from(0x29, 1).wait()
 
         # TCA should have received channel select byte (1 << 3 = 0x08)
         assert tca_dev.written == [bytes([0x08])]
@@ -63,7 +65,7 @@ class TestTCA9548A:
 
     def test_channel_out_of_range(self):
         bus = I2CVirtual()
-        tca = TCA9548A("tca", bus, address=0x70)
+        tca = TCA9548A("tca", Logger("test"), bus, address=0x70)
         with pytest.raises(ValueError):
             tca.get_channel(8)
 
@@ -73,7 +75,55 @@ class TestTCA9548A:
         bus.add_device(0x70)
         bus.add_device(0x29)
 
-        tca = TCA9548A("tca", bus, address=0x70)
+        tca = TCA9548A("tca", Logger("test"), bus, address=0x70)
         ch0 = tca.get_channel(0)
         ch0.init()
-        assert ch0.scan() == [0x29]
+        (addresses,) = ch0.scan().wait()
+        assert addresses == [0x29]
+
+
+class TestRpiI2CVirtual:
+    """Virtual twin of RpiI2C: same constructor, drop-in replacement."""
+
+    def test_constructor_matches_rpii2c(self):
+        # Same (name, logger, bus) signature as RpiI2C
+        bus = RpiI2CVirtual("rpi_virt", Logger("test"), bus=1)
+        bus.init()
+        (addresses,) = bus.scan().wait()
+        assert addresses == []
+
+    def test_read_write_delegates_to_inner(self):
+        bus = RpiI2CVirtual("rpi_virt", Logger("test"))
+        bus.init()
+        dev = bus.add_device(0x48)
+        dev.inject_read(b"\xAB")
+        bus.write_to(0x48, b"\x01").wait()
+        assert dev.written == [b"\x01"]
+        (result,) = bus.read_from(0x48, 1).wait()
+        assert result == b"\xAB"
+
+
+class TestTCA9548AVirtual:
+    """Virtual twin of TCA9548A: inherits real, bypasses mux writes."""
+
+    def test_init_does_not_write_to_bus(self):
+        # Parent bus has NO device at 0x70, real TCA would fail. Virtual must not.
+        bus = I2CVirtual()
+        bus.init()
+        tca = TCA9548AVirtual("tca", Logger("test"), bus, address=0x70)
+        tca.init()  # should not raise
+
+    def test_channel_select_tracks_state_without_bus_write(self):
+        bus = I2CVirtual()
+        bus.init()
+        # Register downstream device only; no TCA device at 0x70.
+        target = bus.add_device(0x29)
+        target.inject_read(b"\xEF")
+
+        tca = TCA9548AVirtual("tca", Logger("test"), bus, address=0x70)
+        tca.init()
+        ch2 = tca.get_channel(2)
+        ch2.init()
+        (result,) = ch2.read_from(0x29, 1).wait()
+        assert result == b"\xEF"
+        assert tca._current_channel == 2

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -1,0 +1,210 @@
+"""Tests for PWM drivers (PCA9685 on virtual I2C + virtual chip + RPi sysfs + ESC)."""
+
+import pytest
+
+from evo_lib.drivers.i2c.virtual import I2CVirtual
+from evo_lib.drivers.pwm.pca9685 import PCA9685Chip, PCA9685ChipVirtual
+from evo_lib.drivers.pwm.rpi import RpiPWM, RpiPWMVirtual
+from evo_lib.drivers.pwm.virtual import PWMChipVirtual, PWMVirtual
+from evo_lib.logger import Logger
+
+
+class TestPWMVirtual:
+    def test_set_duty_cycle(self):
+        pwm = PWMVirtual("test", Logger("test"), freq_hz=50.0)
+        pwm.init()
+        pwm.set_duty_cycle(0.5)
+        assert pwm.duty_cycle == 0.5
+        # At 50Hz, period = 20000us, 50% = 10000us
+        assert pwm.pulse_width_us == pytest.approx(10000.0)
+
+    def test_set_pulse_width_us(self):
+        pwm = PWMVirtual("test", Logger("test"), freq_hz=50.0)
+        pwm.init()
+        pwm.set_pulse_width_us(1500.0)
+        assert pwm.pulse_width_us == pytest.approx(1500.0)
+        assert pwm.duty_cycle == pytest.approx(0.075)
+
+    def test_free(self):
+        pwm = PWMVirtual("test", Logger("test"))
+        pwm.init()
+        pwm.set_duty_cycle(0.5)
+        pwm.free()
+        assert pwm.duty_cycle == 0.0
+
+    def test_clamp(self):
+        pwm = PWMVirtual("test", Logger("test"))
+        pwm.init()
+        pwm.set_duty_cycle(1.5)
+        assert pwm.duty_cycle == 1.0
+        pwm.set_duty_cycle(-0.5)
+        assert pwm.duty_cycle == 0.0
+
+
+class TestPWMChipVirtual:
+    def test_get_channel(self):
+        chip = PWMChipVirtual("test", Logger("test"))
+        ch = chip.get_channel(0, "ch0")
+        assert isinstance(ch, PWMVirtual)
+        assert ch.name == "ch0"
+
+    def test_get_channel_returns_same_instance(self):
+        chip = PWMChipVirtual("test", Logger("test"))
+        ch1 = chip.get_channel(3, "ch3")
+        ch2 = chip.get_channel(3, "ch3")
+        assert ch1 is ch2
+
+    def test_get_channel_bad_number(self):
+        chip = PWMChipVirtual("test", Logger("test"))
+        with pytest.raises(ValueError):
+            chip.get_channel(16, "bad")
+
+
+class TestPCA9685Chip:
+    @pytest.fixture
+    def bus_and_chip(self):
+        bus = I2CVirtual()
+        bus.init()
+        dev = bus.add_device(0x40)
+        # init() reads MODE1 then does several writes
+        dev.inject_read(b"\x00")  # MODE1 read
+        chip = PCA9685Chip("test", Logger("test"), bus, address=0x40, freq_hz=50.0)
+        chip.init()
+        dev.written.clear()
+        return bus, dev, chip
+
+    def test_init_prescale(self):
+        bus = I2CVirtual()
+        bus.init()
+        dev = bus.add_device(0x40)
+        dev.inject_read(b"\x00")  # MODE1 read
+        chip = PCA9685Chip("test", Logger("test"), bus, address=0x40, freq_hz=50.0)
+        chip.init()
+        # Expected sequence:
+        # [0] MODE1 read addr, [1] MODE1 sleep+clear restart, [2] PRESCALE,
+        # [3] MODE1 wake+AI, [4] ALL_LED_OFF broadcast (warm-reset safety),
+        # [5] MODE1 wake+AI+restart
+        assert dev.written[0] == bytes([0x00])  # MODE1 read addr
+        assert dev.written[1] == bytes([0x00, 0x10])  # sleep mode
+        assert dev.written[2] == bytes([0xFE, 121])  # prescale
+        assert dev.written[3] == bytes([0x00, 0x20])  # wake + AI
+        assert dev.written[4] == bytes([0xFA, 0, 0, 0, 0x10])  # ALL_LED full-off
+        assert dev.written[5] == bytes([0x00, 0xA0])  # restart + AI
+
+    def test_set_duty_cycle_half(self, bus_and_chip):
+        _, dev, chip = bus_and_chip
+        ch = chip.get_channel(0, "ch0")
+        ch.set_duty_cycle(0.5)
+        # off_count = round(0.5 * 4096) = 2048
+        # write: base_reg=0x06, on_l=0, on_h=0, off_l=0x00, off_h=0x08
+        assert dev.written[-1] == bytes([0x06, 0, 0, 0x00, 0x08])
+
+    def test_set_duty_cycle_full_off(self, bus_and_chip):
+        _, dev, chip = bus_and_chip
+        ch = chip.get_channel(0, "ch0")
+        ch.set_duty_cycle(0.0)
+        # Full off: off_h has bit 4 set
+        assert dev.written[-1] == bytes([0x06, 0, 0, 0, 0x10])
+
+    def test_set_duty_cycle_full_on(self, bus_and_chip):
+        _, dev, chip = bus_and_chip
+        ch = chip.get_channel(0, "ch0")
+        ch.set_duty_cycle(1.0)
+        # Full on: on_h has bit 4 set
+        assert dev.written[-1] == bytes([0x06, 0, 0x10, 0, 0])
+
+    def test_set_pulse_width_us(self, bus_and_chip):
+        _, dev, chip = bus_and_chip
+        ch = chip.get_channel(0, "ch0")
+        ch.set_pulse_width_us(1500.0)
+        # duty = 1500 / 20000 = 0.075, off_count = round(0.075 * 4096) = 307
+        # 307 = 0x133 -> off_l=0x33, off_h=0x01
+        assert dev.written[-1] == bytes([0x06, 0, 0, 0x33, 0x01])
+
+    def test_channel_2_register_offset(self, bus_and_chip):
+        _, dev, chip = bus_and_chip
+        ch = chip.get_channel(2, "ch2")
+        ch.set_duty_cycle(0.0)
+        # Channel 2 base = 0x06 + 4*2 = 0x0E
+        assert dev.written[-1][0] == 0x0E
+
+    def test_channel_out_of_range(self, bus_and_chip):
+        _, _, chip = bus_and_chip
+        with pytest.raises(ValueError):
+            chip.get_channel(16, "bad")
+
+
+class TestRpiPWM:
+    @pytest.fixture
+    def sysfs_pwm(self, tmp_path):
+        """Create a fake sysfs PWM tree."""
+        chip = tmp_path / "pwmchip0"
+        chip.mkdir()
+        (chip / "export").write_text("")
+        pwm0 = chip / "pwm0"
+        pwm0.mkdir()
+        for f in ("period", "duty_cycle", "enable"):
+            (pwm0 / f).write_text("0")
+        return RpiPWM("test", Logger("test"), channel=0, freq_hz=50.0, chip_path=str(chip))
+
+    def test_init_sets_period(self, sysfs_pwm, tmp_path):
+        sysfs_pwm.init()
+        period = (tmp_path / "pwmchip0" / "pwm0" / "period").read_text()
+        assert period == "20000000"  # 50Hz = 20ms = 20_000_000ns
+
+    def test_set_duty_cycle(self, sysfs_pwm, tmp_path):
+        sysfs_pwm.init()
+        sysfs_pwm.set_duty_cycle(0.5)
+        duty = (tmp_path / "pwmchip0" / "pwm0" / "duty_cycle").read_text()
+        assert duty == "10000000"  # 50% of 20ms
+
+    def test_set_pulse_width_us(self, sysfs_pwm, tmp_path):
+        sysfs_pwm.init()
+        sysfs_pwm.set_pulse_width_us(1500.0)
+        duty = (tmp_path / "pwmchip0" / "pwm0" / "duty_cycle").read_text()
+        assert duty == "1500000"  # 1500us = 1_500_000ns
+
+    def test_free(self, sysfs_pwm, tmp_path):
+        sysfs_pwm.init()
+        sysfs_pwm.set_duty_cycle(0.5)
+        sysfs_pwm.free()
+        duty = (tmp_path / "pwmchip0" / "pwm0" / "duty_cycle").read_text()
+        assert duty == "0"
+
+    def test_invalid_channel(self):
+        with pytest.raises(ValueError):
+            RpiPWM("bad", Logger("test"), channel=2)
+
+
+class TestPCA9685ChipVirtual:
+    """Drop-in virtual twin of PCA9685Chip: zero-setup, no I2C writes."""
+
+    def test_constructor_matches_real_signature(self):
+        # Same (name, logger, bus, address, freq_hz) as PCA9685Chip
+        bus = I2CVirtual()
+        bus.init()
+        chip = PCA9685ChipVirtual("pca_virt", Logger("test"), bus, address=0x40, freq_hz=50.0)
+        chip.init()  # must not write to bus (no device at 0x40)
+
+    def test_channel_is_driveable_without_i2c_setup(self):
+        bus = I2CVirtual()
+        bus.init()
+        chip = PCA9685ChipVirtual("pca_virt", Logger("test"), bus)
+        chip.init()
+        ch = chip.get_channel(2, "ch2")
+        ch.set_duty_cycle(0.5)
+        assert ch.duty_cycle == 0.5
+
+
+class TestRpiPWMVirtual:
+    """Drop-in virtual twin of RpiPWM: same sysfs-style signature, no I/O."""
+
+    def test_constructor_matches_rpipwm_signature(self):
+        pwm = RpiPWMVirtual("rpi_pwm_virt", Logger("test"), channel=0, freq_hz=50.0)
+        pwm.init()
+        pwm.set_duty_cycle(0.5)
+        assert pwm.duty_cycle == 0.5
+
+    def test_invalid_channel_rejected_like_real(self):
+        with pytest.raises(ValueError):
+            RpiPWMVirtual("bad", Logger("test"), channel=2)

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -1,0 +1,150 @@
+"""Tests for Servo drivers (PWMServo adapter + virtual)."""
+
+import pytest
+
+from evo_lib.drivers.pwm.virtual import PWMVirtual
+from evo_lib.drivers.servo.pwm_servo import PWMServo, PWMServoVirtual
+from evo_lib.drivers.servo.virtual import ServoVirtual
+from evo_lib.logger import Logger
+
+
+class TestServoVirtual:
+    def test_move_to_angle(self):
+        servo = ServoVirtual("test", Logger("test"), angle_range=180.0)
+        servo.init()
+        servo.move_to_angle(90.0)
+        assert servo.current_angle == 90.0
+        assert servo.current_fraction == pytest.approx(0.5)
+
+    def test_move_to_fraction(self):
+        servo = ServoVirtual("test", Logger("test"), angle_range=180.0)
+        servo.init()
+        servo.move_to_fraction(0.25)
+        assert servo.current_fraction == 0.25
+        assert servo.current_angle == pytest.approx(45.0)
+
+    def test_free(self):
+        servo = ServoVirtual("test", Logger("test"))
+        servo.init()
+        assert servo.enabled is True
+        servo.free()
+        assert servo.enabled is False
+
+
+class TestPWMServo:
+    @pytest.fixture
+    def pwm_and_servo(self):
+        log = Logger("test")
+        pwm = PWMVirtual("pwm", log, freq_hz=50.0)
+        pwm.init()
+        servo = PWMServo("servo", log, pwm, min_pulse_us=500.0, max_pulse_us=2500.0, angle_range=180.0)
+        return pwm, servo
+
+    def test_move_to_angle_center(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        servo.move_to_angle(90.0)
+        assert pwm.pulse_width_us == pytest.approx(1500.0)
+
+    def test_move_to_angle_min(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        servo.move_to_angle(0.0)
+        assert pwm.pulse_width_us == pytest.approx(500.0)
+
+    def test_move_to_angle_max(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        servo.move_to_angle(180.0)
+        assert pwm.pulse_width_us == pytest.approx(2500.0)
+
+    def test_move_to_fraction(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        servo.move_to_fraction(0.25)
+        assert pwm.pulse_width_us == pytest.approx(1000.0)
+
+    def test_free_delegates(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        pwm.set_duty_cycle(0.5)
+        servo.free()
+        assert pwm.duty_cycle == 0.0
+
+    def test_angle_clamped(self, pwm_and_servo):
+        pwm, servo = pwm_and_servo
+        servo.move_to_angle(-10.0)
+        assert pwm.pulse_width_us == pytest.approx(500.0)
+        servo.move_to_angle(200.0)
+        assert pwm.pulse_width_us == pytest.approx(2500.0)
+
+    def test_angle_clamped_by_safety_limits(self):
+        log = Logger("test")
+        pwm = PWMVirtual("pwm", log, freq_hz=50.0)
+        pwm.init()
+        servo = PWMServo(
+            "s", log, pwm,
+            min_pulse_us=500.0, max_pulse_us=2800.0, angle_range=205.0,
+            min_angle=10.0, max_angle=195.0,
+        )
+        # Below safety min → clamped to min_angle=10, pulse ≈ 612.2
+        servo.move_to_angle(0.0)
+        assert pwm.pulse_width_us == pytest.approx(500.0 + (10.0 / 205.0) * 2300.0)
+        # Above safety max → clamped to max_angle=195, pulse ≈ 2687.8
+        servo.move_to_angle(205.0)
+        assert pwm.pulse_width_us == pytest.approx(500.0 + (195.0 / 205.0) * 2300.0)
+        # Within safety range → untouched
+        servo.move_to_angle(100.0)
+        assert pwm.pulse_width_us == pytest.approx(500.0 + (100.0 / 205.0) * 2300.0)
+
+
+class TestServoCommands:
+    """Exercise DriverCommands registered on the Servo interface + virtual read-backs."""
+
+    def test_move_to_angle_via_command(self):
+        servo = ServoVirtual("test", Logger("test"))
+        servo.init()
+        cmd = ServoVirtual.commands.get("move_to_angle")
+        cmd.call(servo, angle=45.0).wait()
+        assert servo.current_angle == 45.0
+
+    def test_virtual_commands_include_interface_and_readbacks(self):
+        names = {c.name for c in ServoVirtual.commands.get_all()}
+        assert names == {
+            "move_to_angle", "move_to_fraction", "free",
+            "get_angle", "get_fraction", "is_enabled",
+        }
+
+    def test_get_angle_via_command(self):
+        servo = ServoVirtual("test", Logger("test"))
+        servo.init()
+        servo.move_to_angle(72.0)
+        cmd = ServoVirtual.commands.get("get_angle")
+        (angle,) = cmd.call(servo).wait()
+        assert angle == 72.0
+
+
+class TestPWMServoVirtual:
+    """Drop-in virtual twin of PWMServo: same signature + read-backs from PWM state."""
+
+    def test_move_propagates_to_pwm(self):
+        log = Logger("test")
+        pwm = PWMVirtual("pwm", log, freq_hz=50.0)
+        pwm.init()
+        servo = PWMServoVirtual(
+            "servo", log, pwm,
+            min_pulse_us=500.0, max_pulse_us=2500.0, angle_range=180.0,
+        )
+        servo.init()
+        servo.move_to_angle(90.0)
+        # Center angle -> center pulse (1500us) on the underlying virtual PWM
+        assert pwm.pulse_width_us == pytest.approx(1500.0)
+        # Read-back derives the angle from the PWM's pulse, not from internal state
+        (angle,) = servo.get_angle().wait()
+        assert angle == pytest.approx(90.0)
+
+    def test_get_fraction_via_command(self):
+        log = Logger("test")
+        pwm = PWMVirtual("pwm", log, freq_hz=50.0)
+        pwm.init()
+        servo = PWMServoVirtual("servo", log, pwm)
+        servo.init()
+        servo.move_to_fraction(0.25)
+        cmd = PWMServoVirtual.commands.get("get_fraction")
+        (fraction,) = cmd.call(servo).wait()
+        assert fraction == pytest.approx(0.25)


### PR DESCRIPTION
Adds PWM and Servo driver stacks (PCA9685, RpiPWM, PWMServo, virtuals, drop-in twins) and refactors the I2C interface to Task-based with DriverCommands + virtual twins, aligning with the library-wide driver contract (Logger, Task-returning I/O, drop-in config swap).