### PR TITLE
feat: add WS2812B LedStrip driver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ rpi = [
     "pyserial>=3.5",
     # RPLidar A-series driver.
     "adafruit-circuitpython-rplidar>=1.2.20",
+    "rpi-ws281x>=5.0",
 ]
 
 # -- Development dependencies --

--- a/src/evo_lib/drivers/led_strip/__init__.py
+++ b/src/evo_lib/drivers/led_strip/__init__.py
@@ -1,0 +1,11 @@
+"""LedStrip drivers: real and virtual implementations."""
+
+from evo_lib.drivers.led_strip.virtual import LedStripVirtual, LedStripVirtualDefinition
+from evo_lib.drivers.led_strip.ws2812b import WS2812B, WS2812BDefinition
+
+__all__ = [
+    "LedStripVirtual",
+    "LedStripVirtualDefinition",
+    "WS2812B",
+    "WS2812BDefinition",
+]

--- a/src/evo_lib/drivers/led_strip/virtual.py
+++ b/src/evo_lib/drivers/led_strip/virtual.py
@@ -1,0 +1,82 @@
+"""LedStrip drivers: virtual implementations for testing and simulation."""
+
+import logging
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.led_strip import LedStrip
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.types.color import Color
+
+
+class LedStripVirtual(LedStrip):
+    """In-memory LED strip for tests and simulation."""
+
+    def __init__(
+        self,
+        name: str,
+        num_pixels: int,
+        brightness: float = 0.5,
+        logger: logging.Logger | None = None,
+    ):
+        super().__init__(name)
+        self._num_pixels = num_pixels
+        self._brightness = max(0.0, min(1.0, brightness))
+        self._log = logger or logging.getLogger(__name__)
+        self.pixels: list[Color] = [Color(0.0, 0.0, 0.0) for _ in range(num_pixels)]
+
+    def init(self) -> None:
+        self._log.info("LedStripVirtual '%s' initialized: %d pixels", self.name, self._num_pixels)
+
+    def close(self) -> None:
+        pass
+
+    def set_pixel(self, index: int, color: Color) -> None:
+        self.pixels[index] = color
+
+    def get_pixel(self, index: int) -> Color:
+        return self.pixels[index]
+
+    def fill(self, color: Color) -> None:
+        self.pixels = [color] * self._num_pixels
+
+    def set_brightness(self, brightness: float) -> None:
+        self._brightness = max(0.0, min(1.0, brightness))
+
+    def get_brightness(self) -> float:
+        return self._brightness
+
+    def show(self) -> Task[None]:
+        return ImmediateResultTask(None)
+
+    def clear(self) -> Task[None]:
+        self.fill(Color(0.0, 0.0, 0.0))
+        return ImmediateResultTask(None)
+
+    @property
+    def num_pixels(self) -> int:
+        return self._num_pixels
+
+
+class LedStripVirtualDefinition(DriverDefinition):
+    """Factory for LedStripVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("name", ArgTypes.String())
+        defn.add_required("num_pixels", ArgTypes.U16())
+        defn.add_optional("brightness", ArgTypes.F32(), 0.5)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> LedStripVirtual:
+        name = args.get("name")
+        return LedStripVirtual(
+            name=name,
+            num_pixels=args.get("num_pixels"),
+            brightness=args.get("brightness"),
+            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
+        )

--- a/src/evo_lib/drivers/led_strip/ws2812b.py
+++ b/src/evo_lib/drivers/led_strip/ws2812b.py
@@ -1,0 +1,119 @@
+"""WS2812B driver: addressable LED strip via rpi_ws281x (DMA-based).
+
+The WS2812B (NeoPixel) uses a single-wire protocol with strict timing.
+The rpi_ws281x library handles this via DMA on the Raspberry Pi.
+"""
+
+import logging
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.interfaces.led_strip import LedStrip
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.types.color import Color
+
+# Lazy-loaded in init() so this module can be imported without rpi_ws281x installed
+_ws = None
+
+
+class WS2812B(LedStrip):
+    """Addressable LED strip via rpi_ws281x."""
+
+    def __init__(
+        self,
+        name: str,
+        pin: int,
+        num_pixels: int,
+        brightness: float = 0.5,
+        logger: logging.Logger | None = None,
+    ):
+        super().__init__(name)
+        self._pin = pin
+        self._num_pixels = num_pixels
+        self._brightness = max(0.0, min(1.0, brightness))
+        self._log = logger or logging.getLogger(__name__)
+        self._strip = None
+
+    def init(self) -> None:
+        global _ws
+        if _ws is None:
+            import rpi_ws281x
+
+            _ws = rpi_ws281x
+
+        self._strip = _ws.PixelStrip(
+            self._num_pixels,
+            self._pin,
+            brightness=round(self._brightness * 255),
+        )
+        self._strip.begin()
+        self._log.info(
+            "WS2812B '%s' initialized: %d pixels on GPIO %d",
+            self.name,
+            self._num_pixels,
+            self._pin,
+        )
+
+    def close(self) -> None:
+        if self._strip is not None:
+            for i in range(self._num_pixels):
+                self._strip.setPixelColor(i, 0)
+            self._strip.show()
+            self._log.info("WS2812B '%s' closed", self.name)
+
+    def set_pixel(self, index: int, color: Color) -> None:
+        r, g, b = round(color.r * 255), round(color.g * 255), round(color.b * 255)
+        self._strip.setPixelColor(index, (r << 16) | (g << 8) | b)
+
+    def get_pixel(self, index: int) -> Color:
+        val = self._strip.getPixelColor(index)
+        return Color.from_rgb_int(val)
+
+    def fill(self, color: Color) -> None:
+        for i in range(self._num_pixels):
+            self.set_pixel(i, color)
+
+    def set_brightness(self, brightness: float) -> None:
+        self._brightness = max(0.0, min(1.0, brightness))
+        self._strip.setBrightness(round(self._brightness * 255))
+
+    def get_brightness(self) -> float:
+        return self._brightness
+
+    def show(self) -> Task[None]:
+        self._strip.show()
+        return ImmediateResultTask(None)
+
+    def clear(self) -> Task[None]:
+        self.fill(Color(0.0, 0.0, 0.0))
+        return self.show()
+
+    @property
+    def num_pixels(self) -> int:
+        return self._num_pixels
+
+
+class WS2812BDefinition(DriverDefinition):
+    """Factory for WS2812B from config args."""
+
+    def __init__(self, logger: Logger):
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("name", ArgTypes.String())
+        defn.add_required("pin", ArgTypes.U8())
+        defn.add_required("num_pixels", ArgTypes.U16())
+        defn.add_optional("brightness", ArgTypes.F32(), 0.5)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> WS2812B:
+        name = args.get("name")
+        return WS2812B(
+            name=name,
+            pin=args.get("pin"),
+            num_pixels=args.get("num_pixels"),
+            brightness=args.get("brightness"),
+            logger=self._logger.get_sublogger(name).get_stdlib_logger(),
+        )

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -1,0 +1,52 @@
+"""Tests for WS2812B LED strip drivers."""
+
+from evo_lib.drivers.led_strip.virtual import LedStripVirtual
+from evo_lib.types.color import Color
+
+
+class TestLedStripVirtual:
+    def test_default_pixels_are_black(self):
+        strip = LedStripVirtual("leds", num_pixels=8)
+        strip.init()
+        for p in strip.pixels:
+            assert p.r == 0.0 and p.g == 0.0 and p.b == 0.0
+
+    def test_set_and_get_pixel(self):
+        strip = LedStripVirtual("leds", num_pixels=4)
+        strip.init()
+        red = Color(1.0, 0.0, 0.0)
+        strip.set_pixel(1, red)
+        assert strip.get_pixel(1).r == 1.0
+        assert strip.get_pixel(0).r == 0.0
+
+    def test_fill(self):
+        strip = LedStripVirtual("leds", num_pixels=3)
+        strip.init()
+        blue = Color(0.0, 0.0, 1.0)
+        strip.fill(blue)
+        for p in strip.pixels:
+            assert p.b == 1.0
+
+    def test_clear(self):
+        strip = LedStripVirtual("leds", num_pixels=3)
+        strip.init()
+        strip.fill(Color(1.0, 1.0, 1.0))
+        strip.clear().wait()
+        for p in strip.pixels:
+            assert p.r == 0.0
+
+    def test_brightness(self):
+        strip = LedStripVirtual("leds", num_pixels=1, brightness=0.8)
+        assert strip.get_brightness() == 0.8
+        strip.set_brightness(0.3)
+        assert abs(strip.get_brightness() - 0.3) < 0.001
+
+    def test_num_pixels(self):
+        strip = LedStripVirtual("leds", num_pixels=10)
+        assert strip.num_pixels == 10
+
+    def test_show_returns_task(self):
+        strip = LedStripVirtual("leds", num_pixels=1)
+        strip.init()
+        task = strip.show()
+        assert task.wait() is None


### PR DESCRIPTION
## Summary
- WS2812B via rpi_ws281x (lazy import, DMA-based)
- LedStripVirtual for testing
- DriverDefinitions for both
- rpi-ws281x added to rpi extras
- 7 tests for virtual implementation