### PR TITLE
feat(drivers): Constellation board driver for Hololutek

### DIFF
--- a/src/evo_lib/drivers/board/__init__.py
+++ b/src/evo_lib/drivers/board/__init__.py
@@ -1,0 +1,15 @@
+"""Custom Evolutek boards: aggregators of standalone chips with no MCU.
+
+A board driver in this package is a pure composition helper over chip-level
+drivers (MCP23017, PCA9685, TCA9548A, ...). It owns the child peripherals,
+chains their lifecycle, and exposes them through get_subcomponents().
+
+Boards with a MCU running custom firmware (e.g. Carte Stepper, Carte
+Localisation) do NOT belong here: they speak a bespoke protocol and live
+under their transport (CAN, serial, ...) rather than in this aggregation
+layer.
+"""
+
+from evo_lib.drivers.board.base import BoardDriver
+
+__all__ = ["BoardDriver"]

--- a/src/evo_lib/drivers/board/base.py
+++ b/src/evo_lib/drivers/board/base.py
@@ -1,0 +1,49 @@
+"""BoardDriver: base class for passthrough Evolutek boards.
+
+A passthrough board has no microcontroller of its own. The parent bus
+(I2C, SPI, GPIO, ...) traverses the board to reach the underlying chips,
+so the driver never issues a "board-level" command: it just owns the
+children and chains their lifecycle.
+
+Subclasses instantiate the concrete children in their own __init__ and
+hand the list to super().__init__(). The base class stays agnostic about
+the number and kind of parent buses: a board mixing I2C + SPI + native
+GPIO is fine, each child carries its own dependencies.
+"""
+
+from evo_lib.logger import Logger
+from evo_lib.peripheral import InterfaceHolder, Peripheral
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class BoardDriver(InterfaceHolder):
+    """Composition helper for passthrough boards.
+
+    Owns a fixed list of child peripherals, chains init() in declaration
+    order and close() in reverse. Exposes children through get_subcomponents()
+    so the rest of the library (registry, introspection, virtual swaps) sees
+    the full peripheral tree.
+    """
+
+    def __init__(self, name: str, logger: Logger, children: list[Peripheral]):
+        super().__init__(name)
+        self._log = logger
+        self._children = children
+
+    def init(self) -> Task[()]:
+        for child in self._children:
+            child.init().wait()
+        self._log.info(f"Board '{self.name}' initialized ({len(self._children)} sub-components)")
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        # Reverse order so dependents close before their dependencies.
+        for child in reversed(self._children):
+            try:
+                child.close()
+            except Exception as exc:
+                self._log.warning(f"Board '{self.name}': error closing '{child.name}': {exc}")
+        self._log.info(f"Board '{self.name}' closed")
+
+    def get_subcomponents(self) -> list[Peripheral]:
+        return list(self._children)

