### PR TITLE
fix(geometry): correct Pose inheritance, slots, transforms and tests

### DIFF
--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -39,4 +39,7 @@ Each file documents a single concept. Files are self-contained but link to relat
 |------|------|---------|
 | [Color](types/color.md) | `types/color.md` | RGBA value object (normalized floats) |
 | [Vector and Pose Types](types/vect.md) | `types/vect.md` | Vect2D, Vect3D, Pose2D, Pose3D (quaternion-based 3D) |
+| [Geometry Vocabulary](types/geometry-vocabulary.md) | `types/geometry-vocabulary.md` | Glossary: SE(n), SO(n), pose, frame, quaternion |
+| [Geometry Examples](types/geometry-examples.md) | `types/geometry-examples.md` | Worked examples: compose vs add, frame chaining, pitfalls |
+| [Geometry Performance](types/geometry-performance.md) | `types/geometry-performance.md` | Patterns for embedded: sqr_norm, cached trig, dot-product heading comparison |
 | [Locatable Components](types/locatable-components.md) | `types/locatable-components.md` | Proposal: config-driven pose for components |

--- a/docs/glossary/types/geometry-examples.md
+++ b/docs/glossary/types/geometry-examples.md
@@ -1,0 +1,228 @@
+# Geometry Examples
+
+Worked examples for the `Vect2D` / `Pose2D` / `Pose3D` / `RigidTransform2D` types.
+
+The goal is to build correct intuition: when do you use `+`, when do you use `compose`, when does the naive formula produce silently wrong results.
+
+---
+
+## 1. ℝ² vs SE(2) — the robot that moves forward
+
+Robot at position `(100, 0)`, facing north (`θ = π/2`). It wants to move forward 50 mm **in its own direction**.
+
+### Wrong (treating the pose as a vector)
+
+```python
+robot = Pose2D(100, 0, math.pi / 2)
+delta = Pose2D(50, 0, 0)          # "go forward 50 mm"
+new = robot + delta                # Pose2D(150, 0, π/2)
+```
+
+The robot teleported 50 mm **east**, not north. Adding vectors ignores the robot's orientation.
+
+### Right (SE(2) composition)
+
+```python
+robot = Pose2D(100, 0, math.pi / 2)
+delta = Pose2D(50, 0, 0)           # 50 mm forward, in the local frame
+new = robot.compose(delta)         # Pose2D(100, 50, π/2)
+```
+
+`compose` applies the robot's rotation to the local offset. The robot moves 50 mm north in its own frame.
+
+**Takeaway**: a pose's orientation decides how a local offset maps back to the parent frame. Always compose — never add.
+
+---
+
+## 2. Averaging angles — SO(2) is not ℝ
+
+Two heading measurements: 359° and 1°. The true mean is 0° (or 360°, same thing).
+
+### Naive arithmetic mean (wrong)
+
+```python
+(359 + 1) / 2 = 180     # robot would face south
+```
+
+### Through Cartesian coordinates (right)
+
+```python
+import math
+angles = [math.radians(359), math.radians(1)]
+x = sum(math.cos(a) for a in angles) / len(angles)
+y = sum(math.sin(a) for a in angles) / len(angles)
+mean = math.atan2(y, x)  # ≈ 0 radians
+```
+
+### Cheaper on embedded hardware (also right)
+
+```python
+TWO_PI = 2 * math.pi
+
+def normalize_near(a: float, ref: float) -> float:
+    """Bring *a* into [ref - π, ref + π] without trigonometry."""
+    d = a - ref
+    while d > math.pi:  d -= TWO_PI
+    while d < -math.pi: d += TWO_PI
+    return ref + d
+
+def mean_angles(angles):
+    ref = angles[0]
+    return sum(normalize_near(a, ref) for a in angles) / len(angles)
+```
+
+**Why this works**: angles live on a **circle**. `359°` and `1°` are 2° apart, not 358° apart. Arithmetic averaging assumes a line, which is why it breaks around the 0/2π boundary.
+
+See [`geometry-performance.md`](geometry-performance.md) for more options (dot-product comparisons, polynomial approximations, LUTs).
+
+---
+
+## 3. Sensor fusion — chaining frames
+
+Lidar mounted at `(0, 85, 0)` on the robot (85 mm in front, same orientation as the robot). Robot at `(500, 300, π/4)` on the table.
+
+The lidar detects an obstacle at `(200, 0)` **in its own frame**.
+
+**Question**: where is the obstacle on the table?
+
+```python
+robot = Pose2D(500, 300, math.pi / 4)     # robot frame inside table frame
+lidar_on_robot = Pose2D(0, 85, 0)          # lidar frame inside robot frame
+
+# Lidar frame inside table frame (SE(2) composition)
+lidar_on_table = robot.compose(lidar_on_robot)
+# ≈ Pose2D(500 - 85·sin(π/4), 300 + 85·cos(π/4), π/4)
+# ≈ Pose2D(439.9, 360.1, π/4)
+
+# Obstacle in the lidar frame
+obstacle_local = Vect2D(200, 0)
+
+# Obstacle on the table
+obstacle_global = lidar_on_table.transform(obstacle_local)
+# ≈ Vect2D(439.9 + 200·cos(π/4), 360.1 + 200·sin(π/4))
+# ≈ Vect2D(581.3, 501.5)
+```
+
+Two different operations on two different types:
+
+| Operation | Signature | Meaning |
+|-----------|-----------|---------|
+| `compose` | `SE(2) × SE(2) → SE(2)` | chain two frames |
+| `transform` | `SE(2) × ℝ² → ℝ²` | apply a transformation to a point |
+
+This is exactly why `Pose` and `Vect` are distinct types.
+
+---
+
+## 4. Interpolating between two poses
+
+Robot starts at `(0, 0, 0)` and must reach `(100, 0, π/2)`. Midpoint?
+
+### Naive vector midpoint (sometimes wrong)
+
+```python
+A = Pose2D(0, 0, 0)
+B = Pose2D(100, 0, math.pi / 2)
+mid_wrong = Pose2D((A.x + B.x) / 2, (A.y + B.y) / 2, (A.theta + B.theta) / 2)
+```
+
+Here it gives `Pose2D(50, 0, π/4)` — correct by luck. But if `B = (100, 0, 2π - 0.1)` (almost a full turn backward), the arithmetic mean yields `π - 0.05` (half a turn the wrong way) instead of `-0.05` (just a hair backward).
+
+### Correct (SE(2) interpolation)
+
+```python
+def shortest_angle_diff(a: float, b: float) -> float:
+    return math.atan2(math.sin(b - a), math.cos(b - a))
+
+def slerp_pose2d(A: Pose2D, B: Pose2D, t: float) -> Pose2D:
+    x = A.x + t * (B.x - A.x)
+    y = A.y + t * (B.y - A.y)
+    theta = A.theta + t * shortest_angle_diff(A.theta, B.theta)
+    return Pose2D(x, y, theta)
+```
+
+**Takeaway**: interpolation on the angle must go the **short way around the circle**, not the arithmetic way.
+
+---
+
+## 5. Force vs displacement vs position
+
+Three 2D vectors, structurally identical (two floats), physically very different:
+
+```python
+F  = Vect2D(5.0, 0.0)       # force, in newtons
+dx = Vect2D(50.0, 0.0)      # displacement, in millimeters
+p  = Vect2D(500.0, 300.0)   # position on the table, in millimeters
+
+# Meaningful
+p_new    = p + dx            # position + displacement → new position. OK.
+F_total  = F + F             # sum of forces → force. OK.
+dx_scale = 2 * dx            # 2 × displacement → displacement. OK.
+
+# Not meaningful, but Python accepts it
+mix = p + F                  # "500 mm + 5 N" — dimensional nonsense
+```
+
+Python does not check units. `Vect2D` lumps three physical semantics into one type. That is a pragmatic compromise (ten classes would be too many). But putting `Pose2D` in the same bucket goes one step too far: a pose is not even a vector.
+
+---
+
+## 6. Inverse — going back
+
+Robot seen from the beacon camera: `Pose2D(300, 200, π/3)`. What is the beacon, seen from the robot?
+
+```python
+robot_from_beacon = Pose2D(300, 200, math.pi / 3)
+beacon_from_robot = robot_from_beacon.inverse()
+
+# Sanity check
+robot_from_beacon.compose(beacon_from_robot) == Pose2D(0, 0, 0)  # True (up to epsilon)
+```
+
+**Careful**: `inverse()` on SE(2) is **not** just negating the coordinates. The translation must also be rotated by the inverse rotation. That is exactly what `Pose2D.inverse()` does:
+
+```python
+p = Vect2D(-self.x, -self.y).rotate(-self.theta)
+return Pose2D(p.x, p.y, -self.theta)
+```
+
+Writing `Pose2D(-300, -200, -π/3)` would give a completely different (and wrong) frame.
+
+---
+
+## 7. Composing transformations vs composing poses
+
+`RigidTransform2D` and `Pose2D` represent the same mathematical object (an element of SE(2)), but the APIs differ:
+
+| `Pose2D` | `RigidTransform2D` |
+|----------|-------------------|
+| Immutable (each operation returns a new pose) | Mutable (operations update in place) |
+| Recomputes `cos`/`sin` on every `transform` | Caches `_c`, `_s` once in `__init__` |
+| Convenient for one-shot computations | Efficient for repeated applications |
+
+Use `RigidTransform2D` when you apply the **same** transformation to many points in a tight loop (lidar scan conversion, point cloud batch transform). Use `Pose2D` for everything else.
+
+```python
+# Lidar scan conversion — keep cos/sin cached
+lidar_pose = robot.compose(lidar_on_robot)
+T = RigidTransform2D(
+    offset=Vect2D(lidar_pose.x, lidar_pose.y),
+    angle=lidar_pose.theta,
+)
+for point in scan_points:
+    T.apply_to_point(point)   # mutates in place, no allocation, no trig calls
+```
+
+---
+
+## 8. Common pitfalls to watch for
+
+| Anti-pattern | What to do instead |
+|--------------|-------------------|
+| `pose_a + pose_b` | `pose_a.compose(pose_b)` |
+| `-pose` to "reverse" a pose | `pose.inverse()` |
+| `(angle_a + angle_b) / 2` | `mean_angles(...)` with shortest-path reduction |
+| `pose.norm()` | Meaningless (mixed units). Use `pose.position.norm()` if you need the distance from origin. |
+| `2 * pose` | Meaningless. Use interpolation or composition. |
+| `abs(theta_1 - theta_2) < tol` | `abs(shortest_angle_diff(theta_1, theta_2)) < tol` |
+| Calling `point.rotate(theta)` inside a tight loop | Cache `(c, s)` or use `RigidTransform2D`. |

