### PR TITLE
feat: add driver definitions to serial drivers and reset_input_buffer()

### DIFF
--- a/src/evo_lib/drivers/serial/__init__.py
+++ b/src/evo_lib/drivers/serial/__init__.py
@@ -1,9 +1,18 @@
 """Serial drivers: real and virtual implementations."""
 
-from evo_lib.drivers.serial.rpi import RpiSerial
-from evo_lib.drivers.serial.virtual import SerialVirtual
+from evo_lib.drivers.serial.rpi import (
+    RpiSerial,
+    RpiSerialDefinition,
+    RpiSerialVirtual,
+    RpiSerialVirtualDefinition,
+)
+from evo_lib.drivers.serial.virtual import SerialVirtual, SerialVirtualDefinition
 
 __all__ = [
     "RpiSerial",
+    "RpiSerialDefinition",
+    "RpiSerialVirtual",
+    "RpiSerialVirtualDefinition",
     "SerialVirtual",
+    "SerialVirtualDefinition",
 ]

--- a/src/evo_lib/drivers/serial/rpi.py
+++ b/src/evo_lib/drivers/serial/rpi.py
@@ -1,12 +1,17 @@
 """Serial driver: real implementation via pyserial."""
 
-import logging
 import threading
 
-from evo_lib.interfaces.serial import Serial
-
-# Lazy-loaded in init() so this module can be imported without pyserial installed
-_serial = None
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.drivers.serial.virtual import SerialVirtual
+from evo_lib.interfaces.serial import DEFAULT_BAUDRATE, DEFAULT_TIMEOUT, Serial
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
 
 
 class RpiSerial(Serial):
@@ -19,41 +24,38 @@ class RpiSerial(Serial):
     def __init__(
         self,
         name: str,
+        logger: Logger,
         port: str,
-        baudrate: int = 38400,
-        timeout: float = 1.0,
-        logger: logging.Logger | None = None,
+        baudrate: int = DEFAULT_BAUDRATE,
+        timeout: float = DEFAULT_TIMEOUT,
     ):
         super().__init__(name)
         self._port_path = port
         self._baudrate = baudrate
         self._timeout = timeout
-        self._log = logger or logging.getLogger(__name__)
+        self._log = logger
         self._serial = None
         self._lock = threading.Lock()
 
-    def init(self) -> None:
-        global _serial
-        if _serial is None:
-            import serial
+    def init(self) -> Task[()]:
+        # pyserial imported lazily so this module stays importable without it.
+        # sys.modules caches the module, so repeated init() calls are free.
+        import serial
 