--- a/src/evo_lib/drivers/board/carte_mobile.py
+++ b/src/evo_lib/drivers/board/carte_mobile.py
@@ -1,0 +1,145 @@
+"""Carte Mobile driver: passthrough board on the Evolutek PAL robot arm.
+
+Hardware (KiCad: carte-actionneurs branch cartes-bras-pal-2026, folder
+"Cartes PAL 2026/Carte Mobile/"):
+- 1x MCP23017: 16-pin I2C GPIO expander
+- 1x TCA9548APWR: 8-channel I2C multiplexer
+- No MCU, no firmware: the RPi I2C bus traverses the card and addresses
+  each chip directly via its own I2C address.
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.drivers.board.base import BoardDriver
+from evo_lib.drivers.gpio.mcp23017 import MCP23017Chip
+from evo_lib.drivers.gpio.virtual import GPIOChipVirtual
+from evo_lib.drivers.i2c.tca9548a import TCA9548A, TCA9548AVirtual
+from evo_lib.interfaces.i2c import I2C
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral
+from evo_lib.registry import Registry
+
+
+class CarteMobile(BoardDriver):
+    """Carte Mobile: MCP23017 GPIO expander + TCA9548A I2C multiplexer.
+
+    Both chips share the same parent I2C bus and are differentiated by
+    their I2C addresses. Helper accessors re-expose children for ergonomics.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        gpio_address: int = 0x20,
+        mux_address: int = 0x70,
+    ):
+        self._gpio = MCP23017Chip(
+            name=f"{name}.gpio",
+            bus=bus,
+            address=gpio_address,
+            logger=logger.get_sublogger(f"{name}.gpio").get_stdlib_logger(),
+        )
+        self._mux = TCA9548A(
+            name=f"{name}.mux",
+            logger=logger.get_sublogger(f"{name}.mux"),
+            parent_bus=bus,
+            address=mux_address,
+        )
+        super().__init__(name, logger, children=[self._gpio, self._mux])
+
+    @property
+    def gpio(self) -> MCP23017Chip:
+        return self._gpio
+
+    @property
+    def mux(self) -> TCA9548A:
+        return self._mux
+
+
+class CarteMobileDefinition(DriverDefinition):
+    """Factory for CarteMobile from config args. Parent bus resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("gpio_address", ArgTypes.U8(), 0x20)
+        defn.add_optional("mux_address", ArgTypes.U8(), 0x70)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> CarteMobile:
+        name = args.get_name()
+        return CarteMobile(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            bus=args.get("bus"),
+            gpio_address=args.get("gpio_address"),
+            mux_address=args.get("mux_address"),
+        )
+
+
+class CarteMobileVirtual(BoardDriver):
+    """Virtual drop-in twin of CarteMobile: substitutes each child with its
+    virtual equivalent. Interface is identical so consumers swap transparently.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        gpio_address: int = 0x20,
+        mux_address: int = 0x70,
+    ):
+        self._gpio = GPIOChipVirtual(
+            name=f"{name}.gpio",
+            logger=logger.get_sublogger(f"{name}.gpio"),
+            address=gpio_address,
+        )
+        self._mux = TCA9548AVirtual(
+            name=f"{name}.mux",
+            logger=logger.get_sublogger(f"{name}.mux"),
+            parent_bus=bus,
+            address=mux_address,
+        )
+        super().__init__(name, logger, children=[self._gpio, self._mux])
+
+    @property
+    def gpio(self) -> GPIOChipVirtual:
+        return self._gpio
+
+    @property
+    def mux(self) -> TCA9548AVirtual:
+        return self._mux
+
+
+class CarteMobileVirtualDefinition(DriverDefinition):
+    """Factory for CarteMobileVirtual from config args."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("gpio_address", ArgTypes.U8(), 0x20)
+        defn.add_optional("mux_address", ArgTypes.U8(), 0x70)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> CarteMobileVirtual:
+        name = args.get_name()
+        return CarteMobileVirtual(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            bus=args.get("bus"),
+            gpio_address=args.get("gpio_address"),
+            mux_address=args.get("mux_address"),
+        )

--- a/src/evo_lib/drivers/board/constellation.py
+++ b/src/evo_lib/drivers/board/constellation.py
@@ -1,0 +1,166 @@
+"""Constellation driver: passthrough board on the Hololutek robot.
+
+Hardware (KiCad: carte-actionneurs branch Constellation-Hololutek-2026,
+folder "Constellations actionneurs/Hololutek 2026 - {Repartiteur,Doigts}/"):
+- 1x PCA9685PW: 16-channel PWM servo controller (servo outputs J1-J8)
+- 1x TCA9548APWR: 8-channel I2C multiplexer (for color sensors on the
+  Doigts sub-board)
+- AX12 connectors (J12-J15) traverse the board passively to the parent
+  AX12 daisy chain: no chip on the Constellation handles smart-servo
+  traffic.
+- No MCU, no firmware. The RPi I2C bus reaches both chips directly.
+
+Three Constellations share the robot I2C bus on Hololutek (one per face of
+the hexagonal frame). Address offsets are set by jumpers JP1-JP6 on PCA9685
+and TCA9548A: base addresses 0x40 and 0x70 plus a per-face offset.
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverDefinition, DriverInitArgs, DriverInitArgsDefinition
+from evo_lib.drivers.board.base import BoardDriver
+from evo_lib.drivers.i2c.tca9548a import TCA9548A, TCA9548AVirtual
+from evo_lib.drivers.pwm.pca9685 import PCA9685Chip, PCA9685ChipVirtual
+from evo_lib.interfaces.i2c import I2C
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral
+from evo_lib.registry import Registry
+
+_DEFAULT_PWM_ADDRESS = 0x40
+_DEFAULT_MUX_ADDRESS = 0x70
+_DEFAULT_SERVO_FREQ_HZ = 50.0
+
+
+class Constellation(BoardDriver):
+    """Constellation: PCA9685 servo controller + TCA9548A I2C multiplexer.
+
+    Both chips share the same parent I2C bus, differentiated by addresses
+    set via board jumpers. Helper accessors re-expose children for
+    ergonomics (get_servo_channel, get_sensor_bus).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        pwm_address: int = _DEFAULT_PWM_ADDRESS,
+        mux_address: int = _DEFAULT_MUX_ADDRESS,
+        servo_freq_hz: float = _DEFAULT_SERVO_FREQ_HZ,
+    ):
+        self._pwm = PCA9685Chip(
+            name=f"{name}.pwm",
+            logger=logger.get_sublogger(f"{name}.pwm"),
+            bus=bus,
+            address=pwm_address,
+            freq_hz=servo_freq_hz,
+        )
+        self._mux = TCA9548A(
+            name=f"{name}.mux",
+            logger=logger.get_sublogger(f"{name}.mux"),
+            parent_bus=bus,
+            address=mux_address,
+        )
+        super().__init__(name, logger, children=[self._pwm, self._mux])
+
+    @property
+    def pwm(self) -> PCA9685Chip:
+        return self._pwm
+
+    @property
+    def mux(self) -> TCA9548A:
+        return self._mux
+
+
+class ConstellationDefinition(DriverDefinition):
+    """Factory for Constellation from config args. Parent bus resolved by name."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("pwm_address", ArgTypes.U8(), _DEFAULT_PWM_ADDRESS)
+        defn.add_optional("mux_address", ArgTypes.U8(), _DEFAULT_MUX_ADDRESS)
+        defn.add_optional("servo_freq_hz", ArgTypes.F32(), _DEFAULT_SERVO_FREQ_HZ)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> Constellation:
+        name = args.get_name()
+        return Constellation(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            bus=args.get("bus"),
+            pwm_address=args.get("pwm_address"),
+            mux_address=args.get("mux_address"),
+            servo_freq_hz=args.get("servo_freq_hz"),
+        )
+
+
+class ConstellationVirtual(BoardDriver):
+    """Virtual drop-in twin of Constellation: virtual PWM + virtual mux.
+
+    Same public interface as Constellation for transparent simulation swap.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        bus: I2C,
+        pwm_address: int = _DEFAULT_PWM_ADDRESS,
+        mux_address: int = _DEFAULT_MUX_ADDRESS,
+        servo_freq_hz: float = _DEFAULT_SERVO_FREQ_HZ,
+    ):
+        self._pwm = PCA9685ChipVirtual(
+            name=f"{name}.pwm",
+            logger=logger.get_sublogger(f"{name}.pwm"),
+            bus=bus,
+            address=pwm_address,
+            freq_hz=servo_freq_hz,
+        )
+        self._mux = TCA9548AVirtual(
+            name=f"{name}.mux",
+            logger=logger.get_sublogger(f"{name}.mux"),
+            parent_bus=bus,
+            address=mux_address,
+        )
+        super().__init__(name, logger, children=[self._pwm, self._mux])
+
+    @property
+    def pwm(self) -> PCA9685ChipVirtual:
+        return self._pwm
+
+    @property
+    def mux(self) -> TCA9548AVirtual:
+        return self._mux
+
+
+class ConstellationVirtualDefinition(DriverDefinition):
+    """Factory for ConstellationVirtual from config args."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__()
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("bus", ArgTypes.Component(I2C, self._peripherals))
+        defn.add_optional("pwm_address", ArgTypes.U8(), _DEFAULT_PWM_ADDRESS)
+        defn.add_optional("mux_address", ArgTypes.U8(), _DEFAULT_MUX_ADDRESS)
+        defn.add_optional("servo_freq_hz", ArgTypes.F32(), _DEFAULT_SERVO_FREQ_HZ)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> ConstellationVirtual:
+        name = args.get_name()
+        return ConstellationVirtual(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            bus=args.get("bus"),
+            pwm_address=args.get("pwm_address"),
+            mux_address=args.get("mux_address"),
+            servo_freq_hz=args.get("servo_freq_hz"),
+        )