--- a/docs/glossary/types/geometry-performance.md
+++ b/docs/glossary/types/geometry-performance.md
@@ -1,0 +1,252 @@
+# Geometry Performance Notes
+
+Evolutek robots run on constrained hardware: Raspberry Pi for the main compute, STM32 (Cortex-M) for the slave boards. Trigonometry and heap allocations in hot paths cost real latency.
+
+This page lists the tricks used inside the geometry module and the patterns to follow (or avoid) in user code.
+
+---
+
+## Trigonometric cost, order of magnitude
+
+| Platform | Clock | `sinf` / `cosf` | `atan2f` | `sqrtf` | ~ wall time for `sinf` |
+|----------|-------|-----------------|----------|---------|------------------------|
+| Raspberry Pi 4 (Cortex-A72, hard FPU + NEON) | 1.5 GHz | ~30-50 cy | ~80-120 cy | 1-5 cy (FSQRT) | ~25 ns |
+| STM32G4 (Cortex-M4F, hard single-precision FPU) | 170 MHz | ~30-80 cy | ~150-250 cy | ~14 cy (VSQRT) | ~300 ns |
+| ESP32 (Xtensa LX6, single-precision FPU) | 240 MHz | ~100-200 cy | ~300-400 cy | ~10-20 cy | ~600 ns |
+| Cortex-M0/M3 (no FPU, soft-float) | ~48-72 MHz | ~200-400 cy | ~500 cy | ~100-200 cy | ~5 µs |
+| PC x86_64 (modern desktop) | ~4 GHz | ~15-30 cy | ~40 cy | 1 cy | ~5 ns |
+
+Orders of magnitude, not benchmarks: exact figures depend on libm version, compiler flags, and `float` vs `double`. Takeaway: on the RPi a `sinf` costs a few tens of nanoseconds; on an STM32G4 it costs a few hundred; without a FPU, it crosses the microsecond.
+
+At a 1 kHz control loop, those cycles matter. A `Pose2D.transform(point)` call with on-the-fly `cos`/`sin` costs roughly 50–80 cycles on RPi. Multiply by a 360-point lidar scan at 10 Hz = 3600 trig pairs per second just for frame conversion.
+
+The STM32G4 is the target for most Evolutek slave boards (asserv, actionneurs, alim…): it has a single-precision FPU, so `sinf`/`cosf` are fast in absolute terms, but the 170 MHz clock and in-order pipeline make per-call overhead visible in tight control loops. Caching `cos`/`sin` (as `RigidTransform2D` does) remains worthwhile.
+
+---
+
+## Three levels of optimization
+
+1. **Algorithmic** — pick a different formula that avoids the expensive call entirely.
+2. **Representational** — store something else than an angle (unit vector, quaternion) so the expensive conversion is paid once, at object creation.
+3. **Hardware** — when you can't avoid it: polynomial approximations, lookup tables, fused instructions.
+
+Exhaust level 1 before moving to level 2, and level 2 before level 3.
+
+---
+
+## Pattern 1 — Compare squared distances, not distances
+
+Computing `sqrt` is pointless when you only want to order distances or test them against a threshold.
+
+```python
+# Bad: sqrt for nothing
+if (robot.position - target).norm() < 50:
+    ...
+
+# Good: square the threshold once
+RADIUS_SQ = 50 * 50
+if (robot.position - target).sqr_norm() < RADIUS_SQ:
+    ...
+```
+
+`Vect2D.sqr_norm()` and `Vect3D.sqr_norm()` exist precisely for this. Prefer them whenever possible.
+
+---
+
+## Pattern 2 — Compare angles via dot product
+
+To test whether two headings are close (say, within 5°), you do **not** need `atan2` or `normalize_angle`.
+
+Store the orientation as a unit vector `(cos θ, sin θ)` and compare dot products to a precomputed cosine threshold:
+
+```python
+import math
+
+COS_5_DEG = math.cos(math.radians(5))    # precomputed once
+
+def heading_close(v1: Vect2D, v2: Vect2D) -> bool:
+    """True if the angle between v1 and v2 is less than 5 degrees."""
+    return v1.x * v2.x + v1.y * v2.y > COS_5_DEG
+```
+
+**Cost**: 2 mul + 1 add + 1 compare. No trig at all.
+
+Versus the naive version — `abs(normalize_angle(theta1 - theta2)) < tol` — which triggers `atan2` inside `normalize_angle`.
+
+This is the same idea that makes quaternions attractive in 3D: **never convert back to an angle in the hot path**.
+
+---
+
+## Pattern 3 — Cache `cos` / `sin` for a transformation
+
+`Pose2D.transform(point)` computes `cos(theta)` and `sin(theta)` every call. Fine for one-shot usage; terrible in a loop.
+
+When you need to apply the **same** transformation to many points, use `RigidTransform2D`: it caches `_c`, `_s` once in `__init__` and reuses them on every `apply_to_point`.
+
+```python
+# Bad: N trig pairs for N points
+for p in point_cloud:
+    q = robot_pose.transform(p)      # 2 trig calls per point
+    results.append(q)
+
+# Good: 1 trig pair, reused N times
+T = RigidTransform2D(
+    offset=Vect2D(robot_pose.x, robot_pose.y),
+    angle=robot_pose.theta,
+)
+for p in point_cloud:
+    T.apply_to_point(p)              # 4 mul + 4 add, zero trig
+```
+
+If you implement a new rotation-heavy routine, expose a version that accepts a precomputed `(c, s)` pair or a `RigidTransform2D`.
+
+---
+
+## Pattern 4 — Average angles without trigonometry
+
+Given `N` angle measurements that are **close to each other** (the usual case for filtering sensor noise), avoid the full Cartesian mean.
+
+### Fastest: wrap around a reference, then arithmetic mean
+
+```python
+TWO_PI = 2 * math.pi
+
+def mean_angles(angles):
+    """Circular mean, no trig. Valid when all angles lie in the same half-circle."""
+    ref = angles[0]
+    total = 0.0
+    for a in angles:
+        d = a - ref
+        if d > math.pi:     d -= TWO_PI
+        elif d < -math.pi:  d += TWO_PI
+        total += d
+    return ref + total / len(angles)
+```
+
+**Cost**: `N` subtractions + up to `N` compares + 1 division. Zero trig.
+
+### Slower but robust: Cartesian mean
+
+```python
+def mean_angles_robust(angles):
+    """Works for any distribution, including angles scattered around the circle."""
+    x = sum(math.cos(a) for a in angles) / len(angles)
+    y = sum(math.sin(a) for a in angles) / len(angles)
+    return math.atan2(y, x)
+```
+
+**Cost**: `2N` trig calls + `atan2`. Pay this only if you actually cannot bound the measurements to a half-circle.
+
+---
+
+## Pattern 5 — Normalize angles by subtraction, not `atan2`
+
+`atan2(sin(x), cos(x))` is a common idiom to wrap an angle into `(-π, π]`, but it uses trig. When you know the input is "a small number of turns off", subtract `2π` directly.
+
+```python
+TWO_PI = 2 * math.pi
+
+def normalize_angle(a: float) -> float:
+    while a > math.pi:  a -= TWO_PI
+    while a < -math.pi: a += TWO_PI
+    return a
+```
+
+**Cost**: 0-2 subtractions in practice, since inputs rarely drift beyond one or two turns. If your pipeline generates wildly drifting angles, use a modulo-based normalization (`a - TWO_PI * floor((a + pi) / TWO_PI)`) instead of the loop.
+
+---
+
+## Pattern 6 — Avoid allocations in the hot loop
+
+Python does not free memory synchronously; creating `Vect2D` instances inside a 10 kHz loop pressures the allocator and can trigger GC pauses on RPi.
+
+Prefer in-place operators (`+=`, `-=`, `*=`, `_components` setter) on a reused buffer:
+
+```python
+# Bad: allocates one Vect2D per iteration
+acc = Vect2D(0, 0)
+for p in points:
+    acc = acc + p
+
+# Good: mutates the accumulator, zero new objects
+acc = Vect2D(0, 0)
+for p in points:
+    acc += p
+```
+
+Same idea for `RigidTransform2D.apply_to_point` — it mutates the argument in place rather than returning a new `Vect2D`.
+
+---
+
+## Pattern 7 — Polynomial approximations (when on bare MCU)
+
+On a Cortex-M without FPU, even `sinf` hurts. Two cheap substitutes, from cheapest to most accurate:
+
+```c
+// Taylor-truncated, good for |x| < 0.5 rad, error ~0.5%
+static inline float sin_small(float x) { return x - (x * x * x) / 6.0f; }
+static inline float cos_small(float x) { return 1.0f - (x * x) / 2.0f; }
+
+// Bhaskara I approximation, good over [-π, π], error ~1.6%
+static inline float sin_bhaskara(float x) {
+    // normalize x to [0, π] first
+    return (16.0f * x * (3.14159265f - x)) /
+           (5.0f * 3.14159265f * 3.14159265f - 4.0f * x * (3.14159265f - x));
+}
+```
+
+**Cost**: 3-5 multiplications. Usually beats `sinf` on soft-float targets.
+
+Not applicable to Python code, but useful to know for firmware that implements the same geometry on the STM32 boards.
+
+---
+
+## Pattern 8 — Lookup tables
+
+For **discrete** angle inputs (e.g. encoder ticks, 4096 steps per revolution):
+
+```c
+static const float SIN_LUT[4096] = { /* precomputed at build time */ };
+
+float sin_lut(uint16_t tick) { return SIN_LUT[tick & 0x0FFF]; }
+```
+
+**Cost**: 1 load. Constant time.
+
+Relevant for motor control (FOC), less useful for high-level 2D robotics where angles are floats.
+
+---
+
+## Decision tree: what to use when
+
+| Situation | Pattern |
+|-----------|---------|
+| Compare distances | Pattern 1 (`sqr_norm`) |
+| Compare two headings | Pattern 2 (dot product of unit vectors) |
+| Rotate many points by the same angle | Pattern 3 (`RigidTransform2D` with cached `_c`, `_s`) |
+| Average noisy heading measurements | Pattern 4, "fastest" version |
+| Average angles scattered over the whole circle | Pattern 4, "robust" version |
+| Normalize a slightly drifting angle | Pattern 5 (subtraction loop) |
+| Accumulate in a loop | Pattern 6 (in-place operators) |
+| Bare MCU, no FPU | Pattern 7 (polynomial approx) |
+| Discrete encoder angle | Pattern 8 (LUT) |
+
+---
+
+## Notes on the current implementation
+
+- `RigidTransform2D.__init__` caches `_c`, `_s` — good.
+- `Pose2D.transform` calls `point.rotate(theta)`, which computes `cos`/`sin` every time — **acceptable for one-shot work**, avoid in tight loops (switch to `RigidTransform2D`).
+- `Vect2D.sqr_norm` exists: use it.
+- Euler-to-quaternion conversion in `Pose3D.__init__` pays the trig cost **once** at construction. All subsequent `transform`/`compose` calls are pure multiply-add. This is intentional.
+- `Pose3D.from_quaternion` bypasses `_euler_to_quat` entirely — use it when you already have a unit quaternion (e.g. IMU output).
+
+---
+
+## Takeaway
+
+1. Pay the trig cost **once**, at object creation, not every call.
+2. Compare **squared** quantities whenever you only need ordering.
+3. Compare **dot products**, not angles.
+4. Mutate in place in hot loops.
+5. Only reach for polynomial approximations or LUTs when the profiler says so.

