### PR TITLE
Improve AX-12 driver: typed errors, no-echo default, REPL commands

### DIFF
--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -65,6 +65,12 @@ _HEADER_B1 = 0xFF
 # motor load can drop a packet every few hundred transactions.
 _DEFAULT_RETRIES = 3
 _DEFAULT_RETRY_DELAY = 0.025
+# USB2AX (Xevelabs, the standard Evolutek dongle) does not echo TX on RX: it
+# handles half-duplex direction internally in its ATmega firmware. Only the
+# older USB2Dynamixel (FT232 + external tri-state) echoes. Default to no-echo
+# because that matches the hardware actually used on the robot; set echo=True
+# only if you plug a USB2Dynamixel in.
+_DEFAULT_ECHO = False
 
 # Max AX-12 packet size we ever emit: 2 header + id + len + inst + reg + up to
 # 2 data bytes + checksum = 9. Round up for headroom on future register writes.
@@ -97,6 +103,7 @@ class AX12Bus(InterfaceHolder):
         baudrate: int = _DEFAULT_BAUDRATE,
         retries: int = _DEFAULT_RETRIES,
         retry_delay: float = _DEFAULT_RETRY_DELAY,
+        echo: bool = _DEFAULT_ECHO,
     ):
         super().__init__(name)
         self._log = logger
@@ -104,10 +111,11 @@ class AX12Bus(InterfaceHolder):
         self._baudrate = baudrate
         self._retries = retries
         self._retry_delay = retry_delay
+        self._echo = echo
         self._lock = threading.Lock()
         self._servos: dict[int, "AX12"] = {}
         # Reusable TX buffer (hot path): avoids per-call bytearray allocation on
-        # every write/read. Safe under the bus lock — only one packet is ever
+        # every write/read. Safe under the bus lock, only one packet is ever
         # being built at a time. Matters on RPi 3 B+ where GC pressure adds up.
         self._tx_buf = bytearray(_TX_BUF_SIZE)
 
@@ -200,13 +208,16 @@ class AX12Bus(InterfaceHolder):
         return self._read_status(servo_id)
 
     def _send_and_drop_echo(self, packet: bytes) -> None:
-        """Write then discard the local echo (half-duplex USB2AX).
+        """Write then, if the dongle echoes, discard the local echo.
 
-        Reading exactly len(packet) bytes right after the write eats the
-        guaranteed echo without racing the servo's reply.
+        USB2AX (Xevelabs, default) does not echo: we skip the drain read
+        entirely, which is what the legacy libdxl.so-based stack has been
+        doing in production for years. USB2Dynamixel-style dongles that
+        mirror TX onto RX require echo=True in the constructor.
         """
         self._bus.write(packet)
-        _ = self._bus.read(len(packet))
+        if self._echo:
+            _ = self._bus.read(len(packet))
 
     def _read_status(self, expected_id: int) -> bytes:
         """Read and validate a Dynamixel 1.0 status packet.
@@ -410,9 +421,11 @@ class AX12BusVirtual(AX12Bus):
         baudrate: int = _DEFAULT_BAUDRATE,
         retries: int = _DEFAULT_RETRIES,
         retry_delay: float = _DEFAULT_RETRY_DELAY,
+        echo: bool = _DEFAULT_ECHO,
     ):
         super().__init__(
-            name, logger, bus, baudrate=baudrate, retries=retries, retry_delay=retry_delay
+            name, logger, bus,
+            baudrate=baudrate, retries=retries, retry_delay=retry_delay, echo=echo,
         )
         # servo_id -> {register_addr: byte}
         self._registers: dict[int, dict[int, int]] = {}
@@ -475,6 +488,7 @@ class AX12BusDefinition(DriverDefinition):
         defn.add_optional("baudrate", ArgTypes.U32(), _DEFAULT_BAUDRATE)
         defn.add_optional("retries", ArgTypes.U32(), _DEFAULT_RETRIES)
         defn.add_optional("retry_delay", ArgTypes.F32(), _DEFAULT_RETRY_DELAY)
+        defn.add_optional("echo", ArgTypes.Bool(), _DEFAULT_ECHO)
         return defn
 
     def create(self, args: DriverInitArgs) -> AX12Bus:
@@ -485,6 +499,7 @@ class AX12BusDefinition(DriverDefinition):
             baudrate=args.get("baudrate"),
             retries=args.get("retries"),
             retry_delay=args.get("retry_delay"),
+            echo=args.get("echo"),
         )
 
 
@@ -506,6 +521,7 @@ class AX12BusVirtualDefinition(DriverDefinition):
         defn.add_optional("baudrate", ArgTypes.U32(), _DEFAULT_BAUDRATE)
         defn.add_optional("retries", ArgTypes.U32(), _DEFAULT_RETRIES)
         defn.add_optional("retry_delay", ArgTypes.F32(), _DEFAULT_RETRY_DELAY)
+        defn.add_optional("echo", ArgTypes.Bool(), _DEFAULT_ECHO)
         return defn
 
     def create(self, args: DriverInitArgs) -> AX12BusVirtual:
@@ -516,6 +532,7 @@ class AX12BusVirtualDefinition(DriverDefinition):
             baudrate=args.get("baudrate"),
             retries=args.get("retries"),
             retry_delay=args.get("retry_delay"),
+            echo=args.get("echo"),
         )
 
 

--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -16,6 +16,7 @@ import time
 
 from evo_lib.argtypes import ArgTypes
 from evo_lib.driver_definition import (
+    DriverCommands,
     DriverDefinition,
     DriverInitArgs,
     DriverInitArgsDefinition,
@@ -262,6 +263,8 @@ class AX12(SmartServo):
     Bus-agnostic: works with any AX12Bus (real or virtual).
     """
 
+    commands = DriverCommands(parents=[SmartServo.commands])
+
     def __init__(self, name: str, logger: Logger, bus: AX12Bus, servo_id: int):
         super().__init__(name)
         self._log = logger
@@ -302,6 +305,7 @@ class AX12(SmartServo):
         self._write_word(_GOAL_POSITION_L, position)
         return ImmediateResultTask()
 
+    @commands.register(args=[], result=[])
     def reset(self) -> Task[()]:
         """Move to the mechanical center (150°)."""
         return self.move_to_position(_POSITION_CENTER)
@@ -335,6 +339,10 @@ class AX12(SmartServo):
         self._write_word(_MOVING_SPEED_L, round(speed * _SPEED_MAX))
         return ImmediateResultTask()
 
+    @commands.register(
+        args=[],
+        result=[("speed", ArgTypes.I16(help="Present speed, signed magnitude in [-1023, 1023]"))],
+    )
     def get_speed(self) -> Task[int]:
         """Present speed as a signed magnitude in [-1023, 1023].
 
@@ -347,6 +355,10 @@ class AX12(SmartServo):
 
     # --- Load (motor current) ---
 
+    @commands.register(
+        args=[],
+        result=[("load", ArgTypes.I16(help="Present load, signed magnitude in [-1023, 1023]"))],
+    )
     def get_load(self) -> Task[int]:
         """Present load as a signed magnitude in [-1023, 1023].
 
@@ -359,11 +371,19 @@ class AX12(SmartServo):
 
     # --- Diagnostics ---
 
+    @commands.register(
+        args=[],
+        result=[("voltage", ArgTypes.F32(help="Present bus voltage (V)"))],
+    )
     def get_voltage(self) -> Task[float]:
         """Present voltage in volts (register is tenths of a volt)."""
         data = self._bus.read_register(self._id, _PRESENT_VOLTAGE, 1)
         return ImmediateResultTask(data[0] / 10.0)
 
+    @commands.register(
+        args=[],
+        result=[("temperature", ArgTypes.U8(help="Present motor temperature (°C)"))],
+    )
     def get_temperature(self) -> Task[int]:
         """Present temperature in °C (internal sensor, shutdown ~70°C)."""
         data = self._bus.read_register(self._id, _PRESENT_TEMPERATURE, 1)
@@ -478,6 +498,8 @@ class AX12BusDefinition(DriverDefinition):
     """Factory for AX12Bus from config args."""
 
     def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        # The bus itself has no user-facing commands; individual AX12 servos
+        # are the command targets via their own AX12Definition.
         super().__init__()
         self._logger = logger
         self._peripherals = peripherals
@@ -540,7 +562,7 @@ class AX12Definition(DriverDefinition):
     """Factory for a single AX12 servo from config args."""
 
     def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
-        super().__init__()
+        super().__init__(AX12.commands)
         self._logger = logger
         self._peripherals = peripherals
 

--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -26,7 +26,7 @@ from evo_lib.interfaces.smart_servo import SmartServo
 from evo_lib.logger import Logger
 from evo_lib.peripheral import InterfaceHolder, Peripheral
 from evo_lib.registry import Registry
-from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.task import ImmediateErrorTask, ImmediateResultTask, Task
 
 # Dynamixel 1.0 instructions
 _INST_READ = 0x02
@@ -76,6 +76,100 @@ _DEFAULT_ECHO = False
 # Max AX-12 packet size we ever emit: 2 header + id + len + inst + reg + up to
 # 2 data bytes + checksum = 9. Round up for headroom on future register writes.
 _TX_BUF_SIZE = 16
+
+
+# --- Error hierarchy ---
+# Dynamixel 1.0 status error byte (AX-12A e-manual). Inherits from OSError so
+# existing `except OSError` call sites (retry loop, REPL, close handler) keep
+# working without migration. Bus-side errors are retryable; servo-side refusals
+# are not — the servo has already rejected the packet and would refuse the
+# exact same retry, just burning bus time.
+
+
+class DynamixelError(OSError):
+    """Base for all AX-12 protocol errors."""
+
+
+class DynamixelBusError(DynamixelError):
+    """Transient bus fault (framing, timeout, crossed reply). Retryable."""
+
+
+class DynamixelServoError(DynamixelError):
+    """Servo reported an error byte in its status packet. Not retryable
+    (except PacketChecksumError, handled specially in the retry loop)."""
+
+    ERROR_BIT: int = 0
+
+    def __init__(self, servo_id: int, error_byte: int, reason: str):
+        self.servo_id = servo_id
+        self.error_byte = error_byte
+        super().__init__(f"AX12 id {servo_id}: {reason} (0x{error_byte:02x})")
+
+
+class InputVoltageError(DynamixelServoError):
+    ERROR_BIT = 0x01
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "input voltage out of range")
+
+
+class AngleLimitError(DynamixelServoError):
+    ERROR_BIT = 0x02
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "goal position outside angle limits")
+
+
+class OverheatingError(DynamixelServoError):
+    ERROR_BIT = 0x04
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "overheating")
+
+
+class RangeError(DynamixelServoError):
+    ERROR_BIT = 0x08
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "instruction parameter out of range")
+
+
+class PacketChecksumError(DynamixelServoError):
+    """Servo received a corrupted instruction packet. TX-side noise, retryable."""
+    ERROR_BIT = 0x10
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "servo received bad checksum (TX noise)")
+
+
+class OverloadError(DynamixelServoError):
+    ERROR_BIT = 0x20
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "overload (motor stalled)")
+
+
+class InstructionError(DynamixelServoError):
+    ERROR_BIT = 0x40
+    def __init__(self, servo_id: int, error_byte: int):
+        super().__init__(servo_id, error_byte, "unknown instruction")
+
+
+# Order matters only for diagnostics when multiple bits are set: we surface
+# the lowest-numbered bit that matched. The error_byte attribute preserves
+# the full mask so callers can inspect all flags.
+_ERROR_BITS: tuple[type[DynamixelServoError], ...] = (
+    InputVoltageError,
+    AngleLimitError,
+    OverheatingError,
+    RangeError,
+    PacketChecksumError,
+    OverloadError,
+    InstructionError,
+)
+
+
+def _decode_servo_error(servo_id: int, error_byte: int) -> DynamixelServoError:
+    for cls in _ERROR_BITS:
+        if error_byte & cls.ERROR_BIT:
+            return cls(servo_id, error_byte)
+    # Reserved bit 7 or an unknown combination — still servo-side, so not
+    # retried. Keep the raw byte visible in the message for diagnostics.
+    return DynamixelServoError(servo_id, error_byte, "unknown servo error")
 
 
 def _checksum(servo_id: int, length: int, *data: int) -> int:
@@ -157,10 +251,28 @@ class AX12Bus(InterfaceHolder):
         # On failure we flush the RX buffer before retrying: a half-received
         # status packet would desync the next framing attempt. We accept the
         # cost of dropping a valid-but-late reply (timing edge case).
+        #
+        # Servo-side refusals (DynamixelServoError) are NOT retried: the servo
+        # has already processed the packet and rejected it; retrying sends the
+        # exact same bytes and gets the exact same refusal. The one exception
+        # is PacketChecksumError: the servo reports that the instruction it
+        # received had a bad checksum, which is one-shot TX noise and safe to
+        # rejouer.
         attempts = 0
         while True:
             try:
                 return op()
+            except DynamixelServoError as err:
+                if not isinstance(err, PacketChecksumError):
+                    raise
+                self._bus.reset_input_buffer()
+                if attempts >= self._retries:
+                    raise
+                attempts += 1
+                self._log.debug(
+                    f"AX12Bus '{self.name}' retry {attempts}/{self._retries}: {err}"
+                )
+                time.sleep(self._retry_delay)
             except OSError as err:
                 self._bus.reset_input_buffer()
                 if attempts >= self._retries:
@@ -227,33 +339,33 @@ class AX12Bus(InterfaceHolder):
         """
         header = self._bus.read(2)
         if header[0] != _HEADER_B0 or header[1] != _HEADER_B1:
-            raise OSError(f"Dynamixel: invalid header {bytes(header)!r}")
+            raise DynamixelBusError(f"invalid header {bytes(header)!r}")
         id_len = self._bus.read(2)
         resp_id, resp_length = id_len[0], id_len[1]
         # Detect a crossed reply (servo X answers a request addressed to Y —
         # happens after a prior timeout leaves a stale status in the buffer).
         if resp_id != expected_id:
-            raise OSError(
-                f"Dynamixel: crossed reply (expected id {expected_id}, got {resp_id})"
+            raise DynamixelBusError(
+                f"crossed reply (expected id {expected_id}, got {resp_id})"
             )
         # AX-12 status packet: error + 0..N params + checksum. Minimum 2 bytes
         # (error + checksum). Below that, payload[0] and payload[-1] collide
         # and we'd silently misread the error byte. Upper bound guards against
         # a faulty servo making us block on the serial timeout.
         if resp_length < 2 or resp_length > 8:
-            raise OSError(f"Dynamixel: implausible status length {resp_length}")
+            raise DynamixelBusError(f"implausible status length {resp_length}")
         payload = self._bus.read(resp_length)
         cs = resp_id + resp_length
         for b in payload[:-1]:
             cs += b
         expected = (~cs) & 0xFF
         if payload[-1] != expected:
-            raise OSError(
-                f"Dynamixel: bad checksum (got {payload[-1]:#x}, expected {expected:#x})"
+            raise DynamixelBusError(
+                f"bad checksum (got {payload[-1]:#x}, expected {expected:#x})"
             )
         error = payload[0]
         if error != 0:
-            raise OSError(f"Dynamixel error flags: 0x{error:02x}")
+            raise _decode_servo_error(resp_id, error)
         return bytes(payload[1:-1])
 
 
@@ -277,7 +389,15 @@ class AX12(SmartServo):
         return self._id
 
     def init(self) -> Task[()]:
-        self._bus.write_register(self._id, _TORQUE_ENABLE, bytes([1]))
+        # Route failures through ImmediateErrorTask instead of raising
+        # synchronously: that keeps PeripheralsInitializer.on_error() reachable,
+        # which lets this servo (and its dependents) be marked as skipped
+        # rather than crashing the whole boot sequence.
+        try:
+            self._bus.write_register(self._id, _TORQUE_ENABLE, bytes([1]))
+        except OSError as err:
+            self._log.error(f"AX12 '{self.name}' (ID {self._id}) init failed: {err}")
+            return ImmediateErrorTask(err)
         self._log.info(f"AX12 '{self.name}' (ID {self._id}) torque enabled")
         return ImmediateResultTask()
 

--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -389,6 +389,29 @@ class AX12(SmartServo):
         data = self._bus.read_register(self._id, _PRESENT_TEMPERATURE, 1)
         return ImmediateResultTask(data[0])
 
+    # --- Angle limits (EEPROM, persistent across power cycles) ---
+
+    @commands.register(
+        args=[],
+        result=[("cw_limit", ArgTypes.U16(help="CW (lower) goal-position bound in native units"))],
+    )
+    def get_cw_angle_limit(self) -> Task[int]:
+        """Read the CW angle limit from EEPROM.
+
+        Goal positions below this value are rejected by the servo firmware
+        with an Angle Limit Error (status error bit 1). A value of 0 on
+        both limits puts the servo in wheel (continuous) mode.
+        """
+        return ImmediateResultTask(self._read_word(_CW_ANGLE_LIMIT_L))
+
+    @commands.register(
+        args=[],
+        result=[("ccw_limit", ArgTypes.U16(help="CCW (upper) goal-position bound in native units"))],
+    )
+    def get_ccw_angle_limit(self) -> Task[int]:
+        """Read the CCW angle limit from EEPROM."""
+        return ImmediateResultTask(self._read_word(_CCW_ANGLE_LIMIT_L))
+
     # --- Operating modes ---
 
     def mode_joint(self) -> Task[()]:

--- a/src/evo_lib/drivers/smart_servo/virtual.py
+++ b/src/evo_lib/drivers/smart_servo/virtual.py
@@ -76,7 +76,7 @@ class SmartServoVirtualDefinition(DriverDefinition):
     """Factory for SmartServoVirtual from config args."""
 
     def __init__(self, logger: Logger):
-        super().__init__()
+        super().__init__(SmartServo.commands)
         self._logger = logger
 
     def get_init_args_definition(self) -> DriverInitArgsDefinition:

--- a/src/evo_lib/interfaces/smart_servo.py
+++ b/src/evo_lib/interfaces/smart_servo.py
@@ -3,6 +3,8 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands
 from evo_lib.interfaces.servo import Servo
 
 if TYPE_CHECKING:
@@ -16,22 +18,44 @@ class SmartServo(Servo):
     its actual position and can be queried at any time.
     """
 
+    commands = DriverCommands(parents=[Servo.commands])
+
     @abstractmethod
+    @commands.register(
+        args=[("position", ArgTypes.U16(help="Target position in native units"))],
+        result=[],
+    )
     def move_to_position(self, position: int) -> Task[()]:
         """Move to the given position (native units)."""
 
     @abstractmethod
+    @commands.register(
+        args=[],
+        result=[("position", ArgTypes.U16(help="Current position in native units"))],
+    )
     def get_position(self) -> Task[int]:
         """Read current position (in native units)."""
 
     @abstractmethod
+    @commands.register(
+        args=[],
+        result=[("angle", ArgTypes.F32(help="Current angle in degrees"))],
+    )
     def get_angle(self) -> Task[float]:
         """Read current position (in degrees)."""
 
     @abstractmethod
+    @commands.register(
+        args=[],
+        result=[("fraction", ArgTypes.F32(help="Current position as fraction of full range"))],
+    )
     def get_fraction(self) -> Task[float]:
         """Read current position (as a fraction between 0 and 1)."""
 
     @abstractmethod
+    @commands.register(
+        args=[("speed", ArgTypes.F32(help="Movement speed as a fraction (0.0 to 1.0)"))],
+        result=[],
+    )
     def set_speed(self, speed: float) -> Task[()]:
         """Set movement speed (as a fraction between 0 and 1)."""

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -3,7 +3,7 @@
 import struct
 
 from evo_lib.drivers.pilot.protocol import INIT_PACKET, Commands, build_packet
-from evo_lib.drivers.pilot.virtual import HolonomicPilotVirtual, PilotVirtual
+from evo_lib.drivers.pilot.virtual import DifferentialPilotVirtual, HolonomicPilotVirtual
 from evo_lib.interfaces.pilot import PilotMoveStatus
 from evo_lib.logger import Logger
 
@@ -35,9 +35,9 @@ class TestProtocol:
         assert INIT_PACKET == bytes([5, 254, 0xAA, 0xAA, 0xAA])
 
 
-class TestPilotVirtual:
+class TestDifferentialPilotVirtual:
     def test_go_to(self):
-        pilot = PilotVirtual("pilot", Logger("test"), speed_trsl=10000.0)
+        pilot = DifferentialPilotVirtual("pilot", Logger("test"), speed_trsl=10000.0)
         pilot.init()
         (status,) = pilot.go_to(100.0, 0.0).wait()
         assert status == PilotMoveStatus.REACHED
@@ -45,7 +45,7 @@ class TestPilotVirtual:
         assert abs(x - 100.0) < 0.1
 
     def test_rotate(self):
-        pilot = PilotVirtual("pilot", Logger("test"), speed_rot=100.0)
+        pilot = DifferentialPilotVirtual("pilot", Logger("test"), speed_rot=100.0)
         pilot.init()
         (status,) = pilot.rotate(1.57).wait()
         assert status == PilotMoveStatus.REACHED
@@ -53,17 +53,17 @@ class TestPilotVirtual:
         assert abs(theta - 1.57) < 0.01
 
     def test_free(self):
-        pilot = PilotVirtual("pilot", Logger("test"))
+        pilot = DifferentialPilotVirtual("pilot", Logger("test"))
         pilot.init()
         pilot.free().wait()
 
     def test_stop(self):
-        pilot = PilotVirtual("pilot", Logger("test"))
+        pilot = DifferentialPilotVirtual("pilot", Logger("test"))
         pilot.init()
         pilot.stop().wait()
 
     def test_initial_position(self):
-        pilot = PilotVirtual("pilot", Logger("test"))
+        pilot = DifferentialPilotVirtual("pilot", Logger("test"))
         assert pilot.position == (0.0, 0.0, 0.0)
 
 

--- a/tests/test_smart_servo.py
+++ b/tests/test_smart_servo.py
@@ -3,9 +3,24 @@
 import pytest
 
 from evo_lib.drivers.serial.virtual import SerialVirtual
-from evo_lib.drivers.smart_servo.ax12 import AX12, AX12Bus, AX12BusVirtual, _checksum
+from evo_lib.drivers.smart_servo.ax12 import (
+    AX12,
+    AX12Bus,
+    AX12BusVirtual,
+    AngleLimitError,
+    DynamixelBusError,
+    DynamixelServoError,
+    InputVoltageError,
+    InstructionError,
+    OverheatingError,
+    OverloadError,
+    PacketChecksumError,
+    RangeError,
+    _checksum,
+)
 from evo_lib.drivers.smart_servo.virtual import SmartServoVirtual
 from evo_lib.logger import Logger
+from evo_lib.task import ImmediateErrorTask
 
 
 @pytest.fixture
@@ -78,7 +93,7 @@ class TestAX12BusFraming:
         bad = bytearray(_status_packet(2, 0x00, 0x02))
         bad[-1] ^= 0xFF
         serial.inject_read(bytes(bad) + b"\xde\xad\xbe\xef")
-        with pytest.raises(OSError, match="checksum"):
+        with pytest.raises(DynamixelBusError, match="checksum"):
             bus.read_register(2, 36, 2)
         assert serial.in_waiting == 0
 
@@ -104,16 +119,66 @@ class TestAX12BusFraming:
         bus.init()
         assert serial._baudrate == 500_000
 
-    def test_servo_error_flags_raise(self, log):
+    def _inject_error_status(self, serial, servo_id: int, error_byte: int) -> None:
+        """Inject a status packet carrying the given error byte (no params)."""
+        length = 2  # error + checksum
+        cs = _checksum(servo_id, length, error_byte)
+        serial.inject_read(bytes([0xFF, 0xFF, servo_id, length, error_byte, cs]))
+
+    @pytest.mark.parametrize(
+        "error_byte,exc_type",
+        [
+            (0x01, InputVoltageError),
+            (0x02, AngleLimitError),
+            (0x04, OverheatingError),
+            (0x08, RangeError),
+            (0x10, PacketChecksumError),
+            (0x20, OverloadError),
+            (0x40, InstructionError),
+        ],
+    )
+    def test_servo_error_flags_decode_to_typed_exceptions(
+        self, log, error_byte, exc_type
+    ):
         serial, bus = self._make(log, retries=0)
-        # Status packet with error byte = 0x04 (overload).
-        params = [0x04]
-        length = len(params) + 1
-        cs = _checksum(2, length, *params)
-        packet = bytes([0xFF, 0xFF, 2, length, *params, cs])
-        serial.inject_read(packet)
-        with pytest.raises(OSError, match="0x04"):
+        self._inject_error_status(serial, 2, error_byte)
+        with pytest.raises(exc_type) as excinfo:
             bus.read_register(2, 36, 2)
+        # Raw byte preserved for diagnostics when multiple bits are set.
+        assert excinfo.value.error_byte == error_byte
+        assert excinfo.value.servo_id == 2
+
+    def test_servo_error_not_retried(self, log, monkeypatch):
+        # AngleLimit is a servo-side refusal: retrying sends the same bytes
+        # and gets the same refusal. The retry loop must propagate on the
+        # first attempt, not waste 3 round-trips.
+        serial, bus = self._make(log, retries=3, retry_delay=0.0)
+        calls = [0]
+
+        def flaky(servo_id, register, count):
+            calls[0] += 1
+            raise AngleLimitError(servo_id, 0x02)
+
+        monkeypatch.setattr(bus, "_do_read", flaky)
+        with pytest.raises(AngleLimitError):
+            bus.read_register(2, 36, 2)
+        assert calls[0] == 1
+
+    def test_packet_checksum_error_is_retried(self, log, monkeypatch):
+        # PacketChecksumError is the servo saying "your TX packet was
+        # corrupt" — that is one-shot line noise and legitimately retryable.
+        serial, bus = self._make(log, retries=2, retry_delay=0.0)
+        calls = [0]
+
+        def flaky(servo_id, register, count):
+            calls[0] += 1
+            if calls[0] < 2:
+                raise PacketChecksumError(servo_id, 0x10)
+            return b"\x00\x02"
+
+        monkeypatch.setattr(bus, "_do_read", flaky)
+        assert bus.read_register(2, 36, 2) == b"\x00\x02"
+        assert calls[0] == 2
 
     def test_retry_recovers_after_transient_failure(self, log, monkeypatch):
         # Drive the retry path directly: the serial mock state after failure +
@@ -198,6 +263,26 @@ class TestAX12WithVirtualBus:
         assert bus.read_register(1, 8, 2) == b"\x00\x00"
         servo.mode_joint().wait()
         assert bus.read_register(1, 8, 2) == bytes([1023 & 0xFF, 1023 >> 8])
+
+    def test_init_returns_error_task_on_bus_failure(self, log, monkeypatch):
+        # AX12.init() must NOT raise synchronously when the bus is unreachable:
+        # a sync raise bypasses PeripheralsInitializer.on_error() and crashes
+        # the whole boot. Wrapping in ImmediateErrorTask lets the initializer
+        # skip the servo cleanly.
+        bus = self._bus(log)
+        servo = AX12("s", log, bus, servo_id=42)
+
+        def boom(servo_id, register, data):
+            raise DynamixelBusError("no reply")
+
+        monkeypatch.setattr(bus, "write_register", boom)
+
+        task = servo.init()
+        assert isinstance(task, ImmediateErrorTask)
+        seen: list[Exception] = []
+        task.on_error(seen.append)
+        assert len(seen) == 1
+        assert isinstance(seen[0], DynamixelBusError)
 
     def test_turn_sets_direction_bit(self, log):
         bus = self._bus(log)

--- a/tests/test_smart_servo.py
+++ b/tests/test_smart_servo.py
@@ -21,7 +21,7 @@ def _status_packet(servo_id: int, *params: int) -> bytes:
 
 
 def _write_packet(servo_id: int, register: int, data: bytes) -> bytes:
-    """Rebuild the WRITE packet the driver sends, for echo injection."""
+    """Rebuild the WRITE packet the driver sends, to assert on serial.written."""
     length = len(data) + 3
     params = [0x03, register, *data]
     cs = _checksum(servo_id, length, *params)
@@ -29,7 +29,7 @@ def _write_packet(servo_id: int, register: int, data: bytes) -> bytes:
 
 
 def _read_packet(servo_id: int, register: int, count: int) -> bytes:
-    """Rebuild the READ packet the driver sends, for echo injection."""
+    """Rebuild the READ packet the driver sends, to assert on serial.written."""
     length = 4
     params = [0x02, register, count]
     cs = _checksum(servo_id, length, *params)
@@ -50,8 +50,9 @@ class TestSmartServoVirtual:
 class TestAX12BusFraming:
     """Exercise the real AX12Bus protocol layer against SerialVirtual.
 
-    Real USB2AX is half-duplex: every write is echoed back. We simulate
-    that by injecting echo + status together.
+    Default mode is echo=False, which matches the USB2AX dongle used on
+    the robot: the dongle does not mirror TX onto RX. One dedicated test
+    covers the echo=True path for USB2Dynamixel-style dongles.
     """
 
     def _make(self, log, **kwargs):
@@ -61,32 +62,39 @@ class TestAX12BusFraming:
         bus.init()
         return serial, bus
 
-    def test_write_register_frames_and_drains_echo(self, log):
+    def test_write_register_frames_and_reads_status(self, log):
         serial, bus = self._make(log)
-        echo = _write_packet(2, 24, bytes([1]))
-        serial.inject_read(echo + _status_packet(2))
+        serial.inject_read(_status_packet(2))
         bus.write_register(2, 24, bytes([1]))
-        assert serial.written == [echo]
+        assert serial.written == [_write_packet(2, 24, bytes([1]))]
 
     def test_read_register_parses_status(self, log):
         serial, bus = self._make(log)
-        serial.inject_read(_read_packet(2, 36, 2) + _status_packet(2, 0x00, 0x02))
+        serial.inject_read(_status_packet(2, 0x00, 0x02))
         assert bus.read_register(2, 36, 2) == b"\x00\x02"
 
     def test_bad_checksum_resyncs_and_raises(self, log):
         serial, bus = self._make(log, retries=0)
         bad = bytearray(_status_packet(2, 0x00, 0x02))
         bad[-1] ^= 0xFF
-        serial.inject_read(_read_packet(2, 36, 2) + bytes(bad) + b"\xde\xad\xbe\xef")
+        serial.inject_read(bytes(bad) + b"\xde\xad\xbe\xef")
         with pytest.raises(OSError, match="checksum"):
             bus.read_register(2, 36, 2)
         assert serial.in_waiting == 0
 
     def test_broadcast_skips_status_read(self, log):
         serial, bus = self._make(log)
-        echo = _write_packet(0xFE, 24, bytes([0]))
-        serial.inject_read(echo)
         bus.write_register(0xFE, 24, bytes([0]))
+        assert serial.written == [_write_packet(0xFE, 24, bytes([0]))]
+
+    def test_echo_mode_drains_local_echo(self, log):
+        # USB2Dynamixel-style dongles mirror the TX packet onto RX before
+        # the servo's reply. With echo=True, the bus must consume that
+        # mirror instead of mistaking it for the status reply.
+        serial, bus = self._make(log, echo=True)
+        echo = _write_packet(2, 24, bytes([1]))
+        serial.inject_read(echo + _status_packet(2))
+        bus.write_register(2, 24, bytes([1]))
         assert serial.written == [echo]
 
     def test_init_sets_baudrate_on_underlying_serial(self, log):
@@ -103,7 +111,7 @@ class TestAX12BusFraming:
         length = len(params) + 1
         cs = _checksum(2, length, *params)
         packet = bytes([0xFF, 0xFF, 2, length, *params, cs])
-        serial.inject_read(_read_packet(2, 36, 2) + packet)
+        serial.inject_read(packet)
         with pytest.raises(OSError, match="0x04"):
             bus.read_register(2, 36, 2)
 


### PR DESCRIPTION
AX-12 driver improvements accumulated while bringing up the Hololutek proto.

- `fix(ax12)`: default to no-echo mode to match the USB2AX (Xevelabs) dongle used on the robot.
- `feat(smart_servo)`: expose `move_to_*`, `get_position/angle/load/voltage/temperature`, `set_speed`, `reset`, `free` as REPL commands on the SmartServo interface, and add diagnostics on AX-12 (speed, load, voltage, temperature).
- `feat(ax12)`: expose `get_cw_angle_limit` / `get_ccw_angle_limit` for operational bound inspection.
- `fix(tests)`: adapt test_pilot to the `PilotVirtual` → `DifferentialPilotVirtual` rename so collection works again.
- `feat(ax12)`: decode the Dynamixel status error byte into a typed exception hierarchy (`AngleLimitError`, `OverloadError`, `OverheatingError`, ...). Servo refusals no longer go through the retry loop; `AX12.init()` returns an `ImmediateErrorTask` on bus failure instead of raising synchronously, so the peripheral initializer can skip cleanly.

358 tests pass.