--- a/tests/test_board_base.py
+++ b/tests/test_board_base.py
@@ -1,0 +1,63 @@
+"""Lifecycle tests for the BoardDriver base class.
+
+Uses trivial fake children to verify init/close ordering without tying the
+test to any concrete chip driver.
+"""
+
+from evo_lib.drivers.board.base import BoardDriver
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class _FakeChild(Peripheral):
+    def __init__(self, name: str, events: list[tuple[str, str]]):
+        super().__init__(name)
+        self._events = events
+
+    def init(self) -> Task[()]:
+        self._events.append(("init", self.name))
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self._events.append(("close", self.name))
+
+
+def test_board_driver_chains_lifecycle_in_order():
+    events: list[tuple[str, str]] = []
+    children = [_FakeChild(n, events) for n in ("a", "b", "c")]
+    board = BoardDriver(name="test_board", logger=Logger("test"), children=children)
+
+    board.init().wait()
+    board.close()
+
+    assert events == [
+        ("init", "a"),
+        ("init", "b"),
+        ("init", "c"),
+        ("close", "c"),
+        ("close", "b"),
+        ("close", "a"),
+    ]
+    assert board.get_subcomponents() == children
+
+
+def test_board_driver_close_continues_after_child_failure():
+    events: list[tuple[str, str]] = []
+
+    class _RaisingChild(_FakeChild):
+        def close(self) -> None:
+            self._events.append(("close", self.name))
+            raise RuntimeError("boom")
+
+    children = [_FakeChild("a", events), _RaisingChild("b", events), _FakeChild("c", events)]
+    board = BoardDriver(name="test_board", logger=Logger("test"), children=children)
+
+    board.init().wait()
+    board.close()
+
+    assert [e for e in events if e[0] == "close"] == [
+        ("close", "c"),
+        ("close", "b"),
+        ("close", "a"),
+    ]