-            _serial = serial
-
-        self._serial = _serial.Serial(
+        self._serial = serial.Serial(
             port=self._port_path,
             baudrate=self._baudrate,
             timeout=self._timeout,
         )
         self._log.info(
-            "Serial '%s' opened at %d baud",
-            self._port_path,
-            self._baudrate,
+            f"RpiSerial '{self.name}' opened on {self._port_path} @ {self._baudrate} baud"
         )
+        return ImmediateResultTask()
 
     def close(self) -> None:
         if self._serial is not None:
             self._serial.close()
-            self._log.info("Serial '%s' closed", self._port_path)
+            self._log.info(f"RpiSerial '{self.name}' closed")
             self._serial = None
 
     def _check_ready(self) -> None:
@@ -86,8 +88,134 @@ class RpiSerial(Serial):
         with self._lock:
             self._serial.flush()
 
+    def reset_input_buffer(self) -> None:
+        self._check_ready()
+        with self._lock:
+            self._serial.reset_input_buffer()
+
+    def set_baudrate(self, baudrate: int) -> None:
+        self._check_ready()
+        with self._lock:
+            # pyserial reconfigures termios in-place on assignment.
+            self._serial.baudrate = baudrate
+            self._baudrate = baudrate
+        self._log.info(f"RpiSerial '{self.name}' baudrate set to {baudrate}")
+
     @property
     def in_waiting(self) -> int:
         self._check_ready()
         with self._lock:
             return self._serial.in_waiting
+
+
+class RpiSerialDefinition(DriverDefinition):
+    """Factory for RpiSerial from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__()
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("port", ArgTypes.String())
+        defn.add_optional("baudrate", ArgTypes.U32(), DEFAULT_BAUDRATE)
+        defn.add_optional("timeout", ArgTypes.F32(), DEFAULT_TIMEOUT)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiSerial:
+        return RpiSerial(
+            name=args.get_name(),
+            logger=self._logger,
+            port=args.get("port"),
+            baudrate=args.get("baudrate"),
+            timeout=args.get("timeout"),
+        )
+
+
+class RpiSerialVirtual(Serial):
+    """Virtual twin of RpiSerial: same constructor signature, pure in-memory.
+
+    Delegates to SerialVirtual for all serial logic. Accepts the same
+    arguments as RpiSerial so the factory can swap them transparently
+    in config. Exposes inject_read() / written for simulation setups.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        port: str,
+        baudrate: int = DEFAULT_BAUDRATE,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
+        super().__init__(name)
+        self._log = logger
+        self._port_path = port
+        self._baudrate = baudrate
+        self._inner = SerialVirtual(name, logger, timeout=timeout)
+
+    def init(self) -> Task[()]:
+        self._log.info(
+            f"RpiSerialVirtual '{self.name}' initialized "
+            f"(port={self._port_path}, baudrate={self._baudrate})"
+        )
+        return self._inner.init()
+
+    def close(self) -> None:
+        self._inner.close()
+
+    def write(self, data: bytes) -> None:
+        self._inner.write(data)
+
+    def read(self, count: int) -> bytes:
+        return self._inner.read(count)
+
+    def read_available(self) -> bytes:
+        return self._inner.read_available()
+
+    def flush(self) -> None:
+        self._inner.flush()
+
+    def reset_input_buffer(self) -> None:
+        self._inner.reset_input_buffer()
+
+    def set_baudrate(self, baudrate: int) -> None:
+        self._baudrate = baudrate
+        self._inner.set_baudrate(baudrate)
+
+    @property
+    def in_waiting(self) -> int:
+        return self._inner.in_waiting
+
+    # --- Simulation helpers ---
+
+    @property
+    def written(self) -> list[bytes]:
+        return self._inner.written
+
+    def inject_read(self, data: bytes) -> None:
+        self._inner.inject_read(data)
+
+
+class RpiSerialVirtualDefinition(DriverDefinition):
+    """Factory for RpiSerialVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__()
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("port", ArgTypes.String())
+        defn.add_optional("baudrate", ArgTypes.U32(), DEFAULT_BAUDRATE)
+        defn.add_optional("timeout", ArgTypes.F32(), DEFAULT_TIMEOUT)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> RpiSerialVirtual:
+        return RpiSerialVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            port=args.get("port"),
+            baudrate=args.get("baudrate"),
+            timeout=args.get("timeout"),
+        )

--- a/src/evo_lib/drivers/serial/virtual.py
+++ b/src/evo_lib/drivers/serial/virtual.py
@@ -2,7 +2,15 @@
 
 import threading
 
-from evo_lib.interfaces.serial import Serial
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.interfaces.serial import DEFAULT_BAUDRATE, DEFAULT_TIMEOUT, Serial
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
 
 
 class SerialVirtual(Serial):
@@ -12,21 +20,31 @@ class SerialVirtual(Serial):
     for assertions. Thread-safe so it can be used with async reader threads.
     """
 
-    def __init__(self, name: str = "virtual", timeout: float = 1.0):
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
         super().__init__(name)
+        self._log = logger
         self._timeout = timeout
+        self._baudrate = DEFAULT_BAUDRATE
         self._lock = threading.Lock()
         self._read_buffer = bytearray()
         self._read_event = threading.Event()
         self.written: list[bytes] = []
         self._opened = False
 
-    def init(self) -> None:
+    def init(self) -> Task[()]:
         self._opened = True
+        self._log.info(f"SerialVirtual '{self.name}' opened")
+        return ImmediateResultTask()
 
     def close(self) -> None:
         self._opened = False
         self._read_event.set()  # Unblock any waiting reads
+        self._log.info(f"SerialVirtual '{self.name}' closed")
 
     def _check_ready(self) -> None:
         if not self._opened:
@@ -64,6 +82,20 @@ class SerialVirtual(Serial):
     def flush(self) -> None:
         self._check_ready()
 
+    def reset_input_buffer(self) -> None:
+        self._check_ready()
+        with self._lock:
+            self._read_buffer.clear()
+            # Drop any pending wake-up: a concurrent reader must re-wait
+            # instead of consuming an empty buffer and timing out.
+            self._read_event.clear()
+
+    def set_baudrate(self, baudrate: int) -> None:
+        self._check_ready()
+        # No hardware to reconfigure; record the value for assertions.
+        self._baudrate = baudrate
+        self._log.info(f"SerialVirtual '{self.name}' baudrate set to {baudrate}")
+
     @property
     def in_waiting(self) -> int:
         self._check_ready()
@@ -77,3 +109,23 @@ class SerialVirtual(Serial):
         with self._lock:
             self._read_buffer.extend(data)
         self._read_event.set()
+
+
+class SerialVirtualDefinition(DriverDefinition):
+    """Factory for SerialVirtual from config args."""
+
+    def __init__(self, logger: Logger):
+        super().__init__()
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_optional("timeout", ArgTypes.F32(), DEFAULT_TIMEOUT)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> SerialVirtual:
+        return SerialVirtual(
+            name=args.get_name(),
+            logger=self._logger,
+            timeout=args.get("timeout"),
+        )

--- a/src/evo_lib/interfaces/serial.py
+++ b/src/evo_lib/interfaces/serial.py
@@ -4,6 +4,9 @@ from abc import abstractmethod
 
 from evo_lib.peripheral import Interface
 
+DEFAULT_BAUDRATE = 38400
+DEFAULT_TIMEOUT = 1.0
+
 
 class Serial(Interface):
     """A serial bus (UART) abstraction.
@@ -36,6 +39,29 @@ class Serial(Interface):
     @abstractmethod
     def flush(self) -> None:
         """Flush the output buffer (wait until all bytes are sent)."""
+
+    @abstractmethod
+    def reset_input_buffer(self) -> None:
+        """Discard all bytes currently waiting in the input buffer.
+
+        Used to recover from a desynchronized state after a timeout, or
+        to drop the local echo on half-duplex buses (AX-12 Dynamixel)
+        before reading a device response.
+        """
+
+    def set_baudrate(self, baudrate: int) -> None:
+        """Reconfigure the bus baudrate on the fly (no reopen).
+
+        Optional capability. UART-based buses (pyserial, virtual twins)
+        override this. Buses with a fixed-speed transport (BT SPP, TCP
+        bridges) inherit the default and raise NotImplementedError.
+
+        AX-12 Dynamixel servos rely on this to switch between their
+        EEPROM-configured baudrates (1 Mbps, 500 kbps, ...) at runtime.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support runtime baudrate change"
+        )
 
     @property
     @abstractmethod

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -4,46 +4,54 @@ import threading
 
 import pytest
 