--- a/docs/glossary/types/geometry-vocabulary.md
+++ b/docs/glossary/types/geometry-vocabulary.md
@@ -1,0 +1,182 @@
+# Geometry Vocabulary
+
+Reference glossary for the mathematical and robotics terminology used by the geometry types (`Vect2D`, `Vect3D`, `Pose2D`, `Pose3D`, `RigidTransform2D`...).
+
+Not a math course: each entry is a short definition with a pointer to where the concept shows up in the codebase.
+
+---
+
+## Mathematical structures
+
+### Set
+A collection of objects. No operations are assumed; you can only ask "does `x` belong to this set?".
+
+### Group
+A set with **one** operation (noted `·` or `+`) that satisfies:
+1. **Closure**: `a · b` stays in the set.
+2. **Associativity**: `(a · b) · c = a · (b · c)`.
+3. **Identity element**: there exists `e` such that `a · e = e · a = a`.
+4. **Inverse**: for every `a`, there exists `a⁻¹` such that `a · a⁻¹ = e`.
+
+Examples: `(ℤ, +)`, `(ℝ*, ×)`, `SE(2)` under pose composition.
+
+### Vector space (over ℝ)
+A group under addition, plus a scalar multiplication `α·v` that distributes.
+You can **add** vectors and **scale** them. `ℝ²`, `ℝ³` are the canonical examples.
+
+### Manifold
+A space that **locally looks like `ℝⁿ`** but may be globally curved. A circle is a 1D manifold: zoom in far enough, it looks like a line; globally, it is a closed loop.
+
+### Lie group
+A group that is also a smooth manifold: trajectories inside the group are smooth, derivatives make sense. `SO(n)`, `SE(n)`, the circle, the sphere.
+
+### ℝ (read "R")
+The set of real numbers. Infinite line.
+
+### ℝⁿ
+The set of ordered n-tuples of reals. `ℝ² = {(x, y)}`, `ℝ³ = {(x, y, z)}`.
+
+---
+
+## Classical groups
+
+| Group | Name | Content |
+|-------|------|---------|
+| **GL(n)** | General Linear | Invertible `n × n` matrices. Biggest bucket. |
+| **O(n)** | Orthogonal | Matrices that preserve distances. Rotations **and** mirrors. |
+| **SO(n)** | Special Orthogonal | Pure rotations (det = +1, no mirror). `SO(2)` = circle, `SO(3)` = 3D rotations. |
+| **E(n)** | Euclidean | Rotations + mirrors + translations in `ℝⁿ`. |
+| **SE(n)** | Special Euclidean | Rotations + translations, **no mirror**. The group of "rigid displacements". |
+
+In this library, `Pose2D` ∈ SE(2) and `Pose3D` ∈ SE(3).
+
+---
+
+## Geometric objects
+
+### Point
+A location in space. Element of `ℝⁿ` expressed in some frame. **No addition between points** (it would mean nothing physically).
+
+### Vector
+A displacement, direction, or force. Element of a vector space. Can be added, scaled, normed.
+
+### Pose (frame)
+A position **plus** an orientation. Element of `SE(n)`. Represents a local coordinate frame relative to a parent.
+
+### Transformation
+A function that moves points. In `SE(n)`, a transformation is equivalent to a pose: the pose `T` **is** the transformation that maps the parent frame onto the frame `T` defines.
+
+### Frame (coordinate frame)
+A coordinate system: "table frame", "robot frame", "lidar frame". Each pose defines a frame relative to a parent.
+
+---
+
+## Operations
+
+### Translation
+Pure displacement, no rotation. A vector `(tx, ty)`.
+
+### Rotation
+Change of orientation around a point (2D) or an axis (3D). Parametrized by one angle `θ` in 2D, by three angles or a quaternion in 3D.
+
+### Rigid transformation
+Rotation + translation. Preserves distances and angles. Element of `SE(n)`.
+
+### Composition
+Chaining two transformations. Noted `T₁ · T₂` or `T₁.compose(T₂)`. **Not commutative**: `T₁·T₂ ≠ T₂·T₁` in general.
+
+### Inverse
+The transformation that undoes another. `T · T⁻¹ = identity`. For a pose: "how do I step into the child frame from the parent?".
+
+### Action
+Applying a transformation to a point: `T · p` gives a new point. Distinct from `T · T'` which gives a new transformation.
+
+---
+
+## Orientation parameterizations
+
+### Angle (`θ`, `theta`)
+Single real number in radians. 2D only. Simple but lives on a circle (`SO(2)`), so averaging and interpolating are non-trivial.
+
+### Heading, course, yaw
+Synonyms of `θ` in 2D. In 3D, `yaw` is rotation around the vertical axis.
+
+### Roll, pitch, yaw
+The three Euler angles in 3D. Roll (around X, lateral tilt), pitch (around Y, nose up/down), yaw (around Z, heading).
+
+### Euler angles
+Parameterization of 3D rotations by three successive angles. Intuitive but suffers from **gimbal lock** (loss of one degree of freedom when two axes align).
+
+### Quaternion
+Parameterization of 3D rotations by four numbers `(w, x, y, z)` with `w² + x² + y² + z² = 1`. No gimbal lock, fast composition, clean interpolation (slerp). Used internally by `Pose3D`.
+
+### Rotation matrix
+Orthogonal 2×2 in 2D, 3×3 in 3D. Most direct representation, but redundant (9 numbers for 3 DOF in 3D).
+
+---
+
+## Frame / reference concepts
+
+### Parent frame
+The frame in which a pose is **expressed**. The table is typically the parent of the robot.
+
+### Local (child) frame
+The frame defined by the pose itself. The robot frame, in which positions are expressed **relative to the robot**.
+
+### Local coordinates
+Coordinates of a point expressed in a local frame (e.g. in the lidar frame).
+
+### Global coordinates
+Coordinates in a root frame (e.g. on the table).
+
+### Change of frame
+Converting a point from local to global coordinates (or the reverse). Exactly `pose.transform(point)` and `pose.inverse().transform(point)`.
+
+---
+
+## Usual robotics concepts
+
+### Odometry
+Pose estimation by integrating measured displacements (wheel encoders). Accumulates in `SE(2)` step by step. Drifts over time.
+
+### SLAM
+Simultaneous Localization And Mapping. Builds a map **and** localizes in it at the same time. Heavy user of `SE(2)` / `SE(3)` poses.
+
+### Kinematics
+Study of motion without regard to forces. `SE(n)` transformations are the base tool.
+
+### Forward kinematics
+Given arm joint angles, where is the gripper? `SE(3)` composition along each segment.
+
+### Inverse kinematics
+Given a desired gripper pose, what joint angles? Reverse problem, usually iterative.
+
+### Rigid body
+A body that does not deform. Its position and orientation are fully described by an element of `SE(n)`.
+
+---
+
+## This library's notation
+
+| Symbol | Meaning |
+|--------|---------|
+| `Pose2D(x, y, theta)` | Element of SE(2). Position in mm, orientation in radians. |
+| `Pose3D(x, y, z, roll, pitch, yaw)` | Element of SE(3). Position in mm, orientation stored as quaternion internally. |
+| `Vect2D(x, y)`, `Vect3D(x, y, z)` | Vectors / points in `ℝ²` and `ℝ³`. Addable, scalable, normable. |
+| `transform(point)` | Action of a pose on a point: local → parent coordinates. |
+| `compose(other)` | Multiplication in `SE(n)`: chain two transformations or frames. |
+| `inverse()` | Inverse in `SE(n)`: child frame → parent frame. |
+| `RigidTransform2D` | Same object as `Pose2D`, but with a mutable API (`apply_to_point` modifies in place). Useful for chaining without allocating. |
+| `AffineTransform2D` | `RigidTransform2D` + scaling. **Leaves** SE(2), goes into the bigger affine group. Does not preserve distances. |
+| `MirrorTransform2D` | Axial symmetry. **Also leaves** SE(2) (determinant = -1, lands in E(2)). Useful for mirroring strategies across the table side. |
+
+---
+
+## Takeaway: four words to remember
+
+1. **Point** (location) ≠ **vector** (displacement) ≠ **pose** (frame).
+2. You **compose** two poses, and you **transform** a point with a pose. Never the other way around.
+3. Angles live on a **circle**: never add or average them like plain reals without `normalize_angle` afterward.
+4. **SE(n)** = "position + orientation with group structure". It is **not** a vector space.
+
+Everything else (Lie theory, quaternion math, manifolds) only matters for advanced topics (Kalman filtering, graph SLAM, optimal control).