--- a/tests/test_carte_mobile.py
+++ b/tests/test_carte_mobile.py
@@ -1,0 +1,36 @@
+"""Composition tests for the Carte Mobile board driver and its virtual twin."""
+
+import pytest
+
+from evo_lib.drivers.board.carte_mobile import CarteMobile, CarteMobileVirtual
+from evo_lib.drivers.gpio.mcp23017 import MCP23017Chip
+from evo_lib.drivers.gpio.virtual import GPIOChipVirtual
+from evo_lib.drivers.i2c.tca9548a import TCA9548A, TCA9548AVirtual
+from evo_lib.drivers.i2c.virtual import I2CVirtual
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def bus():
+    b = I2CVirtual()
+    b.init()
+    b.add_device(0x20)
+    b.add_device(0x70)
+    yield b
+    b.close()
+
+
+def test_carte_mobile_wires_real_children(bus):
+    card = CarteMobile(name="bras_pal", logger=Logger("test"), bus=bus)
+    assert isinstance(card.gpio, MCP23017Chip)
+    assert isinstance(card.mux, TCA9548A)
+    assert card.get_subcomponents() == [card.gpio, card.mux]
+
+
+def test_carte_mobile_virtual_swaps_every_child():
+    bus = I2CVirtual()
+    bus.init()
+    card = CarteMobileVirtual(name="bras_pal", logger=Logger("test"), bus=bus)
+    assert isinstance(card.gpio, GPIOChipVirtual)
+    assert isinstance(card.mux, TCA9548AVirtual)
+    assert card.get_subcomponents() == [card.gpio, card.mux]

--- a/tests/test_constellation.py
+++ b/tests/test_constellation.py
@@ -1,0 +1,27 @@
+"""Composition tests for the Constellation board driver and its virtual twin."""
+
+from evo_lib.drivers.board.constellation import Constellation, ConstellationVirtual
+from evo_lib.drivers.i2c.tca9548a import TCA9548A, TCA9548AVirtual
+from evo_lib.drivers.i2c.virtual import I2CVirtual
+from evo_lib.drivers.pwm.pca9685 import PCA9685Chip, PCA9685ChipVirtual
+from evo_lib.logger import Logger
+
+
+def test_constellation_wires_real_children():
+    bus = I2CVirtual()
+    bus.init()
+    bus.add_device(0x40)
+    bus.add_device(0x70)
+    card = Constellation(name="face_a", logger=Logger("test"), bus=bus)
+    assert isinstance(card.pwm, PCA9685Chip)
+    assert isinstance(card.mux, TCA9548A)
+    assert card.get_subcomponents() == [card.pwm, card.mux]
+
+
+def test_constellation_virtual_swaps_every_child():
+    bus = I2CVirtual()
+    bus.init()
+    card = ConstellationVirtual(name="face_a", logger=Logger("test"), bus=bus)
+    assert isinstance(card.pwm, PCA9685ChipVirtual)
+    assert isinstance(card.mux, TCA9548AVirtual)
+    assert card.get_subcomponents() == [card.pwm, card.mux]


### PR DESCRIPTION
Adds the Constellation driver, second concrete board on top of the `drivers/board/` subpackage introduced in #74.

**Depends on #74** (base class + Carte Mobile). Merge #74 first, this PR will then rebase onto master to a clean single-commit diff.

Constellation composes a PCA9685 servo controller and a TCA9548A I2C mux on a shared parent I2C bus, with addresses set by board jumpers so three instances coexist on the Hololutek hexagonal frame (one per face). AX12 connectors are passive and stay outside the driver (the smart-servo daisy chain bypasses the board).

`ConstellationVirtual` drop-in twin composes `PCA9685ChipVirtual` + `TCA9548AVirtual` for transparent simulation swaps.

Hardware: `carte-actionneurs` branch `Constellation-Hololutek-2026`, folder `Constellations actionneurs/Hololutek 2026 - {Repartiteur,Doigts}/` (will never merge to main, holo-specific board).