+from evo_lib.drivers.serial.rpi import RpiSerialVirtual
 from evo_lib.drivers.serial.virtual import SerialVirtual
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def bus():
+    drv = SerialVirtual(name="test", logger=Logger("test"))
+    drv.init()
+    yield drv
+    drv.close()
+
+
+@pytest.fixture
+def short_timeout_bus():
+    drv = SerialVirtual(name="test", logger=Logger("test"), timeout=0.05)
+    drv.init()
+    yield drv
+    drv.close()
 
 
 class TestSerialVirtual:
-    def test_write_records_data(self):
-        bus = SerialVirtual()
-        bus.init()
+    def test_write_records_data(self, bus):
         bus.write(b"\x01\x02")
         bus.write(b"\x03")
         assert bus.written == [b"\x01\x02", b"\x03"]
 
-    def test_read_consumes_injected_data(self):
-        bus = SerialVirtual()
-        bus.init()
+    def test_read_consumes_injected_data(self, bus):
         bus.inject_read(b"\xaa\xbb\xcc")
         result = bus.read(2)
         assert result == b"\xaa\xbb"
         assert bus.in_waiting == 1
 
-    def test_read_available_returns_all(self):
-        bus = SerialVirtual()
-        bus.init()
+    def test_read_available_returns_all(self, bus):
         bus.inject_read(b"\x01\x02\x03")
         result = bus.read_available()
         assert result == b"\x01\x02\x03"
         assert bus.in_waiting == 0
 