--- a/src/evo_lib/types/pose.py
+++ b/src/evo_lib/types/pose.py
@@ -1,8 +1,15 @@
 """Geometry types shared across omnissiah modules.
 
-Position and Pose represent 2D coordinates on the table.
-Utility functions provide distance computation and angle normalization.
+Pose2D and Pose3D represent rigid-body poses (position + orientation) on the
+table or in 3D space. They are elements of SE(2) / SE(3): they compose, they
+invert, they transform points — but they are **not** vectors. Addition,
+scaling, and norm are intentionally not defined.
+
+See docs/glossary/types/geometry-vocabulary.md for the underlying concepts
+and docs/glossary/types/geometry-examples.md for worked examples.
 """
+
+from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
@@ -11,10 +18,11 @@ from evo_lib.types.vect import Vect2D, Vect3D
 
 
 class PoseBase(ABC):
-    """Abstract base for pose types (position + orientation).
+    """Abstract base for pose types.
 
     These are elements of SE(n), not vectors. Addition, scaling, and norm
-    are intentionally not defined.
+    are intentionally not defined — use ``compose``, ``inverse``, and
+    ``transform`` instead.
     """
 
     __slots__ = ()
@@ -26,71 +34,98 @@ class PoseBase(ABC):
     @property
     @abstractmethod
     def _comparison_key(self) -> tuple[float, ...]:
-        """Values used for equality and hashing."""
+        """Values used for equality."""
         ...
-
-    # -- Comparison ---------------------------------------------------------
 
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return NotImplemented
         return all(
-            math.isclose(a, b) for a, b in zip(self._comparison_key, other._comparison_key)  # type: ignore[union-attr]
+            math.isclose(a, b)
+            for a, b in zip(self._comparison_key, other._comparison_key)  # type: ignore[union-attr]
         )
 
-    def __hash__(self) -> int:
-        return hash(tuple(round(v, 9) for v in self._comparison_key))
+    # Poses are logically mutable (transforms can alter heading in place).
+    # Equality is approximate (``math.isclose``), which cannot be reconciled
+    # with a stable hash. Make poses explicitly unhashable.
+    __hash__ = None  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
-# Concrete pose types
+# Pose2D
 # ---------------------------------------------------------------------------
 
 
-class Pose2D(PoseBase, Vect2D):
-    """2D position with orientation (x, y, theta).
+class Pose2D(PoseBase):
+    """2D rigid-body pose (x, y, theta).
 
-    Represents a rigid-body pose in the plane: where something is and which
-    direction it faces. Use *transform* to convert points between reference
-    frames.
+    Represents where something is and which direction it faces on the table.
+    Internally caches ``cos(theta)`` and ``sin(theta)`` to avoid recomputing
+    them on every ``transform`` call (see docs/glossary/types/geometry-performance.md).
+
+    This class uses **composition** with Vect2D (via the ``position``
+    accessor) rather than inheriting from it: a pose is not a vector, and
+    inheriting vector arithmetic would silently produce geometrically wrong
+    results (cf. ``pose_a + pose_b`` — use ``pose_a.compose(pose_b)``).
     """
 
-    __slots__ = ("heading")
+    __slots__ = ("x", "y", "theta", "_c", "_s")
 
-    def __init__(self, x: float = 0.0, y: float = 0.0, heading: float = 0.0) -> None:
-        super().__init__(x, y)
-        self.heading = float(heading)
+    def __init__(self, x: float = 0.0, y: float = 0.0, theta: float = 0.0) -> None:
+        self.x = float(x)
+        self.y = float(y)
+        self.theta = float(theta)
+        self._c = math.cos(self.theta)
+        self._s = math.sin(self.theta)
 
     def copy(self) -> Pose2D:
-        return Pose2D(self.x, self.y, self.heading)
+        return Pose2D(self.x, self.y, self.theta)
 
     @property
     def _comparison_key(self) -> tuple[float, ...]:
-        return (self.x, self.y, self.heading)
+        return (self.x, self.y, self.theta)
 
     @property
     def position(self) -> Vect2D:
-        """The translation part as a Vect2D."""
+        """The translation part as a new Vect2D (caller-owned copy)."""
         return Vect2D(self.x, self.y)
+
+    # -- SE(2) operations ---------------------------------------------------
 
     def transform(self, point: Vect2D) -> Vect2D:
         """Transform *point* from this frame into the parent frame.
 
-        Applies rotation then translation:
-            x' = self.x + point.x * cos(theta) - point.y * sin(theta)
-            y' = self.y + point.x * sin(theta) + point.y * cos(theta)
+        Applies rotation then translation, using cached cos/sin:
+            x' = self.x + point.x * c - point.y * s
+            y' = self.y + point.x * s + point.y * c
         """
-        return self.position + point.rotate(self.heading)
+        return Vect2D(
+            self.x + point.x * self._c - point.y * self._s,
+            self.y + point.x * self._s + point.y * self._c,
+        )
 
     def inverse(self) -> Pose2D:
-        """The inverse transform (parent frame -> this frame)."""
-        p = Vect2D(-self.x, -self.y).rotate(-self.heading)
-        return Pose2D(p.x, p.y, -self.heading)
+        """The inverse transform (parent frame -> this frame).
+
+        Note that ``Pose2D(-x, -y, -theta)`` is **not** the inverse: the
+        translation must also be rotated by the inverse rotation.
+        """
+        # Reuse cached cos/sin: cos(-t)=cos(t), sin(-t)=-sin(t)
+        inv = Pose2D.__new__(Pose2D)
+        inv.theta = -self.theta
+        inv._c = self._c
+        inv._s = -self._s
+        inv.x = -self.x * self._c - self.y * self._s
+        inv.y = self.x * self._s - self.y * self._c
+        return inv
 
     def compose(self, other: Pose2D) -> Pose2D:
-        """Compose two transforms: self then other (in the local frame of self)."""
-        p = self.transform(other.position)
-        return Pose2D(p.x, p.y, self.heading + other.heading)
+        """Compose two transforms: self then other (other expressed in self's frame)."""
+        px = self.x + other.x * self._c - other.y * self._s
+        py = self.y + other.x * self._s + other.y * self._c
+        return Pose2D(px, py, self.theta + other.theta)
+
+    # -- Serialization ------------------------------------------------------
 
     @staticmethod
     def from_dict(d: dict) -> Pose2D:
@@ -99,28 +134,33 @@ class Pose2D(PoseBase, Vect2D):
 
     def to_dict(self) -> dict[str, float]:
         """Serialize to a dict."""
-        return {"x": self.x, "y": self.y, "theta": self.heading}
+        return {"x": self.x, "y": self.y, "theta": self.theta}
 
     # -- Conversion ---------------------------------------------------------
 
     def to_3d(self, z: float = 0.0) -> Pose3D:
         """Promote to 3D with the given Z and yaw = theta."""
-        return Pose3D(self.x, self.y, z, yaw=self.heading)
+        return Pose3D(self.x, self.y, z, yaw=self.theta)
 
     # -- Display ------------------------------------------------------------
 
     def __repr__(self) -> str:
-        return f"Pose2D(x={self.x}, y={self.y}, theta={self.heading})"
+        return f"Pose2D(x={self.x}, y={self.y}, theta={self.theta})"
 
 
-class Pose3D(PoseBase, Vect3D):
-    """3D position with orientation (x, y, z, quaternion).
+# ---------------------------------------------------------------------------
+# Pose3D
+# ---------------------------------------------------------------------------
+
+
+class Pose3D(PoseBase):
+    """3D rigid-body pose (x, y, z + quaternion).
 
     Full 6-DOF pose for articulated arms or 3D sensors. Orientation is stored
     as a unit quaternion internally, avoiding gimbal lock. Constructor accepts
     Euler angles (roll, pitch, yaw) for convenience.
 
-    For ground robots, use Pose2D instead (only yaw matters).
+    For ground robots, prefer Pose2D (only yaw matters, cheaper).
     """
 
     __slots__ = ("x", "y", "z", "_qw", "_qx", "_qy", "_qz")
@@ -134,16 +174,28 @@ class Pose3D(PoseBase, Vect3D):
         pitch: float = 0.0,
         yaw: float = 0.0,
     ) -> None:
-        super().__init__(x, y, z)
+        self.x = float(x)
+        self.y = float(y)
+        self.z = float(z)
         qw, qx, qy, qz = Pose3D._euler_to_quat(roll, pitch, yaw)
         self._qw, self._qx, self._qy, self._qz = Pose3D._canonical_sign(qw, qx, qy, qz)
 
     def copy(self) -> Pose3D:
-        return Pose3D(self.x, self.y, self.z, self.roll, self.pitch, self.yaw)
+        return Pose3D.from_quaternion(
+            self.x, self.y, self.z, self._qw, self._qx, self._qy, self._qz
+        )
 
     @classmethod
-    def from_quaternion(cls, x: float, y: float, z: float,
-                        qw: float, qx: float, qy: float, qz: float) -> Pose3D:
+    def from_quaternion(
+        cls,
+        x: float,
+        y: float,
+        z: float,
+        qw: float,
+        qx: float,
+        qy: float,
+        qz: float,
+    ) -> Pose3D:
         """Construct directly from a unit quaternion (no Euler conversion)."""
         obj = object.__new__(cls)
         obj.x = float(x)
@@ -202,14 +254,16 @@ class Pose3D(PoseBase, Vect3D):
 
     @property
     def position(self) -> Vect3D:
-        """The translation part as a Vect3D."""
+        """The translation part as a new Vect3D (caller-owned copy)."""
         return Vect3D(self.x, self.y, self.z)
+
+    # -- SE(3) operations ---------------------------------------------------
 
     def transform(self, point: Vect3D) -> Vect3D:
         """Transform *point* from this frame into the parent frame.
 
-        Uses the quaternion cross-product formula:
-        p' = p + 2w * (q_xyz x p) + 2 * (q_xyz x (q_xyz x p))
+        Quaternion sandwich product, expanded for efficiency:
+            p' = self.position + q * p * q⁻¹
         """
         px, py, pz = point.x, point.y, point.z
         qw, qx, qy, qz = self._qw, self._qx, self._qy, self._qz
@@ -231,7 +285,6 @@ class Pose3D(PoseBase, Vect3D):
         # Inverse rotation = conjugate for unit quaternions
         iqw, iqx, iqy, iqz = self._qw, -self._qx, -self._qy, -self._qz
 
-        # Rotate -t by the inverse quaternion
         tx, ty, tz = -self.x, -self.y, -self.z
         ttx = 2 * (iqy * tz - iqz * ty)
         tty = 2 * (iqz * tx - iqx * tz)
@@ -243,7 +296,7 @@ class Pose3D(PoseBase, Vect3D):
         return Pose3D.from_quaternion(px, py, pz, iqw, iqx, iqy, iqz)
 
     def compose(self, other: Pose3D) -> Pose3D:
-        """Compose two transforms: self then other (in the local frame of self)."""
+        """Compose two transforms: self then other (other expressed in self's frame)."""
         p = self.transform(other.position)
 
         # Quaternion multiplication: q1 * q2
@@ -255,6 +308,8 @@ class Pose3D(PoseBase, Vect3D):
         qz = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
 
         return Pose3D.from_quaternion(p.x, p.y, p.z, qw, qx, qy, qz)
+
+    # -- Serialization ------------------------------------------------------
 
     @staticmethod
     def from_dict(d: dict) -> Pose3D:
@@ -299,7 +354,9 @@ class Pose3D(PoseBase, Vect3D):
         )
 
     @staticmethod
-    def _canonical_sign(qw: float, qx: float, qy: float, qz: float) -> tuple[float, float, float, float]:
+    def _canonical_sign(
+        qw: float, qx: float, qy: float, qz: float
+    ) -> tuple[float, float, float, float]:
         """Ensure canonical sign so q and -q (same rotation) have identical repr."""
         for c in (qw, qx, qy, qz):
             if c > 1e-15:

--- a/src/evo_lib/types/quaternion.py
+++ b/src/evo_lib/types/quaternion.py
@@ -1,1 +1,0 @@
-# TODO: Move quaternion code from pose.py

--- a/src/evo_lib/types/transform.py
+++ b/src/evo_lib/types/transform.py
@@ -1,53 +1,89 @@
+"""In-place 2D transformations.
+
+``RigidTransform2D`` and friends expose a mutable API for hot paths where
+allocating a new Vect2D per point is too expensive (lidar scan conversion,
+point cloud batch processing). For one-shot computations on a Pose2D, use
+``Pose2D.transform`` / ``Pose2D.compose`` instead.
+
+See docs/glossary/types/geometry-performance.md for the performance
+rationale.
+"""
+
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from math import cos, sin
+from math import cos, pi, sin
 
 from evo_lib.types.pose import Pose2D
 from evo_lib.types.vect import Vect2D
 
 
 class Transform2D(ABC):
+    """Abstract base for in-place 2D transformations."""
+
     @abstractmethod
     def apply_to_point(self, point: Vect2D) -> None:
-        pass
+        """Mutate *point* in place."""
 
     @abstractmethod
     def apply_to_angle(self, angle: float) -> float:
-        pass
-
-    def apply_to_pose(self, pose: Pose2D) -> None:
-        self.apply_to_point(pose.position)
-        pose.heading = self.apply_to_angle(pose.heading)
+        """Return the image of *angle* under this transformation."""
 
     @abstractmethod
     def copy(self) -> Transform2D:
