### PR TITLE
Fix graph, correctly reset default value on nodes

### DIFF
--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -114,6 +114,13 @@ class ValueInput(ValueEndpoint):
     def reset(self) -> None:
         self._value = self._default
 
+    def set_default(self, value: Any) -> None:
+        self._default = value
+        self._value = value
+
+    def set_value(self, value: Any) -> None:
+        self._value = value
+
     def get_value(self) -> Any:
         return self._value
 
@@ -125,7 +132,7 @@ class ValueOutput(ValueEndpoint):
 
     def set(self, value: Any) -> None:
         for inp in self._connections:
-            inp._value = value
+            inp.set_value(value)
 
     def link(self, peer: ValueInput) -> None:
         self._connections.append(peer)
@@ -202,6 +209,7 @@ class Node(ABC):
         pass
 
     def run(self) -> None:
+        self.get_runner()._logger.debug(f"Run node '{self.get_name()}'")
         self.get_graph().schedule_run_node(self)
 
     def reset(self) -> None:
@@ -303,7 +311,9 @@ class NodeDefinition:
                 )
             endpoint = node.get_value_input(endpoint_name)
             assert endpoint is not None
-            endpoint._default = default_value
+            endpoint.set_default(default_value)
+
+        node.reset()
 
         return node
 


### PR DESCRIPTION
ValueInput exposed no setter, so NodeDefinition.create_node mutated _default in place without refreshing _value. Nodes kept running with their constructor-time default until the next explicit reset().

- Add ValueInput.set_default()/set_value() for encapsulation
- ValueOutput.set() goes through set_value() instead of touching _valu
- NodeDefinition.create_node() calls node.reset() after applying defaults
- Debug log in Node.run() for graph execution traceability