-    def test_read_available_empty(self):
-        bus = SerialVirtual()
-        bus.init()
+    def test_read_available_empty(self, bus):
         assert bus.read_available() == b""
 
-    def test_read_timeout_raises(self):
-        bus = SerialVirtual(timeout=0.05)
-        bus.init()
+    def test_read_timeout_raises(self, short_timeout_bus):
         with pytest.raises(TimeoutError):
-            bus.read(1)
+            short_timeout_bus.read(1)
 
     def test_read_blocks_until_data_injected(self):
-        bus = SerialVirtual(timeout=2.0)
+        bus = SerialVirtual(name="test", logger=Logger("test"), timeout=2.0)
         bus.init()
 
         result = []
@@ -60,13 +68,72 @@ class TestSerialVirtual:
         assert result == [b"\x01\x02\x03"]
 
     def test_not_opened_raises(self):
-        bus = SerialVirtual()
+        drv = SerialVirtual(name="test", logger=Logger("test"))
         with pytest.raises(RuntimeError):
-            bus.write(b"\x00")
+            drv.write(b"\x00")
 
-    def test_in_waiting(self):
-        bus = SerialVirtual()
-        bus.init()
+    def test_in_waiting(self, bus):
         assert bus.in_waiting == 0
         bus.inject_read(b"\x01\x02")
         assert bus.in_waiting == 2
+
+    def test_reset_input_buffer_discards_pending(self, bus):
+        bus.inject_read(b"\xde\xad\xbe\xef")
+        assert bus.in_waiting == 4
+        bus.reset_input_buffer()
+        assert bus.in_waiting == 0
+        assert bus.read_available() == b""
+
+    def test_reset_input_buffer_forces_reader_to_rewait(self):
+        # A concurrent reader must not be woken up by a stale event
+        # set before reset_input_buffer() was called.
+        bus = SerialVirtual(name="test", logger=Logger("test"), timeout=0.2)
+        bus.init()
+        bus.inject_read(b"\x01")  # sets _read_event
+        bus.reset_input_buffer()  # must also clear _read_event
+
+        error: list[BaseException] = []
+
+        def reader():
+            try:
+                bus.read(1)
+            except BaseException as e:
+                error.append(e)
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join(timeout=1.0)
+        bus.close()
+
+        assert not t.is_alive()
+        assert len(error) == 1
+        assert isinstance(error[0], TimeoutError)
+
+    def test_set_baudrate_records_value(self, bus):
+        bus.set_baudrate(1_000_000)
+        assert bus._baudrate == 1_000_000
+
+
+class TestRpiSerialVirtual:
+    def test_roundtrip_via_delegate(self):
+        # Constructor must accept the same args as RpiSerial, and the
+        # inject_read / written helpers must be delegated from SerialVirtual.
+        drv = RpiSerialVirtual(
+            name="test", logger=Logger("test"), port="/dev/null", baudrate=115200
+        )
+        drv.init()
+        drv.write(b"\xa0")
+        drv.inject_read(b"\x55")
+        assert drv.read(1) == b"\x55"
+        assert drv.written == [b"\xa0"]
+        drv.close()
+
+    def test_set_baudrate_propagates_to_inner(self):
+        drv = RpiSerialVirtual(
+            name="test", logger=Logger("test"), port="/dev/null", baudrate=115200
+        )
+        drv.init()
+        drv.set_baudrate(500_000)
+        assert drv._baudrate == 500_000
+        assert drv._inner._baudrate == 500_000
+        drv.close()


### PR DESCRIPTION
- Add abstract reset_input_buffer() on Serial interface (needed for AX12 half-duplex echo draining and post-timeout recovery).
- Add RpiSerialDefinition and SerialVirtualDefinition so serial drivers can be instantiated from JSON5 config like GPIO.
- Align RpiSerial and SerialVirtual on the reference GPIO pattern: init() returns Task[()], ctor takes the custom Logger.
- Update tests with fixtures and cover reset_input_buffer.