-        pass
+        """Return an independent copy of this transformation."""
+
+    def apply_to_pose(self, pose: Pose2D) -> None:
+        """Mutate *pose* (both translation and heading) in place."""
+        # Note: ``pose.position`` returns a *fresh* Vect2D, so we cannot
+        # mutate it in place. We route through (x, y) directly.
+        p = Vect2D(pose.x, pose.y)
+        self.apply_to_point(p)
+        new_theta = self.apply_to_angle(pose.theta)
+        # Rebuild the pose so the cached cos/sin stay consistent with theta.
+        Pose2D.__init__(pose, p.x, p.y, new_theta)
 
 
-class MirrorTransform2D(ABC):
-    def __init__(self, offset: Vect2D, vertical: bool):
+class MirrorTransform2D(Transform2D):
+    """Axial symmetry (optionally followed by a translation).
+
+    Leaves SE(2) (determinant = -1), so this is not a rigid transformation
+    in the SE(n) sense. Useful for mirroring a strategy across a table
+    axis when switching sides.
+    """
+
+    def __init__(self, offset: Vect2D, vertical: bool) -> None:
         self._vertical: bool = vertical
-        self._offset = offset.copy()
+        self._offset: Vect2D = offset.copy()
 
-    def apply(self, point: Vect2D):
+    def apply_to_point(self, point: Vect2D) -> None:
         if self._vertical:
-            point.y *= -1
+            point.y = -point.y
         else:
-            point.x *= -1
+            point.x = -point.x
         point += self._offset
 
-    def copy(self) -> Transform2D:
+    def apply_to_angle(self, angle: float) -> float:
+        # Vertical mirror (flip Y): angle -> -angle
+        # Horizontal mirror (flip X): angle -> pi - angle
+        return -angle if self._vertical else pi - angle
+
+    def copy(self) -> MirrorTransform2D:
         return MirrorTransform2D(self._offset, self._vertical)
 
 
 class RigidTransform2D(Transform2D):
-    def __init__(self,
-        offset: Vect2D,
-        angle: float
-    ):
-        self.offset = offset.copy()
-        self.angle = angle
-        self._c = cos(angle)
-        self._s = sin(angle)
+    """Rotation + translation. Element of SE(2).
+
+    Caches ``cos(angle)`` and ``sin(angle)`` on construction to avoid
+    recomputing them on every ``apply_to_point``.
+    """
+
+    def __init__(self, offset: Vect2D, angle: float) -> None:
+        self.offset: Vect2D = offset.copy()
+        self.angle: float = angle
+        self._c: float = cos(angle)
+        self._s: float = sin(angle)
 
     @staticmethod
     def create_identity() -> RigidTransform2D:
@@ -58,7 +94,8 @@ class RigidTransform2D(Transform2D):
         return RigidTransform2D(offset, angle)
 
     @staticmethod
-    def create_rotate_arround(center: Vect2D, angle: float) -> RigidTransform2D:
+    def create_rotate_around(center: Vect2D, angle: float) -> RigidTransform2D:
+        """Rotation of *angle* around *center*."""
         t = RigidTransform2D(-center, 0)
         t.transform(RigidTransform2D.create_rotate_then_translate(angle, center))
         return t
@@ -68,13 +105,10 @@ class RigidTransform2D(Transform2D):
         return RigidTransform2D(offset, 0)
 
     def copy(self) -> RigidTransform2D:
-        return RigidTransform2D(
-            self.offset,
-            self.angle
-        )
+        return RigidTransform2D(self.offset, self.angle)
 
-    # Rotate then offset the given point in place
     def apply_to_point(self, point: Vect2D) -> None:
+        """Rotate then offset *point* in place."""
         x = point.x
         y = point.y
         point.x = x * self._c - y * self._s
@@ -85,6 +119,7 @@ class RigidTransform2D(Transform2D):
         return angle + self.angle
 
     def transform(self, other: RigidTransform2D) -> None:
+        """Post-compose with *other*: self becomes ``other ∘ self``."""
         other.apply_to_point(self.offset)
         self.angle += other.angle
         self._c = cos(self.angle)
@@ -98,7 +133,8 @@ class RigidTransform2D(Transform2D):
     def translate(self, offset: Vect2D) -> None:
         self.offset += offset
 
-    def __neg__(self):
+    def __neg__(self) -> RigidTransform2D:
+        """Inverse transform. Note: not the arithmetic negation."""
         a = -self.angle
         x = self.offset.x * self._c + self.offset.y * self._s
         y = -self.offset.x * self._s + self.offset.y * self._c
@@ -106,27 +142,26 @@ class RigidTransform2D(Transform2D):
 
 
 class AffineTransform2D(RigidTransform2D):
-    def __init__(self,
+    """Scale + rotate + translate. Leaves SE(2) (not distance-preserving)."""
+
+    def __init__(
+        self,
         offset: Vect2D = Vect2D(0, 0),
         angle: float = 0,
-        factor: Vect2D = Vect2D(1, 1)
-    ):
+        factor: Vect2D = Vect2D(1, 1),
+    ) -> None:
         super().__init__(offset, angle)
-        self.factor = factor.copy()
+        self.factor: Vect2D = factor.copy()
 
     def copy(self) -> AffineTransform2D:
-        return AffineTransform2D(
-            self.offset,
-            self.angle,
-            self.factor
-        )
+        return AffineTransform2D(self.offset, self.angle, self.factor)
 
-    def scale(self, factor: Vect2D):
+    def scale(self, factor: Vect2D) -> None:
         self.factor.x *= factor.x
         self.factor.y *= factor.y
 
-    # Scale then rotate then offset the given point in place
     def apply_to_point(self, point: Vect2D) -> None:
+        """Scale, rotate, then offset *point* in place."""
         point.x *= self.factor.x
         point.y *= self.factor.y
         super().apply_to_point(point)

--- a/src/evo_lib/types/vect.py
+++ b/src/evo_lib/types/vect.py
@@ -24,21 +24,20 @@ class VectBase(ABC):
 
     __slots__ = ()
 
-    # Components getter
     @property
     @abstractmethod
     def _components(self) -> tuple[float, ...]:
-        """All components as an ordered tuple."""
-        pass
+        """All components as an ordered tuple.
 
-    # Components setter
-    @_components.setter
-    def _components(self, components: tuple[float, ...]) -> None:
-        pass
+        Concrete subclasses must also provide a ``@_components.setter``
+        that updates the backing attributes in place — it is used by the
+        in-place operators (``+=``, ``-=``, ``*=``).
+        """
+        ...
 
     @abstractmethod
     def copy(self) -> VectBase:
-        pass
+        ...
 
     # -- Arithmetic ---------------------------------------------------------
 
@@ -127,7 +126,7 @@ class Vect2D(VectBase):
 
     __slots__ = ("x", "y")
 
-    def __init__(self, x: float | int, y: float | int) -> None:
+    def __init__(self, x: float, y: float) -> None:
         self.x = float(x)
         self.y = float(y)
 
@@ -210,7 +209,7 @@ class Vect3D(VectBase):
         return (self.x, self.y, self.z)
 
     @_components.setter
-    def _components(self, components: tuple[float, float]) -> None:
+    def _components(self, components: tuple[float, float, float]) -> None:
         self.x, self.y, self.z = components
 
     # -- 3D-specific --------------------------------------------------------

--- a/tests/test_pose.py
+++ b/tests/test_pose.py
@@ -21,11 +21,11 @@ class TestPose2DConstruction:
         p = Pose2D(100, 200, 1.57)
         assert p.x == 100.0
         assert p.y == 200.0
-        assert math.isclose(p.heading, 1.57)
+        assert math.isclose(p.theta, 1.57)
 
     def test_theta_defaults_to_zero(self):
         p = Pose2D(10, 20)
-        assert p.heading == 0.0
+        assert p.theta == 0.0
 
 
 class TestPose2DPosition:
@@ -98,7 +98,7 @@ class TestPose2DCompose:
         sensor_global = robot.compose(sensor_local)
         assert math.isclose(sensor_global.x, 50, abs_tol=1e-9)
         assert math.isclose(sensor_global.y, 0, abs_tol=1e-9)
-        assert math.isclose(sensor_global.heading, math.pi / 2)
+        assert math.isclose(sensor_global.theta, math.pi / 2)
 
 
 class TestPose2DFromDict:
@@ -108,7 +108,7 @@ class TestPose2DFromDict:
 
     def test_missing_theta(self):
         p = Pose2D.from_dict({"x": 10, "y": 20})
