### PR TITLE
feat(pilot): promote calibrate_otos to Pilot base + graph reset fix

### DIFF
--- a/src/evo_lib/drivers/pilot/serial_pilot.py
+++ b/src/evo_lib/drivers/pilot/serial_pilot.py
@@ -563,9 +563,9 @@ class HolonomicSerialPilot(DifferentialSerialPilot, HolonomicPilot):
     ) -> Task[PilotMoveStatus]:
         raise NotImplementedError("follow_holonomic_path not implemented yet")
 
-    @commands.register(args=[], result=[])
     def calibrate_otos(self) -> Task[()]:
-        """Calibrate the optical tracking sensor (OTOS)."""
+        """Override `Pilot.calibrate_otos` to forward the calibration
+        request to the firmware via the serial command bus."""
         return self._send_command(Commands.OTOS_CAL)
 
 

--- a/src/evo_lib/interfaces/pilot.py
+++ b/src/evo_lib/interfaces/pilot.py
@@ -9,6 +9,7 @@ from evo_lib.argtypes import ArgTypes
 from evo_lib.driver_definition import DriverCommands
 from evo_lib.event import Event
 from evo_lib.peripheral import Placable
+from evo_lib.task import ImmediateResultTask
 from evo_lib.types.pose import Pose2D
 from evo_lib.types.vect import Vect2D
 
@@ -102,6 +103,15 @@ class Pilot(Placable):
     @commands.register(args = [("pose", Pose2D.ArgType())], result = [])
     def set_pose(self, pose: Pose2D) -> Task[()]:
         pass
+
+    @commands.register(args = [], result = [])
+    def calibrate_otos(self) -> "Task[()]":
+        """Calibrate an optional optical tracking sensor (OTOS).
+
+        Default: no-op. Pilots backed by a firmware exposing an OTOS
+        calibration command override this to run it on the MCU.
+        """
+        return ImmediateResultTask()
 
     @abstractmethod
     @commands.register(args = [


### PR DESCRIPTION
Promotes calibrate_otos to a no-op default on Pilot, so any pilot exposes the command (overridden by HolonomicSerialPilot to call the firmware). Also fixes the graph engine to refresh node values when a config default overrides the constructor default.