### PR TITLE
feat: virtual tirette driver with pull/put simulation commands

### DIFF
--- a/src/evo_lib/argtypes.py
+++ b/src/evo_lib/argtypes.py
@@ -378,9 +378,12 @@ class ArgTypes:
         _default_max: int = None
 
         def __init__(self, help, min, max):
-            super().__init__(help, min, max)
             assert(self._default_min is not None)
             assert(self._default_max is not None)
+            super().__init__(help,
+                min if min is not None else self._default_min,
+                max if max is not None else self._default_max,
+            )
 
         def value_from_config(self, v: ConfigValue) -> int:
             if not isinstance(v, int):

--- a/src/evo_lib/drivers/gpio/mcp23017.py
+++ b/src/evo_lib/drivers/gpio/mcp23017.py
@@ -61,7 +61,7 @@ class MCP23017Pin(GPIO):
         self._log = chip._log
         self._iodir_reg, self._gpio_reg, self._gppu_reg, self._olat_reg, self._bit = _port_regs(pin)
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         if self._direction == GPIODirection.INPUT:
             self._chip.set_bit(self._iodir_reg, self._bit, True)
             self._chip.set_bit(self._gppu_reg, self._bit, self._pull_up)
@@ -74,6 +74,7 @@ class MCP23017Pin(GPIO):
             self.name,
             self._direction.value,
         )
+        return ImmediateResultTask()
 
     def close(self) -> None:
         pass
@@ -117,7 +118,7 @@ class MCP23017Chip(InterfaceHolder):
         self._lock = threading.Lock()
         self._pins: dict[int, MCP23017Pin] = {}
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         """Initialize the MCP23017: set all pins as inputs (default state)."""
         self.write_register(_IODIR_A, 0xFF)
         self.write_register(_IODIR_B, 0xFF)
@@ -126,6 +127,7 @@ class MCP23017Chip(InterfaceHolder):
             self.name,
             self._address,
         )
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._pins.clear()

--- a/src/evo_lib/drivers/gpio/rpi.py
+++ b/src/evo_lib/drivers/gpio/rpi.py
@@ -1,14 +1,20 @@
-"""GPIO driver: real Raspberry Pi implementation via gpiod (libgpiod v2)."""
+"""GPIO driver: real Raspberry Pi implementation via gpiod (libgpiod v2)
+and virtual implementation for testing."""
 
 import os
 import selectors
 import threading
 
 from evo_lib.argtypes import ArgTypes
-from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.driver_definition import (
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
 from evo_lib.event import Event
 from evo_lib.interfaces.gpio import GPIO, GPIODirection, GPIOEdge
 from evo_lib.logger import Logger
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
 from evo_lib.task import ImmediateErrorTask, ImmediateResultTask, Task
 
 # Lazy-loaded in init() so this module can be imported without gpiod installed
@@ -39,10 +45,11 @@ class RpiGPIO(GPIO):
         self._watch_thread: threading.Thread | None = None
         self._events: dict[GPIOEdge, Event[bool]] = {}
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         global _gpiod
         if _gpiod is None:
             import gpiod
+
             _gpiod = gpiod
 
         if self._direction == GPIODirection.INPUT:
@@ -62,6 +69,7 @@ class RpiGPIO(GPIO):
             config={self._pin: settings},
         )
         self._log.info(f"RpiGPIO '{self.name}' initialized on pin {self._pin} ({self._direction})")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         if self._stop_w < 0:
@@ -161,6 +169,71 @@ class RpiGPIODefinition(DriverDefinition):
 
     def create(self, args: DriverInitArgs) -> RpiGPIO:
         return RpiGPIO(
+            name=args.get_name(),
+            logger=self._logger,
+            pin=args.get("pin"),
+            direction=args.get("direction"),
+            chip=args.get("chip"),
+        )
+
+
+class RpiGPIOVirtual(GPIO):
+    """Virtual twin of RpiGPIO: same constructor signature, pure in-memory.
+
+    Delegates to GPIOPinVirtual for all GPIO logic. Accepts the same
+    arguments as RpiGPIO so the factory can swap them transparently.
+    Exposes inject_input() for simulation.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        pin: int,
+        direction: GPIODirection = GPIODirection.INPUT,
+        chip: str = f"virtual/{DEFAULT_CHIP}",
+    ):
+        super().__init__(name)
+        self._pin = pin
+        self._chip_path = chip
+        self._inner = GPIOPinVirtual(name, logger, direction, pin=pin)
+
+    def init(self) -> Task[()]:
+        return self._inner.init()
+
+    def close(self) -> None:
+        self._inner.close()
+
+    def read(self) -> Task[bool]:
+        return self._inner.read()
+
+    def write(self, state: bool) -> Task[None]:
+        return self._inner.write(state)
+
+    def interrupt(self, edge: GPIOEdge = GPIOEdge.BOTH) -> Event[bool]:
+        return self._inner.interrupt(edge)
+
+    def inject_input(self, value: bool) -> None:
+        """Inject a value for simulation. Triggers interrupt events if active."""
+        self._inner.inject_input(value)
+
+
+class RpiGPIOVirtualDefinition(DriverDefinition):
+    """Factory for RpiGPIOVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__()
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("pin", ArgTypes.U8())
+        defn.add_optional("direction", ArgTypes.Enum(GPIODirection), GPIODirection.INPUT)
+        defn.add_optional("chip", ArgTypes.String(), DEFAULT_CHIP)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiGPIOVirtual:
+        return RpiGPIOVirtual(
             name=args.get_name(),
             logger=self._logger,
             pin=args.get("pin"),

--- a/src/evo_lib/drivers/gpio/tirette.py
+++ b/src/evo_lib/drivers/gpio/tirette.py
@@ -1,6 +1,9 @@
-"""Tirette driver: real (GPIO-based) and virtual implementations."""
+"""Tirette driver: wraps a GPIO interface to detect pull/put transitions.
 
-from typing import TYPE_CHECKING
+Both Tirette and TiretteVirtual take a GPIO peripheral by reference;
+they do not instantiate their own GPIO. This lets a tirette sit on any
+GPIO source (RPi, MCP23017, virtual, ...) chosen in config.
+"""
 
 from evo_lib.argtypes import ArgTypes
 from evo_lib.driver_definition import (
@@ -9,37 +12,55 @@ from evo_lib.driver_definition import (
     DriverInitArgs,
     DriverInitArgsDefinition,
 )
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
 from evo_lib.event import Event
-from evo_lib.interfaces.gpio import GPIO, GPIODirection, GPIOEdge
+from evo_lib.interfaces.gpio import GPIO, GPIOEdge
 from evo_lib.logger import Logger
-from evo_lib.peripheral import Placable
+from evo_lib.peripheral import Peripheral, Placable
+from evo_lib.registry import Registry
 from evo_lib.task import ImmediateResultTask, Task
-
-if TYPE_CHECKING:
-    from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
 
 
 class Tirette(Placable):
-    """Real tirette: listens to a GPIO interrupt to detect pull/put."""
+    """Listens to a GPIO interrupt to detect pull/put events.
+
+    The GPIO is injected and managed externally (by the PeripheralsManager).
+    ``debounce_s`` filters mechanical bouncing on insertion/removal: only
+    a state stable for ``debounce_s`` is propagated to listeners.
+    """
 
     commands = DriverCommands()
 
-    def __init__(self, name: str, logger: Logger, gpio: GPIO, active_state: bool):
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio: GPIO,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
         super().__init__(name)
         self._logger = logger
         self._gpio = gpio
         self._active_state = active_state
+        self._debounce_s = debounce_s
 
     def init(self) -> Task[()]:
-        self._gpio.init()
+        # GPIO dependency is initialized by the PeripheralsManager.
         return ImmediateResultTask()
 
     def close(self) -> None:
-        self._gpio.close()
+        # GPIO dependency is closed by the PeripheralsManager.
+        pass
 
     def get_trigger_event(self) -> Event[bool]:
         """Return an event with an argument at True if the tirette is pulled."""
-        return self._gpio.interrupt(GPIOEdge.BOTH).transform(lambda x: (x != self._active_state,))
+        event = self._gpio.interrupt(GPIOEdge.BOTH).transform(
+            lambda x: (x != self._active_state,)
+        )
+        if self._debounce_s > 0:
+            event = event.debounce(self._debounce_s)
+        return event
 
     @commands.register(
         args=[],
@@ -52,39 +73,52 @@ class Tirette(Placable):
 
 
 class TiretteDefinition(DriverDefinition):
-    """Factory for real Tirette. Creates an RpiGPIO internally from the pin number."""
+    """Factory for Tirette. Takes a GPIO peripheral by reference."""
 
-    def __init__(self, logger: Logger):
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
         super().__init__(Tirette.commands)
         self._logger = logger
+        self._peripherals = peripherals
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("pin", ArgTypes.U8())
+        defn.add_required("gpio", ArgTypes.Component(GPIO, self._peripherals))
         defn.add_required(
             "active_state", ArgTypes.Bool(help="True means the tirette is in place when GPIO is high")
+        )
+        defn.add_optional(
+            "debounce_s", ArgTypes.F32(help="Stability window (s) for mechanical bouncing"), 0.0
         )
         return defn
 
     def create(self, args: DriverInitArgs) -> Tirette:
-        from evo_lib.drivers.gpio.rpi import RpiGPIO
-
-        gpio = RpiGPIO(
-            name=f"{args.get_name()}_gpio",
-            logger=self._logger,
-            pin=args.get("pin"),
-            direction=GPIODirection.INPUT,
+        return Tirette(
+            args.get_name(),
+            self._logger,
+            args.get("gpio"),
+            args.get("active_state"),
+            args.get("debounce_s"),
         )
-        return Tirette(args.get_name(), self._logger, gpio, args.get("active_state"))
 
 
 class TiretteVirtual(Tirette):
-    """Virtual tirette for simulation. Adds pull/put commands to inject GPIO state."""
+    """Virtual tirette: same as Tirette but adds pull/put simulation commands.
+
+    Requires a GPIOPinVirtual (which exposes inject_input) rather than any
+    GPIO interface.
+    """
 
     commands = DriverCommands(parents=[Tirette.commands])
 
-    def __init__(self, name: str, logger: Logger, gpio: "RpiGPIOVirtual", active_state: bool):
-        super().__init__(name, logger, gpio, active_state)
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio: GPIOPinVirtual,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
+        super().__init__(name, logger, gpio, active_state, debounce_s)
         self._virtual_gpio = gpio
 
     @commands.register(args=[], result=[])
@@ -103,27 +137,29 @@ class TiretteVirtual(Tirette):
 
 
 class TiretteVirtualDefinition(DriverDefinition):
-    """Factory for TiretteVirtual. Creates an RpiGPIOVirtual internally."""
+    """Factory for TiretteVirtual. Takes a GPIOPinVirtual peripheral by reference."""
 
-    def __init__(self, logger: Logger):
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
         super().__init__(TiretteVirtual.commands)
         self._logger = logger
+        self._peripherals = peripherals
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("pin", ArgTypes.U8())
+        defn.add_required("gpio", ArgTypes.Component(GPIOPinVirtual, self._peripherals))
         defn.add_required(
             "active_state", ArgTypes.Bool(help="True means the tirette is in place when GPIO is high")
+        )
+        defn.add_optional(
+            "debounce_s", ArgTypes.F32(help="Stability window (s) for mechanical bouncing"), 0.0
         )
         return defn
 
     def create(self, args: DriverInitArgs) -> TiretteVirtual:
-        from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
-
-        gpio = RpiGPIOVirtual(
-            name=f"{args.get_name()}_gpio",
-            logger=self._logger,
-            pin=args.get("pin"),
-            direction=GPIODirection.INPUT,
+        return TiretteVirtual(
+            args.get_name(),
+            self._logger,
+            args.get("gpio"),
+            args.get("active_state"),
+            args.get("debounce_s"),
         )
-        return TiretteVirtual(args.get_name(), self._logger, gpio, args.get("active_state"))

--- a/src/evo_lib/drivers/gpio/tirette.py
+++ b/src/evo_lib/drivers/gpio/tirette.py
@@ -1,4 +1,6 @@
-"""Tirette driver: Take a GPIO instance as initialisation argument."""
+"""Tirette driver: real (GPIO-based) and virtual implementations."""
+
+from typing import TYPE_CHECKING
 
 from evo_lib.argtypes import ArgTypes
 from evo_lib.driver_definition import (
@@ -8,14 +10,20 @@ from evo_lib.driver_definition import (
     DriverInitArgsDefinition,
 )
 from evo_lib.event import Event
-from evo_lib.interfaces.gpio import GPIO, GPIOEdge
+from evo_lib.interfaces.gpio import GPIO, GPIODirection, GPIOEdge
 from evo_lib.logger import Logger
-from evo_lib.peripheral import Peripheral, Placable
-from evo_lib.registry import Registry
+from evo_lib.peripheral import Placable
 from evo_lib.task import ImmediateResultTask, Task
+
+if TYPE_CHECKING:
+    from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
 
 
 class Tirette(Placable):
+    """Real tirette: listens to a GPIO interrupt to detect pull/put."""
+
+    commands = DriverCommands()
+
     def __init__(self, name: str, logger: Logger, gpio: GPIO, active_state: bool):
         super().__init__(name)
         self._logger = logger
@@ -23,30 +31,99 @@ class Tirette(Placable):
         self._active_state = active_state
 
     def init(self) -> Task[()]:
-        # TODO: Check GPIO direction
+        self._gpio.init()
         return ImmediateResultTask()
 
     def close(self) -> None:
-        pass  # Nothing to do
+        self._gpio.close()
 
     def get_trigger_event(self) -> Event[bool]:
-        """Return an event with an argument at True if the tirette is pulled"""
+        """Return an event with an argument at True if the tirette is pulled."""
         return self._gpio.interrupt(GPIOEdge.BOTH).transform(lambda x: (x != self._active_state,))
+
+    @commands.register(
+        args=[],
+        result=[("active_state", ArgTypes.Bool(help="True if the tirette is in place (GPIO at active state)"))],
+    )
+    def get_state(self) -> Task[bool]:
+        """Return True if the tirette is in its active state (in place)."""
+        gpio_state = self._gpio.read().wait()[0]
+        return ImmediateResultTask(gpio_state == self._active_state)
 
 
 class TiretteDefinition(DriverDefinition):
-    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
-        super().__init__(DriverCommands())
+    """Factory for real Tirette. Creates an RpiGPIO internally from the pin number."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(Tirette.commands)
         self._logger = logger
-        self._peripherals = peripherals
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:
         defn = DriverInitArgsDefinition()
-        defn.add_required("gpio", ArgTypes.Component(GPIO, self._peripherals))
+        defn.add_required("pin", ArgTypes.U8())
         defn.add_required(
-            "active_state", ArgTypes.Bool(help="True mean that the tirette is on when GPIO is high")
+            "active_state", ArgTypes.Bool(help="True means the tirette is in place when GPIO is high")
         )
         return defn
 
     def create(self, args: DriverInitArgs) -> Tirette:
-        return Tirette(args.get_name(), self._logger, args.get("gpio"), args.get("active_state"))
+        from evo_lib.drivers.gpio.rpi import RpiGPIO
+
+        gpio = RpiGPIO(
+            name=f"{args.get_name()}_gpio",
+            logger=self._logger,
+            pin=args.get("pin"),
+            direction=GPIODirection.INPUT,
+        )
+        return Tirette(args.get_name(), self._logger, gpio, args.get("active_state"))
+
+
+class TiretteVirtual(Tirette):
+    """Virtual tirette for simulation. Adds pull/put commands to inject GPIO state."""
+
+    commands = DriverCommands(parents=[Tirette.commands])
+
+    def __init__(self, name: str, logger: Logger, gpio: "RpiGPIOVirtual", active_state: bool):
+        super().__init__(name, logger, gpio, active_state)
+        self._virtual_gpio = gpio
+
+    @commands.register(args=[], result=[])
+    def pull(self) -> Task[()]:
+        """Simulate pulling the tirette out."""
+        self._virtual_gpio.inject_input(not self._active_state)
+        self._logger.info(f"Tirette '{self.name}' pulled (simulated)")
+        return ImmediateResultTask()
+
+    @commands.register(args=[], result=[])
+    def put(self) -> Task[()]:
+        """Simulate putting the tirette back in."""
+        self._virtual_gpio.inject_input(self._active_state)
+        self._logger.info(f"Tirette '{self.name}' put back (simulated)")
+        return ImmediateResultTask()
+
+
+class TiretteVirtualDefinition(DriverDefinition):
+    """Factory for TiretteVirtual. Creates an RpiGPIOVirtual internally."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(TiretteVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("pin", ArgTypes.U8())
+        defn.add_required(
+            "active_state", ArgTypes.Bool(help="True means the tirette is in place when GPIO is high")
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> TiretteVirtual:
+        from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
+
+        gpio = RpiGPIOVirtual(
+            name=f"{args.get_name()}_gpio",
+            logger=self._logger,
+            pin=args.get("pin"),
+            direction=GPIODirection.INPUT,
+        )
+        return TiretteVirtual(args.get_name(), self._logger, gpio, args.get("active_state"))

--- a/src/evo_lib/drivers/gpio/virtual.py
+++ b/src/evo_lib/drivers/gpio/virtual.py
@@ -126,8 +126,9 @@ class GPIOChipVirtual(InterfaceHolder):
         self._address = address
         self._pins: dict[int, GPIOPinVirtual] = {}
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         self._log.info(f"MCP23017 virtual '{self.name}' initialized at 0x{self._address:02x}")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._pins.clear()

--- a/src/evo_lib/event.py
+++ b/src/evo_lib/event.py
@@ -78,3 +78,44 @@ class Event[*T](Listeners[*T]):
         event = Event[*U]()
         self.register(lambda *args: event.trigger(*callback(*args)))
         return event
+
+    def debounce(self, delay_s: float) -> Event[*T]:
+        """Return a debounced event: only the last value stable for ``delay_s`` fires.
+
+        Each incoming trigger cancels any pending emission and schedules a new
+        one. The downstream event only fires once the upstream has been quiet
+        for ``delay_s``. Useful to filter mechanical bouncing on switches.
+        """
+        debounced = Event[*T]()
+        lock = threading.Lock()
+        timer: threading.Timer | None = None
+        last_args: tuple | None = None
+        # Bumped on every upstream trigger. A pending fire commits only if its
+        # captured generation still matches at fire time; otherwise a newer
+        # event has arrived and will schedule its own fire.
+        generation = 0
+
+        def handler(*args):
+            nonlocal timer, last_args, generation
+            with lock:
+                last_args = args
+                generation += 1
+                my_gen = generation
+                if timer is not None:
+                    timer.cancel()
+
+                def fire():
+                    nonlocal timer
+                    with lock:
+                        if generation != my_gen:
+                            return
+                        args_to_fire = last_args
+                        timer = None
+                    debounced.trigger(*args_to_fire)
+
+                timer = threading.Timer(delay_s, fire)
+                timer.daemon = True
+                timer.start()
+
+        self.register(handler)
+        return debounced

--- a/src/evo_lib/platform.py
+++ b/src/evo_lib/platform.py
@@ -35,7 +35,7 @@ class Platform:
             self.os = PlatformOS.UNKNOWN
 
         release = platform.release()
-        if release.count("Raspbian") > 0: # TODO: Check if correct
+        if "rpt-rpi" in release:
             self.hardware = PlatformHardware.RASPBERRY_PI
         else:
             self.hardware = PlatformHardware.COMPUTER

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,7 @@
 """Tests for multi-shot Event."""
 
 import threading
+import time
 
 from evo_lib.event import Event
 
@@ -73,3 +74,44 @@ class TestEvent:
     def test_trigger_no_callbacks(self):
         ev = Event()
         ev.trigger(1)  # should not raise
+
+
+class TestEventDebounce:
+    def test_debounce_emits_only_after_stable(self):
+        received = []
+        ev = Event()
+        debounced = ev.debounce(0.05)
+        debounced.register(lambda v: received.append(v))
+
+        # Burst of rapid events: only the last one should fire, once
+        ev.trigger(1)
+        ev.trigger(2)
+        ev.trigger(3)
+        time.sleep(0.15)
+        assert received == [3]
+
+    def test_debounce_respects_delay(self):
+        received = []
+        ev = Event()
+        debounced = ev.debounce(0.05)
+        debounced.register(lambda v: received.append(v))
+
+        ev.trigger(1)
+        # Before the delay expires, nothing should have fired yet
+        time.sleep(0.02)
+        assert received == []
+        # After the delay, it fires
+        time.sleep(0.08)
+        assert received == [1]
+
+    def test_debounce_two_stable_values(self):
+        received = []
+        ev = Event()
+        debounced = ev.debounce(0.05)
+        debounced.register(lambda v: received.append(v))
+
+        ev.trigger("a")
+        time.sleep(0.1)
+        ev.trigger("b")
+        time.sleep(0.1)
+        assert received == ["a", "b"]

--- a/tests/test_tirette.py
+++ b/tests/test_tirette.py
@@ -1,0 +1,55 @@
+"""Tests for virtual tirette driver."""
+
+import pytest
+
+from evo_lib.drivers.gpio.tirette import TiretteVirtual
+from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
+from evo_lib.interfaces.gpio import GPIODirection
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def tirette():
+    logger = Logger("test")
+    gpio = RpiGPIOVirtual(name="tirette_gpio", logger=logger, pin=17, direction=GPIODirection.INPUT)
+    t = TiretteVirtual(name="tirette", logger=logger, gpio=gpio, active_state=True)
+    t.init().wait()
+    # Tirette starts in place (like on the real robot)
+    t.put().wait()
+    yield t
+    t.close()
+
+
+class TestTiretteVirtual:
+    def test_pull_triggers_pulled_event(self, tirette):
+        received = []
+        tirette.get_trigger_event().register(lambda pulled: received.append(pulled))
+
+        tirette.pull().wait()
+        assert received == [True]
+
+    def test_put_after_pull_triggers_not_pulled(self, tirette):
+        received = []
+        tirette.get_trigger_event().register(lambda pulled: received.append(pulled))
+
+        tirette.pull().wait()
+        tirette.put().wait()
+        assert received == [True, False]
+
+    def test_no_event_on_same_state(self, tirette):
+        """Putting when already in place should not trigger."""
+        received = []
+        tirette.get_trigger_event().register(lambda pulled: received.append(pulled))
+
+        tirette.put().wait()
+        assert received == []
+
+    def test_full_cycle(self, tirette):
+        received = []
+        tirette.get_trigger_event().register(lambda pulled: received.append(pulled))
+
+        tirette.pull().wait()
+        tirette.put().wait()
+        tirette.pull().wait()
+        tirette.put().wait()
+        assert received == [True, False, True, False]

--- a/tests/test_tirette.py
+++ b/tests/test_tirette.py
@@ -3,7 +3,7 @@
 import pytest
 
 from evo_lib.drivers.gpio.tirette import TiretteVirtual
-from evo_lib.drivers.gpio.rpi import RpiGPIOVirtual
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
 from evo_lib.interfaces.gpio import GPIODirection
 from evo_lib.logger import Logger
 
@@ -11,13 +11,15 @@ from evo_lib.logger import Logger
 @pytest.fixture
 def tirette():
     logger = Logger("test")
-    gpio = RpiGPIOVirtual(name="tirette_gpio", logger=logger, pin=17, direction=GPIODirection.INPUT)
+    gpio = GPIOPinVirtual(name="tirette_gpio", logger=logger, direction=GPIODirection.INPUT, pin=17)
+    gpio.init().wait()
     t = TiretteVirtual(name="tirette", logger=logger, gpio=gpio, active_state=True)
     t.init().wait()
     # Tirette starts in place (like on the real robot)
     t.put().wait()
     yield t
     t.close()
+    gpio.close()
 
 
 class TestTiretteVirtual:


### PR DESCRIPTION
## Summary

- Add `TiretteVirtual` driver: in-memory twin of `Tirette`, exposes `pull`/`put` REPL commands to inject GPIO state for simulation
- Add `RpiGPIOVirtual`: pure in-memory GPIO wrapper delegating to `GPIOPinVirtual`, same constructor signature as `RpiGPIO` so factories can swap transparently
- Add `get_state` command on `Tirette` (inherited by `TiretteVirtual`)
- Fix `init()` return type to `Task[()]` across all GPIO drivers (was `None`, violating `Peripheral` contract)
- Fix `Int` argtypes default min/max not applied when `None` passed
- Rename for consistency: `<Base>Virtual` pattern everywhere