-        assert p.heading == 0.0
+        assert p.theta == 0.0
 
     def test_from_config_like_dict(self):
         config = {
@@ -257,7 +257,7 @@ class TestPose3DCompose:
 
         assert math.isclose(result_2d.x, result_3d.x, abs_tol=1e-9)
         assert math.isclose(result_2d.y, result_3d.y, abs_tol=1e-9)
-        assert math.isclose(result_2d.heading, result_3d.yaw, abs_tol=1e-9)
+        assert math.isclose(result_2d.theta, result_3d.yaw, abs_tol=1e-9)
 
     def test_compose_with_pitch_only(self):
         """Pitch-only compose: sensor tilted 90° down sees (0,0,-100) → (100,0,0) in parent."""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -4,17 +4,21 @@ import math
 
 import pytest
 
-from evo_lib.types.transform import AffineTransform2D as AffineTransform
-from evo_lib.types.transform import RigidTransform2D as RigidTransform
+from evo_lib.types.pose import Pose2D
+from evo_lib.types.transform import (
+    AffineTransform2D,
+    MirrorTransform2D,
+    RigidTransform2D,
+)
 from evo_lib.types.vect import Vect2D
 
 
 class TestRigidTransformConstruction:
-    """Test RigidTransform instantiation and factory methods."""
+    """Test RigidTransform2D instantiation and factory methods."""
 
     def test_basic_construction(self):
         """Test basic construction with offset and angle."""
-        t = RigidTransform(Vect2D(1, 2), math.pi / 4)
+        t = RigidTransform2D(Vect2D(1, 2), math.pi / 4)
         assert t.offset == Vect2D(1, 2)
         assert t.angle == math.pi / 4
         assert t._c == pytest.approx(math.cos(math.pi / 4))
@@ -22,7 +26,7 @@ class TestRigidTransformConstruction:
 
     def test_identity(self):
         """Test identity transform creation."""
-        t = RigidTransform.create_identity()
+        t = RigidTransform2D.create_identity()
         assert t.offset == Vect2D(0, 0)
         assert t.angle == 0
         assert t._c == pytest.approx(1)
@@ -32,14 +36,14 @@ class TestRigidTransformConstruction:
         """Test rotation followed by translation."""
         angle = math.pi / 2
         offset = Vect2D(3, 4)
-        t = RigidTransform.create_rotate_then_translate(angle, offset)
+        t = RigidTransform2D.create_rotate_then_translate(angle, offset)
         assert t.angle == angle
         assert t.offset == offset
 
     def test_translate_only(self):
         """Test translation-only transform."""
         offset = Vect2D(5, -2)
-        t = RigidTransform.create_translate(offset)
+        t = RigidTransform2D.create_translate(offset)
         assert t.offset == offset
         assert t.angle == 0
 
@@ -47,7 +51,7 @@ class TestRigidTransformConstruction:
         """Test rotation around a specific point."""
         center = Vect2D(2, 3)
         angle = math.pi / 3
-        t = RigidTransform.create_rotate_arround(center, angle)
+        t = RigidTransform2D.create_rotate_around(center, angle)
 
         # Point at center should remain at center after transformation
         point = Vect2D(2, 3)
@@ -57,7 +61,7 @@ class TestRigidTransformConstruction:
 
     def test_copy(self):
         """Test that copy creates an independent instance."""
-        t1 = RigidTransform(Vect2D(1, 2), math.pi / 4)
+        t1 = RigidTransform2D(Vect2D(1, 2), math.pi / 4)
         t2 = t1.copy()
 
         # Verify values are the same
@@ -76,7 +80,7 @@ class TestRigidTransformApply:
 
     def test_apply_no_transformation(self):
         """Test apply with identity transform."""
-        t = RigidTransform.create_identity()
+        t = RigidTransform2D.create_identity()
         point = Vect2D(3, 4)
         t.apply_to_point(point)
         assert point.x == pytest.approx(3)
@@ -84,7 +88,7 @@ class TestRigidTransformApply:
 
     def test_apply_translation_only(self):
         """Test apply with translation only."""
-        t = RigidTransform.create_translate(Vect2D(2, -1))
+        t = RigidTransform2D.create_translate(Vect2D(2, -1))
         point = Vect2D(1, 3)
         t.apply_to_point(point)
         assert point.x == pytest.approx(3)
@@ -92,7 +96,7 @@ class TestRigidTransformApply:
 
     def test_apply_rotation_only(self):
         """Test apply with 90-degree rotation around origin."""
-        t = RigidTransform(Vect2D(0, 0), math.pi / 2)
+        t = RigidTransform2D(Vect2D(0, 0), math.pi / 2)
         point = Vect2D(1, 0)
         t.apply_to_point(point)
         # After 90-degree rotation: (1,0) -> (0,1)
@@ -102,7 +106,7 @@ class TestRigidTransformApply:
     def test_apply_rotation_and_translation(self):
         """Test apply with both rotation and translation."""
         # Rotate 90 degrees then translate by (2, 3)
-        t = RigidTransform(Vect2D(2, 3), math.pi / 2)
+        t = RigidTransform2D(Vect2D(2, 3), math.pi / 2)
         point = Vect2D(1, 0)
         t.apply_to_point(point)
         # (1,0) rotated 90 degrees -> (0,1), then translated -> (2,4)
@@ -111,7 +115,7 @@ class TestRigidTransformApply:
 
     def test_apply_negative_rotation(self):
         """Test apply with negative (clockwise) rotation."""
-        t = RigidTransform(Vect2D(0, 0), -math.pi / 2)
+        t = RigidTransform2D(Vect2D(0, 0), -math.pi / 2)
         point = Vect2D(0, 1)
         t.apply_to_point(point)
         # After -90-degree rotation: (0,1) -> (1,0)
@@ -124,8 +128,8 @@ class TestRigidTransformComposition:
 
     def test_transform_composition(self):
         """Test applying one transform to another."""
-        t1 = RigidTransform(Vect2D(1, 0), 0)  # translate by (1,0)
-        t2 = RigidTransform(Vect2D(2, 0), 0)  # translate by (2,0)
+        t1 = RigidTransform2D(Vect2D(1, 0), 0)  # translate by (1,0)
+        t2 = RigidTransform2D(Vect2D(2, 0), 0)  # translate by (2,0)
 
         t1.transform(t2)
 
@@ -135,8 +139,8 @@ class TestRigidTransformComposition:
 
     def test_transform_with_rotation(self):
         """Test composition with rotation."""
-        t1 = RigidTransform(Vect2D(1, 0), 0)
-        t2 = RigidTransform(Vect2D(0, 0), math.pi / 2)
+        t1 = RigidTransform2D(Vect2D(1, 0), 0)
+        t2 = RigidTransform2D(Vect2D(0, 0), math.pi / 2)
 
         initial_angle = t1.angle
         t1.transform(t2)
@@ -150,7 +154,7 @@ class TestRigidTransformModification:
 
     def test_rotate(self):
         """Test adding rotation to transform."""
-        t = RigidTransform(Vect2D(1, 2), 0)
+        t = RigidTransform2D(Vect2D(1, 2), 0)
         t.rotate(math.pi / 4)
 
         assert t.angle == pytest.approx(math.pi / 4)
@@ -159,7 +163,7 @@ class TestRigidTransformModification:
 
     def test_translate(self):
         """Test adding translation to transform."""
-        t = RigidTransform(Vect2D(1, 2), 0)
+        t = RigidTransform2D(Vect2D(1, 2), 0)
         t.translate(Vect2D(3, -1))
 
         assert t.offset.x == pytest.approx(4)
@@ -167,7 +171,7 @@ class TestRigidTransformModification:
 
     def test_rotate_accumulates(self):
         """Test that rotate accumulates."""
-        t = RigidTransform(Vect2D(0, 0), math.pi / 4)
+        t = RigidTransform2D(Vect2D(0, 0), math.pi / 4)
         t.rotate(math.pi / 4)
 
         assert t.angle == pytest.approx(math.pi / 2)
@@ -178,7 +182,7 @@ class TestRigidTransformInversion:
 
     def test_negate_translation_only(self):
         """Test negation of pure translation."""
-        t = RigidTransform(Vect2D(3, 4), 0)
+        t = RigidTransform2D(Vect2D(3, 4), 0)
         neg_t = -t
 
         assert neg_t.offset.x == pytest.approx(-3)
@@ -187,7 +191,7 @@ class TestRigidTransformInversion:
 
     def test_negate_rotation_only(self):
         """Test negation of pure rotation."""
-        t = RigidTransform(Vect2D(0, 0), math.pi / 3)
+        t = RigidTransform2D(Vect2D(0, 0), math.pi / 3)
         neg_t = -t
 
         assert neg_t.angle == pytest.approx(-math.pi / 3)
@@ -196,7 +200,7 @@ class TestRigidTransformInversion:
 
     def test_negate_combined(self):
         """Test negation of combined rotation and translation."""
-        t = RigidTransform(Vect2D(2, 0), math.pi / 2)
+        t = RigidTransform2D(Vect2D(2, 0), math.pi / 2)
         neg_t = -t
 
         # Negated angle
@@ -211,7 +215,7 @@ class TestRigidTransformInversion:
 
     def test_double_negation_identity(self):
         """Test that double negation returns to original."""
-        t = RigidTransform(Vect2D(3, 4), math.pi / 6)
+        t = RigidTransform2D(Vect2D(3, 4), math.pi / 6)
         double_neg = -(-t)
 
         assert double_neg.offset.x == pytest.approx(t.offset.x)
@@ -220,7 +224,7 @@ class TestRigidTransformInversion:
 
     def test_inverse_cancels_transform(self):
         """Test that inverse transform cancels original."""
-        t = RigidTransform(Vect2D(2, 3), math.pi / 4)
+        t = RigidTransform2D(Vect2D(2, 3), math.pi / 4)
         neg_t = -t
 
         # Point after transform then inverse should return to original
@@ -234,11 +238,11 @@ class TestRigidTransformInversion:
 
 
 class TestAffineTransformConstruction:
-    """Test AffineTransform instantiation."""
+    """Test AffineTransform2D instantiation."""
 
     def test_basic_construction(self):
         """Test basic construction with defaults."""
-        t = AffineTransform()
+        t = AffineTransform2D()
         assert t.offset == Vect2D(0, 0)
         assert t.angle == 0
         assert t.factor == Vect2D(1, 1)
@@ -248,7 +252,7 @@ class TestAffineTransformConstruction:
         offset = Vect2D(1, 2)
         angle = math.pi / 3
         scale = Vect2D(2, 3)
-        t = AffineTransform(offset, angle, scale)
+        t = AffineTransform2D(offset, angle, scale)
 
         assert t.offset == offset
         assert t.angle == pytest.approx(angle)
@@ -256,7 +260,7 @@ class TestAffineTransformConstruction:
 
     def test_copy(self):
         """Test that copy creates an independent instance."""
-        t1 = AffineTransform(Vect2D(1, 2), math.pi / 4, Vect2D(2, 3))
+        t1 = AffineTransform2D(Vect2D(1, 2), math.pi / 4, Vect2D(2, 3))
         t2 = t1.copy()
 
         assert t2.offset == t1.offset
@@ -273,7 +277,7 @@ class TestAffineTransformScale:
 
     def test_scale_single(self):
         """Test applying a single scale."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(1, 1))
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(1, 1))
         t.scale(Vect2D(2, 3))
 
         assert t.factor.x == pytest.approx(2)
@@ -281,7 +285,7 @@ class TestAffineTransformScale:
 
     def test_scale_accumulates(self):
         """Test that scale accumulates."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(2, 2))
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(2, 2))
         t.scale(Vect2D(3, 4))
 
         assert t.factor.x == pytest.approx(6)
