### PR TITLE
feat: add ADS1115 AnalogInput driver

### DIFF
--- a/src/evo_lib/drivers/analog_input/__init__.py
+++ b/src/evo_lib/drivers/analog_input/__init__.py
@@ -1,0 +1,17 @@
+"""AnalogInput drivers: real and virtual implementations."""
+
+from evo_lib.drivers.analog_input.ads1115 import ADS1115Channel, ADS1115Chip, ADS1115ChipDefinition
+from evo_lib.drivers.analog_input.virtual import (
+    ADS1115ChipVirtualDefinition,
+    AnalogInputChipVirtual,
+    AnalogInputVirtual,
+)
+
+__all__ = [
+    "ADS1115Channel",
+    "ADS1115Chip",
+    "ADS1115ChipDefinition",
+    "ADS1115ChipVirtualDefinition",
+    "AnalogInputChipVirtual",
+    "AnalogInputVirtual",
+]

--- a/src/evo_lib/drivers/analog_input/__init__.py
+++ b/src/evo_lib/drivers/analog_input/__init__.py
@@ -1,7 +1,14 @@
 """AnalogInput drivers: real and virtual implementations."""
 
-from evo_lib.drivers.analog_input.ads1115 import ADS1115Channel, ADS1115Chip, ADS1115ChipDefinition
+from evo_lib.drivers.analog_input.ads1115 import (
+    ADS1115Channel,
+    ADS1115ChannelDefinition,
+    ADS1115Chip,
+    ADS1115ChipDefinition,
+)
 from evo_lib.drivers.analog_input.virtual import (
+    ADS1115ChannelVirtualDefinition,
+    ADS1115ChipVirtual,
     ADS1115ChipVirtualDefinition,
     AnalogInputChipVirtual,
     AnalogInputVirtual,
@@ -9,8 +16,11 @@ from evo_lib.drivers.analog_input.virtual import (
 
 __all__ = [
     "ADS1115Channel",
+    "ADS1115ChannelDefinition",
+    "ADS1115ChannelVirtualDefinition",
     "ADS1115Chip",
     "ADS1115ChipDefinition",
+    "ADS1115ChipVirtual",
     "ADS1115ChipVirtualDefinition",
     "AnalogInputChipVirtual",
     "AnalogInputVirtual",

--- a/src/evo_lib/drivers/analog_input/ads1115.py
+++ b/src/evo_lib/drivers/analog_input/ads1115.py
@@ -7,17 +7,21 @@ The ADS1115 is a precision ADC with programmable gain. This module exposes it as
 Uses the I2C abstraction for all I2C operations, no Adafruit dependency.
 """
 
-import logging
 import struct
 import threading
 import time
 
 from evo_lib.argtypes import ArgTypes
-from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.driver_definition import (
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
 from evo_lib.interfaces.analog_input import AnalogInput
 from evo_lib.interfaces.i2c import I2C
 from evo_lib.logger import Logger
 from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.registry import Registry
 from evo_lib.task import ImmediateResultTask, Task
 
 NUM_CHANNELS = 4
@@ -57,15 +61,16 @@ _CONVERSION_DELAY = 0.008
 class ADS1115Channel(AnalogInput):
     """A single analog input channel on an ADS1115 chip."""
 
-    def __init__(self, name: str, chip: "ADS1115Chip", channel: int):
+    def __init__(self, name: str, logger: Logger, chip: "ADS1115Chip", channel: int):
         super().__init__(name)
         if not 0 <= channel < NUM_CHANNELS:
             raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        self._log = logger
         self._chip = chip
         self._channel = channel
 
-    def init(self) -> None:
-        pass
+    def init(self) -> Task[()]:
+        return ImmediateResultTask()
 
     def close(self) -> None:
         pass
@@ -86,17 +91,17 @@ class ADS1115Chip(InterfaceHolder):
     def __init__(
         self,
         name: str,
+        logger: Logger,
         bus: I2C,
         address: int = 0x48,
         fsr: float = 2.048,
-        logger: logging.Logger | None = None,
     ):
         super().__init__(name)
+        self._log = logger
         self._bus = bus
         self._address = address
         self._fsr = fsr
         self._pga_bits = _PGA_FSR.get(fsr, _PGA_FSR[2.048])
-        self._log = logger or logging.getLogger(__name__)
         self._lock = threading.Lock()
         self._channels: dict[int, ADS1115Channel] = {}
 
@@ -104,17 +109,16 @@ class ADS1115Chip(InterfaceHolder):
     def fsr(self) -> float:
         return self._fsr
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         self._log.info(
-            "ADS1115 '%s' initialized at 0x%02x, FSR=±%.3fV",
-            self.name,
-            self._address,
-            self._fsr,
+            f"ADS1115 '{self.name}' initialized at 0x{self._address:02x}, "
+            f"FSR=±{self._fsr:.3f}V"
         )
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._channels.clear()
-        self._log.info("ADS1115 '%s' closed", self.name)
+        self._log.info(f"ADS1115 '{self.name}' closed")
 
     def get_subcomponents(self) -> list[Peripheral]:
         return list(self._channels.values())
@@ -125,7 +129,7 @@ class ADS1115Chip(InterfaceHolder):
             raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
         if channel in self._channels:
             return self._channels[channel]
-        ch = ADS1115Channel(name, self, channel)
+        ch = ADS1115Channel(name, self._log, self, channel)
         self._channels[channel] = ch
         return ch
 
@@ -141,32 +145,58 @@ class ADS1115Chip(InterfaceHolder):
         )
         config_bytes = struct.pack(">H", config)
         with self._lock:
-            self._bus.write_to(self._address, bytes([_REG_CONFIG]) + config_bytes)
+            self._bus.write_to(self._address, bytes([_REG_CONFIG]) + config_bytes).wait()
             time.sleep(_CONVERSION_DELAY)
-            data = self._bus.write_then_read(self._address, bytes([_REG_CONVERSION]), 2)
+            (data,) = self._bus.write_then_read(
+                self._address, bytes([_REG_CONVERSION]), 2
+            ).wait()
         return struct.unpack(">h", data)[0]
 
 
 class ADS1115ChipDefinition(DriverDefinition):
-    """Factory for ADS1115Chip from config args."""
+    """Factory for ADS1115Chip from config args. Parent bus resolved by name."""
 
-    def __init__(self, bus: I2C, logger: Logger):
-        self._bus = bus
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
         self._logger = logger
+        self._peripherals = peripherals
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("name", ArgTypes.String())
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
         defn.add_optional("address", ArgTypes.U8(), 0x48)
         defn.add_optional("fsr", ArgTypes.F32(), 2.048)
         return defn
 
     def create(self, args: DriverInitArgs) -> ADS1115Chip:
-        name = args.get("name")
         return ADS1115Chip(
-            name=name,
-            bus=self._bus,
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
             address=args.get("address"),
             fsr=args.get("fsr"),
-            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
         )
+
+
+class ADS1115ChannelDefinition(DriverDefinition):
+    """Factory for an ADS1115Channel on a parent ADS1115Chip.
+
+    The channel is created (or retrieved) via chip.get_channel(), so the
+    chip remains the single source of truth for its 4 channels and will
+    close them alongside its own close().
+    """
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("chip", ArgTypes.Component(ADS1115Chip, self._peripherals))
+        defn.add_required("channel", ArgTypes.U8(min_value=0, max_value=NUM_CHANNELS - 1))
+        return defn
+
+    def create(self, args: DriverInitArgs) -> ADS1115Channel:
+        chip: ADS1115Chip = args.get("chip")
+        return chip.get_channel(args.get("channel"), args.get_name())

--- a/src/evo_lib/drivers/analog_input/ads1115.py
+++ b/src/evo_lib/drivers/analog_input/ads1115.py
@@ -1,0 +1,172 @@
+"""ADS1115 driver: 4-channel 16-bit ADC over I2C (register-level).
+
+The ADS1115 is a precision ADC with programmable gain. This module exposes it as:
+- ADS1115Chip (InterfaceHolder): manages I2C connection and gain config
+- ADS1115Channel (AnalogInput): one instance per input channel (0-3)
+
+Uses the I2C abstraction for all I2C operations, no Adafruit dependency.
+"""
+
+import logging
+import struct
+import threading
+import time
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.analog_input import AnalogInput
+from evo_lib.interfaces.i2c import I2C
+from evo_lib.logger import Logger
+from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.task import ImmediateResultTask, Task
+
+NUM_CHANNELS = 4
+
+# Register addresses
+_REG_CONVERSION = 0x00
+_REG_CONFIG = 0x01
+
+# Config register defaults
+_OS_START = 1 << 15  # Start single-shot conversion
+_MODE_SINGLE = 1 << 8  # Single-shot mode
+_DR_128SPS = 0x04 << 5  # 128 samples per second
+_COMP_DISABLE = 0x03  # Disable comparator (bits 1:0 = 11)
+
+# MUX values for single-ended channels (bits 14:12)
+_MUX_SINGLE = {
+    0: 0x04 << 12,  # AIN0 vs GND
+    1: 0x05 << 12,  # AIN1 vs GND
+    2: 0x06 << 12,  # AIN2 vs GND
+    3: 0x07 << 12,  # AIN3 vs GND
+}
+
+# PGA gain to full-scale range (volts)
+_PGA_FSR = {
+    6.144: 0x00 << 9,
+    4.096: 0x01 << 9,
+    2.048: 0x02 << 9,
+    1.024: 0x03 << 9,
+    0.512: 0x04 << 9,
+    0.256: 0x05 << 9,
+}
+
+# 128 SPS data rate = 7.8ms per conversion, rounded up to 8ms
+_CONVERSION_DELAY = 0.008
+
+
+class ADS1115Channel(AnalogInput):
+    """A single analog input channel on an ADS1115 chip."""
+
+    def __init__(self, name: str, chip: "ADS1115Chip", channel: int):
+        super().__init__(name)
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        self._chip = chip
+        self._channel = channel
+
+    def init(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def read_voltage(self) -> Task[float]:
+        """Trigger a single-shot conversion and return the voltage."""
+        raw = self._chip.read_channel_raw(self._channel)
+        voltage = raw * self._chip.fsr / 32768.0
+        return ImmediateResultTask(voltage)
+
+
+class ADS1115Chip(InterfaceHolder):
+    """Manages the I2C connection to one ADS1115 chip.
+
+    Channels are numbered 0-3 (single-ended vs GND).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        bus: I2C,
+        address: int = 0x48,
+        fsr: float = 2.048,
+        logger: logging.Logger | None = None,
+    ):
+        super().__init__(name)
+        self._bus = bus
+        self._address = address
+        self._fsr = fsr
+        self._pga_bits = _PGA_FSR.get(fsr, _PGA_FSR[2.048])
+        self._log = logger or logging.getLogger(__name__)
+        self._lock = threading.Lock()
+        self._channels: dict[int, ADS1115Channel] = {}
+
+    @property
+    def fsr(self) -> float:
+        return self._fsr
+
+    def init(self) -> None:
+        self._log.info(
+            "ADS1115 '%s' initialized at 0x%02x, FSR=±%.3fV",
+            self.name,
+            self._address,
+            self._fsr,
+        )
+
+    def close(self) -> None:
+        self._channels.clear()
+        self._log.info("ADS1115 '%s' closed", self.name)
+
+    def get_subcomponents(self) -> list[Peripheral]:
+        return list(self._channels.values())
+
+    def get_channel(self, channel: int, name: str) -> ADS1115Channel:
+        """Create or retrieve an ADS1115Channel for the given channel number."""
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        if channel in self._channels:
+            return self._channels[channel]
+        ch = ADS1115Channel(name, self, channel)
+        self._channels[channel] = ch
+        return ch
+
+    def read_channel_raw(self, channel: int) -> int:
+        """Trigger a single-shot conversion and return the raw signed 16-bit value."""
+        config = (
+            _OS_START
+            | _MUX_SINGLE[channel]
+            | self._pga_bits
+            | _MODE_SINGLE
+            | _DR_128SPS
+            | _COMP_DISABLE
+        )
+        config_bytes = struct.pack(">H", config)
+        with self._lock:
+            self._bus.write_to(self._address, bytes([_REG_CONFIG]) + config_bytes)
+            time.sleep(_CONVERSION_DELAY)
+            data = self._bus.write_then_read(self._address, bytes([_REG_CONVERSION]), 2)
+        return struct.unpack(">h", data)[0]
+
+
+class ADS1115ChipDefinition(DriverDefinition):
+    """Factory for ADS1115Chip from config args."""
+
+    def __init__(self, bus: I2C, logger: Logger):
+        self._bus = bus
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("name", ArgTypes.String())
+        defn.add_optional("address", ArgTypes.U8(), 0x48)
+        defn.add_optional("fsr", ArgTypes.F32(), 2.048)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> ADS1115Chip:
+        name = args.get("name")
+        return ADS1115Chip(
+            name=name,
+            bus=self._bus,
+            address=args.get("address"),
+            fsr=args.get("fsr"),
+            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
+        )

--- a/src/evo_lib/drivers/analog_input/virtual.py
+++ b/src/evo_lib/drivers/analog_input/virtual.py
@@ -1,12 +1,16 @@
 """AnalogInput drivers: virtual implementations for testing and simulation."""
 
-import logging
-
 from evo_lib.argtypes import ArgTypes
-from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.driver_definition import (
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
 from evo_lib.interfaces.analog_input import AnalogInput
+from evo_lib.interfaces.i2c import I2C
 from evo_lib.logger import Logger
 from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.registry import Registry
 from evo_lib.task import ImmediateResultTask, Task
 
 NUM_CHANNELS = 4
@@ -15,13 +19,14 @@ NUM_CHANNELS = 4
 class AnalogInputVirtual(AnalogInput):
     """In-memory analog input for tests and simulation."""
 
-    def __init__(self, name: str, logger: logging.Logger | None = None):
+    def __init__(self, name: str, logger: Logger):
         super().__init__(name)
-        self._log = logger or logging.getLogger(__name__)
+        self._log = logger
         self._voltage: float = 0.0
 
-    def init(self) -> None:
-        self._log.info("AnalogInputVirtual '%s' initialized", self.name)
+    def init(self) -> Task[()]:
+        self._log.info(f"AnalogInputVirtual '{self.name}' initialized")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         pass
@@ -35,15 +40,16 @@ class AnalogInputVirtual(AnalogInput):
 
 
 class AnalogInputChipVirtual(InterfaceHolder):
-    """In-memory virtual for the ADS1115 chip, for tests and simulation."""
+    """In-memory virtual ADC chip, for tests and simulation."""
 
-    def __init__(self, name: str, logger: logging.Logger | None = None):
+    def __init__(self, name: str, logger: Logger):
         super().__init__(name)
-        self._log = logger or logging.getLogger(__name__)
+        self._log = logger
         self._channels: dict[int, AnalogInputVirtual] = {}
 
-    def init(self) -> None:
-        self._log.info("AnalogInputChipVirtual '%s' initialized", self.name)
+    def init(self) -> Task[()]:
+        self._log.info(f"AnalogInputChipVirtual '{self.name}' initialized")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._channels.clear()
@@ -57,25 +63,88 @@ class AnalogInputChipVirtual(InterfaceHolder):
             raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
         if channel in self._channels:
             return self._channels[channel]
-        ch = AnalogInputVirtual(name, logger=self._log)
+        ch = AnalogInputVirtual(name, self._log)
         self._channels[channel] = ch
         return ch
 
 
-class ADS1115ChipVirtualDefinition(DriverDefinition):
-    """Factory for AnalogInputChipVirtual from config args."""
+class ADS1115ChipVirtual(AnalogInputChipVirtual):
+    """Virtual twin of ADS1115Chip: same constructor signature, in-memory.
 
-    def __init__(self, logger: Logger):
+    Delegates all ADC logic to AnalogInputChipVirtual. Accepts bus, address and
+    fsr for drop-in config compatibility with ADS1115Chip, but ignores them
+    (the virtual has no real I2C transport). Kept for signature parity —
+    orthogonal to simulation.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        address: int = 0x48,
+        fsr: float = 2.048,
+    ):
+        super().__init__(name, logger)
+        self._bus = bus
+        self._address = address
+        self._fsr = fsr
+
+    @property
+    def fsr(self) -> float:
+        return self._fsr
+
+    def init(self) -> Task[()]:
+        self._log.info(
+            f"ADS1115ChipVirtual '{self.name}' initialized at 0x{self._address:02x}, "
+            f"FSR=±{self._fsr:.3f}V"
+        )
+        return super().init()
+
+
+class ADS1115ChipVirtualDefinition(DriverDefinition):
+    """Factory for ADS1115ChipVirtual. Parent bus resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
         self._logger = logger
+        self._peripherals = peripherals
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("name", ArgTypes.String())
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("address", ArgTypes.U8(), 0x48)
+        defn.add_optional("fsr", ArgTypes.F32(), 2.048)
         return defn
 
-    def create(self, args: DriverInitArgs) -> AnalogInputChipVirtual:
-        name = args.get("name")
-        return AnalogInputChipVirtual(
-            name=name,
-            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
+    def create(self, args: DriverInitArgs) -> ADS1115ChipVirtual:
+        return ADS1115ChipVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            bus=args.get("bus"),
+            address=args.get("address"),
+            fsr=args.get("fsr"),
         )
+
+
+class ADS1115ChannelVirtualDefinition(DriverDefinition):
+    """Factory for a virtual ADS1115 channel on an ADS1115ChipVirtual.
+
+    Mirrors ADS1115ChannelDefinition: resolves the chip by name, delegates
+    channel creation to chip.get_channel() which returns an AnalogInputVirtual.
+    """
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("chip", ArgTypes.Component(ADS1115ChipVirtual, self._peripherals))
+        defn.add_required("channel", ArgTypes.U8(min_value=0, max_value=NUM_CHANNELS - 1))
+        return defn
+
+    def create(self, args: DriverInitArgs) -> AnalogInputVirtual:
+        chip: ADS1115ChipVirtual = args.get("chip")
+        return chip.get_channel(args.get("channel"), args.get_name())

--- a/src/evo_lib/drivers/analog_input/virtual.py
+++ b/src/evo_lib/drivers/analog_input/virtual.py
@@ -1,0 +1,81 @@
+"""AnalogInput drivers: virtual implementations for testing and simulation."""
+
+import logging
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.analog_input import AnalogInput
+from evo_lib.logger import Logger
+from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.task import ImmediateResultTask, Task
+
+NUM_CHANNELS = 4
+
+
+class AnalogInputVirtual(AnalogInput):
+    """In-memory analog input for tests and simulation."""
+
+    def __init__(self, name: str, logger: logging.Logger | None = None):
+        super().__init__(name)
+        self._log = logger or logging.getLogger(__name__)
+        self._voltage: float = 0.0
+
+    def init(self) -> None:
+        self._log.info("AnalogInputVirtual '%s' initialized", self.name)
+
+    def close(self) -> None:
+        pass
+
+    def read_voltage(self) -> Task[float]:
+        return ImmediateResultTask(self._voltage)
+
+    def inject_voltage(self, voltage: float) -> None:
+        """Set the voltage value returned by read_voltage (for testing)."""
+        self._voltage = voltage
+
+
+class AnalogInputChipVirtual(InterfaceHolder):
+    """In-memory virtual for the ADS1115 chip, for tests and simulation."""
+
+    def __init__(self, name: str, logger: logging.Logger | None = None):
+        super().__init__(name)
+        self._log = logger or logging.getLogger(__name__)
+        self._channels: dict[int, AnalogInputVirtual] = {}
+
+    def init(self) -> None:
+        self._log.info("AnalogInputChipVirtual '%s' initialized", self.name)
+
+    def close(self) -> None:
+        self._channels.clear()
+
+    def get_subcomponents(self) -> list[Peripheral]:
+        return list(self._channels.values())
+
+    def get_channel(self, channel: int, name: str) -> AnalogInputVirtual:
+        """Create or retrieve an AnalogInputVirtual for the given channel."""
+        if not 0 <= channel < NUM_CHANNELS:
+            raise ValueError(f"Channel {channel} out of range (0-{NUM_CHANNELS - 1})")
+        if channel in self._channels:
+            return self._channels[channel]
+        ch = AnalogInputVirtual(name, logger=self._log)
+        self._channels[channel] = ch
+        return ch
+
+
+class ADS1115ChipVirtualDefinition(DriverDefinition):
+    """Factory for AnalogInputChipVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("name", ArgTypes.String())
+        return defn
+
+    def create(self, args: DriverInitArgs) -> AnalogInputChipVirtual:
+        name = args.get("name")
+        return AnalogInputChipVirtual(
+            name=name,
+            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
+        )

--- a/src/evo_lib/drivers/gpio/mcp23017.py
+++ b/src/evo_lib/drivers/gpio/mcp23017.py
@@ -1,10 +1,10 @@
 """MCP23017 driver: register-level I2C implementation.
 
 The MCP23017 is a 16-pin I2C GPIO expander. This module exposes it as:
-- MCP23017Chip (ComponentHolder): manages I2C connection to the chip
+- MCP23017Chip (InterfaceHolder): manages I2C connection to the chip
 - MCP23017Pin (GPIO): one instance per physical pin
 
-Uses the I2CBus abstraction for all I2C operations, enabling both real
+Uses the I2C abstraction for all I2C operations, enabling both real
 hardware access and virtual bus testing without any Adafruit dependency.
 """
 

--- a/tests/test_analog_input.py
+++ b/tests/test_analog_input.py
@@ -5,24 +5,31 @@ import struct
 import pytest
 
 from evo_lib.drivers.analog_input.ads1115 import ADS1115Chip
-from evo_lib.drivers.analog_input.virtual import AnalogInputChipVirtual, AnalogInputVirtual
+from evo_lib.drivers.analog_input.virtual import (
+    ADS1115ChipVirtual,
+    AnalogInputChipVirtual,
+    AnalogInputVirtual,
+)
 from evo_lib.drivers.i2c.virtual import I2CVirtual
+from evo_lib.logger import Logger
 
 
 class TestAnalogInputVirtual:
     def test_default_voltage_is_zero(self):
-        ch = AnalogInputVirtual("ch0")
+        ch = AnalogInputVirtual("ch0", Logger("test"))
         ch.init()
-        assert ch.read_voltage().wait() == 0.0
+        (voltage,) = ch.read_voltage().wait()
+        assert voltage == 0.0
 
     def test_inject_voltage(self):
-        ch = AnalogInputVirtual("ch0")
+        ch = AnalogInputVirtual("ch0", Logger("test"))
         ch.init()
         ch.inject_voltage(3.3)
-        assert ch.read_voltage().wait() == 3.3
+        (voltage,) = ch.read_voltage().wait()
+        assert voltage == 3.3
 
     def test_chip_virtual_get_channel(self):
-        chip = AnalogInputChipVirtual("adc")
+        chip = AnalogInputChipVirtual("adc", Logger("test"))
         chip.init()
         ch0 = chip.get_channel(0, "ch0")
         ch1 = chip.get_channel(1, "ch1")
@@ -31,9 +38,21 @@ class TestAnalogInputVirtual:
         assert len(chip.get_subcomponents()) == 2
 
     def test_chip_virtual_bad_channel(self):
-        chip = AnalogInputChipVirtual("adc")
+        chip = AnalogInputChipVirtual("adc", Logger("test"))
         with pytest.raises(ValueError):
             chip.get_channel(4, "bad")
+
+    def test_ads1115_chip_virtual_signature_parity(self):
+        """Drop-in twin must accept the same ctor args as ADS1115Chip."""
+        bus = I2CVirtual()
+        bus.init()
+        chip = ADS1115ChipVirtual("adc", Logger("test"), bus, address=0x49, fsr=4.096)
+        chip.init()
+        assert chip.fsr == 4.096
+        ch = chip.get_channel(0, "ch0")
+        ch.inject_voltage(2.5)
+        (voltage,) = ch.read_voltage().wait()
+        assert voltage == 2.5
 
 
 class TestADS1115Chip:
@@ -44,12 +63,12 @@ class TestADS1115Chip:
         # Inject a raw conversion result: 16384 = 1.024V at ±2.048V FSR
         dev.inject_read(struct.pack(">h", 16384))
 
-        chip = ADS1115Chip("adc", bus, address=0x48, fsr=2.048)
+        chip = ADS1115Chip("adc", Logger("test"), bus, address=0x48, fsr=2.048)
         chip.init()
         ch = chip.get_channel(0, "ch0")
         ch.init()
 
-        voltage = ch.read_voltage().wait()
+        (voltage,) = ch.read_voltage().wait()
 
         # Config register should have been written (3 bytes: reg + 2 config)
         assert len(dev.written) >= 1

--- a/tests/test_analog_input.py
+++ b/tests/test_analog_input.py
@@ -1,0 +1,59 @@
+"""Tests for ADS1115 analog input drivers."""
+
+import struct
+
+import pytest
+
+from evo_lib.drivers.analog_input.ads1115 import ADS1115Chip
+from evo_lib.drivers.analog_input.virtual import AnalogInputChipVirtual, AnalogInputVirtual
+from evo_lib.drivers.i2c.virtual import I2CVirtual
+
+
+class TestAnalogInputVirtual:
+    def test_default_voltage_is_zero(self):
+        ch = AnalogInputVirtual("ch0")
+        ch.init()
+        assert ch.read_voltage().wait() == 0.0
+
+    def test_inject_voltage(self):
+        ch = AnalogInputVirtual("ch0")
+        ch.init()
+        ch.inject_voltage(3.3)
+        assert ch.read_voltage().wait() == 3.3
+
+    def test_chip_virtual_get_channel(self):
+        chip = AnalogInputChipVirtual("adc")
+        chip.init()
+        ch0 = chip.get_channel(0, "ch0")
+        ch1 = chip.get_channel(1, "ch1")
+        assert ch0 is not ch1
+        assert chip.get_channel(0, "ch0") is ch0
+        assert len(chip.get_subcomponents()) == 2
+
+    def test_chip_virtual_bad_channel(self):
+        chip = AnalogInputChipVirtual("adc")
+        with pytest.raises(ValueError):
+            chip.get_channel(4, "bad")
+
+
+class TestADS1115Chip:
+    def test_read_channel_writes_config_and_reads_conversion(self):
+        bus = I2CVirtual()
+        bus.init()
+        dev = bus.add_device(0x48)
+        # Inject a raw conversion result: 16384 = 1.024V at ±2.048V FSR
+        dev.inject_read(struct.pack(">h", 16384))
+
+        chip = ADS1115Chip("adc", bus, address=0x48, fsr=2.048)
+        chip.init()
+        ch = chip.get_channel(0, "ch0")
+        ch.init()
+
+        voltage = ch.read_voltage().wait()
+
+        # Config register should have been written (3 bytes: reg + 2 config)
+        assert len(dev.written) >= 1
+        config_write = dev.written[0]
+        assert config_write[0] == 0x01  # Config register address
+        # Conversion register was read
+        assert abs(voltage - 1.024) < 0.001


### PR DESCRIPTION
## Summary
- ADS1115Chip + ADS1115Channel (register-level I2C, no Adafruit)
- AnalogInputVirtual + AnalogInputChipVirtual for testing
- DriverDefinitions for both
- 5 tests with I2CBusVirtual