@@ -289,7 +293,7 @@ class TestAffineTransformScale:
 
     def test_scale_asymmetric(self):
         """Test asymmetric scaling."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(1, 1))
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(1, 1))
         t.scale(Vect2D(2, 0.5))
 
         assert t.factor.x == pytest.approx(2)
@@ -301,7 +305,7 @@ class TestAffineTransformApply:
 
     def test_apply_no_transformation(self):
         """Test apply with identity affine transform."""
-        t = AffineTransform()
+        t = AffineTransform2D()
         point = Vect2D(3, 4)
         t.apply_to_point(point)
         assert point.x == pytest.approx(3)
@@ -309,7 +313,7 @@ class TestAffineTransformApply:
 
     def test_apply_scale_only(self):
         """Test apply with scaling only."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(2, 3))
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(2, 3))
         point = Vect2D(1, 1)
         t.apply_to_point(point)
         assert point.x == pytest.approx(2)
@@ -318,7 +322,7 @@ class TestAffineTransformApply:
     def test_apply_scale_then_rotate(self):
         """Test scale then rotation then translation."""
         # Scale by 2, rotate 90 degrees, translate by (1, 1)
-        t = AffineTransform(Vect2D(1, 1), math.pi / 2, Vect2D(2, 1))
+        t = AffineTransform2D(Vect2D(1, 1), math.pi / 2, Vect2D(2, 1))
         point = Vect2D(1, 0)
         t.apply_to_point(point)
 
@@ -330,7 +334,7 @@ class TestAffineTransformApply:
 
     def test_apply_non_uniform_scale_then_rotate(self):
         """Test non-uniform scale with rotation."""
-        t = AffineTransform(Vect2D(0, 0), math.pi / 2, Vect2D(2, 3))
+        t = AffineTransform2D(Vect2D(0, 0), math.pi / 2, Vect2D(2, 3))
         point = Vect2D(1, 1)
         t.apply_to_point(point)
 
@@ -341,7 +345,7 @@ class TestAffineTransformApply:
 
     def test_apply_scale_zero(self):
         """Test scaling with zero factor (degenerate case)."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(0, 0))
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(0, 0))
         point = Vect2D(5, 10)
         t.apply_to_point(point)
 
@@ -350,19 +354,86 @@ class TestAffineTransformApply:
 
 
 class TestAffineTransformInheritance:
-    """Test that AffineTransform correctly inherits from RigidTransform."""
+    """Test that AffineTransform2D correctly inherits from RigidTransform2D."""
 
     def test_rotate_method(self):
-        """Test that rotate method from RigidTransform works."""
-        t = AffineTransform(Vect2D(0, 0), 0, Vect2D(1, 1))
+        """Test that rotate method from RigidTransform2D works."""
+        t = AffineTransform2D(Vect2D(0, 0), 0, Vect2D(1, 1))
         t.rotate(math.pi / 4)
 
         assert t.angle == pytest.approx(math.pi / 4)
 
     def test_translate_method(self):
-        """Test that translate method from RigidTransform works."""
-        t = AffineTransform(Vect2D(1, 1), 0, Vect2D(1, 1))
+        """Test that translate method from RigidTransform2D works."""
+        t = AffineTransform2D(Vect2D(1, 1), 0, Vect2D(1, 1))
         t.translate(Vect2D(2, 3))
 
         assert t.offset.x == pytest.approx(3)
         assert t.offset.y == pytest.approx(4)
+
+
+class TestMirrorTransform2D:
+    """Test axial symmetry transform."""
+
+    def test_vertical_mirror_flips_y(self):
+        t = MirrorTransform2D(Vect2D(0, 0), vertical=True)
+        point = Vect2D(3, 5)
+        t.apply_to_point(point)
+        assert point.x == pytest.approx(3)
+        assert point.y == pytest.approx(-5)
+
+    def test_horizontal_mirror_flips_x(self):
+        t = MirrorTransform2D(Vect2D(0, 0), vertical=False)
+        point = Vect2D(3, 5)
+        t.apply_to_point(point)
+        assert point.x == pytest.approx(-3)
+        assert point.y == pytest.approx(5)
+
+    def test_mirror_with_offset(self):
+        t = MirrorTransform2D(Vect2D(10, 0), vertical=True)
+        point = Vect2D(3, 5)
+        t.apply_to_point(point)
+        assert point.x == pytest.approx(13)
+        assert point.y == pytest.approx(-5)
+
+    def test_angle_flip_vertical(self):
+        t = MirrorTransform2D(Vect2D(0, 0), vertical=True)
+        assert t.apply_to_angle(math.pi / 3) == pytest.approx(-math.pi / 3)
+
+    def test_angle_flip_horizontal(self):
+        t = MirrorTransform2D(Vect2D(0, 0), vertical=False)
+        assert t.apply_to_angle(math.pi / 3) == pytest.approx(math.pi - math.pi / 3)
+
+    def test_copy_is_independent(self):
+        t1 = MirrorTransform2D(Vect2D(10, 20), vertical=True)
+        t2 = t1.copy()
+        t1._offset.x = 99
+        assert t2._offset.x == 10
+
+
+class TestApplyToPose:
+    """Test that apply_to_pose actually mutates the pose."""
+
+    def test_rigid_apply_to_pose_translation(self):
+        t = RigidTransform2D(Vect2D(10, 20), 0)
+        pose = Pose2D(1, 2, 0)
+        t.apply_to_pose(pose)
+        assert pose.x == pytest.approx(11)
+        assert pose.y == pytest.approx(22)
+        assert pose.theta == pytest.approx(0)
+
+    def test_rigid_apply_to_pose_rotation(self):
+        t = RigidTransform2D(Vect2D(0, 0), math.pi / 2)
+        pose = Pose2D(1, 0, 0)
+        t.apply_to_pose(pose)
+        assert pose.x == pytest.approx(0, abs=1e-10)
+        assert pose.y == pytest.approx(1)
+        assert pose.theta == pytest.approx(math.pi / 2)
+
+    def test_apply_to_pose_updates_cached_trig(self):
+        """After apply_to_pose, the cached (_c, _s) must match the new theta."""
+        t = RigidTransform2D(Vect2D(0, 0), math.pi / 4)
+        pose = Pose2D(0, 0, 0)
+        t.apply_to_pose(pose)
+        assert pose._c == pytest.approx(math.cos(math.pi / 4))
+        assert pose._s == pytest.approx(math.sin(math.pi / 4))


### PR DESCRIPTION
Stacked on top of #57. Drops `Pose(Vect)` inheritance (poses are in SE(n), not vectors — inherited arithmetic was silently wrong), restores `theta` to match existing tests and config, caches `cos`/`sin` in `Pose2D` for hot paths, and wires up `MirrorTransform2D` and `apply_to_pose` which were both dead code. Also adds three glossary pages under `docs/glossary/types/` (vocabulary, examples, performance).