### PR TITLE
feat(led_strip): WS2812B driver + MdbLed mast indicator

### DIFF
--- a/docs/glossary/interfaces/led-strip.md
+++ b/docs/glossary/interfaces/led-strip.md
@@ -9,27 +9,38 @@ A **LedStrip** is an addressable RGB LED strip where each pixel can be set indiv
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `set_pixel(index, color)` | None | Set a single pixel color (buffered) |
-| `get_pixel(index)` | [Color](../types/color.md) | Get the current pixel color from the buffer |
-| `fill(color)` | None | Set all pixels to the same color (buffered) |
-| `set_brightness(brightness)` | None | Set global brightness (0.0–1.0) |
-| `get_brightness()` | float | Get current global brightness |
+| `set_pixel(index, r, g, b)` | [Task](../concurrency/task.md)\[None\] | Buffer one pixel (RGB floats 0.0–1.0) |
+| `get_pixel(index)` | [Task](../concurrency/task.md)\[float, float, float\] | Read the buffered RGB triplet |
+| `fill(r, g, b)` | [Task](../concurrency/task.md)\[None\] | Buffer the same color into every pixel |
+| `set_brightness(brightness)` | [Task](../concurrency/task.md)\[None\] | Set global brightness (0.0–1.0) |
+| `get_brightness()` | [Task](../concurrency/task.md)\[float\] | Get current global brightness |
 | `show()` | [Task](../concurrency/task.md)\[None\] | Push the pixel buffer to the hardware |
-| `clear()` | [Task](../concurrency/task.md)\[None\] | Turn off all pixels and show immediately |
+| `clear()` | [Task](../concurrency/task.md)\[None\] | Buffer black on every pixel and `show` immediately |
 | `num_pixels` | int (property) | Number of pixels in the strip |
 
 ### Double-buffered
 
 `set_pixel()` and `fill()` modify an internal buffer without touching the hardware.
-Call `show()` to push all changes at once. This avoids visible flickering during updates.
+Call `show()` to push all changes at once. This avoids visible flickering during
+multi-pixel updates.
 
-## Driver
+### Color encoding
 
-| Driver | Hardware | Bus |
-|--------|----------|-----|
-| `ws2812b` | WS2812B / NeoPixel addressable LEDs | SPI or PWM |
+The interface takes RGB primitives (three floats in 0.0–1.0) rather than a
+[Color](../types/color.md) struct because the underlying command system
+serializes scalar fields, not arbitrary objects. The Color type's fourth
+"clear" channel has no LED meaning and is intentionally absent.
+
+## Drivers
+
+| Driver | Hardware | Bus / Strategy |
+|--------|----------|----------------|
+| [WS2812B](../drivers/ws2812b.md) | WS2812B / NeoPixel addressable LEDs | DMA via PWM (GPIO 12/18), PCM (21), or SPI (10) |
+
+A `WS2812BVirtual` twin with bit-exact buffer semantics is provided in the
+same module for tests and simulation.
 
 ## See also
 
-- [Color](../types/color.md) — the RGBA value object used for pixel colors
+- [Color](../types/color.md) — the RGBC value object used for sensor-side reads
 - [Peripheral hierarchy](../architecture/peripheral.md) — base classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ rpi = [
     "pyserial>=3.5",
     # RPLidar A-series driver.
     "adafruit-circuitpython-rplidar>=1.2.20",
+    # WS2812B / NeoPixel addressable LED strip — DMA-driven, requires root
+    # for PWM/PCM modes (or SPI mode on GPIO 10 only, no root).
+    "rpi-ws281x>=5.0",
 ]
 
 # -- Development dependencies --

--- a/src/evo_lib/drivers/led_strip/__init__.py
+++ b/src/evo_lib/drivers/led_strip/__init__.py
@@ -1,5 +1,12 @@
-"""LED strip drivers: WS2812B (rpi_ws281x) and its virtual twin."""
+"""LED strip drivers: WS2812B and the MdbLed indicator built on top of it."""
 
+from evo_lib.drivers.led_strip.mdb_led import (
+    MdbLed,
+    MdbLedDefinition,
+    MdbLedState,
+    MdbLedVirtual,
+    MdbLedVirtualDefinition,
+)
 from evo_lib.drivers.led_strip.ws2812b import (
     WS2812B,
     WS2812BDefinition,
@@ -8,6 +15,11 @@ from evo_lib.drivers.led_strip.ws2812b import (
 )
 
 __all__ = [
+    "MdbLed",
+    "MdbLedDefinition",
+    "MdbLedState",
+    "MdbLedVirtual",
+    "MdbLedVirtualDefinition",
     "WS2812B",
     "WS2812BDefinition",
     "WS2812BVirtual",

--- a/src/evo_lib/drivers/led_strip/__init__.py
+++ b/src/evo_lib/drivers/led_strip/__init__.py
@@ -1,0 +1,15 @@
+"""LED strip drivers: WS2812B (rpi_ws281x) and its virtual twin."""
+
+from evo_lib.drivers.led_strip.ws2812b import (
+    WS2812B,
+    WS2812BDefinition,
+    WS2812BVirtual,
+    WS2812BVirtualDefinition,
+)
+
+__all__ = [
+    "WS2812B",
+    "WS2812BDefinition",
+    "WS2812BVirtual",
+    "WS2812BVirtualDefinition",
+]

--- a/src/evo_lib/drivers/led_strip/mdb_led.py
+++ b/src/evo_lib/drivers/led_strip/mdb_led.py
@@ -1,0 +1,433 @@
+"""Mat-de-balise LED driver: WS2812B with state-driven animations.
+
+The legacy MDB had a Teensy + carte-mat-de-balise running FastLED in
+hardware. For Hololutek 2026 there is no MDB card yet; the mast LEDs are
+wired directly to a RPi GPIO pin and driven through ``rpi_ws281x``.
+
+Compared to a plain ``WS2812B``, ``MdbLed`` exposes the legacy-style
+indication semantics (``set_state``, ``set_team_color``) backed by a
+background animation thread. The high level only emits state changes —
+the rendering policy lives here.
+
+State semantics, mirroring legacy ``LightningMode``:
+
+- ``Off``      — all pixels black, no animation (default at boot).
+- ``Disabled`` — alternating orange/black per pixel, flips every 250 ms.
+- ``Loading``  — single-pixel chase in the team color, 50 ms / step.
+                 Used during pre-match setup; ``set_team_color`` matters
+                 here.
+- ``Running``  — solid green, static (refreshed only on state change).
+- ``Error``    — full-strip red blink, 500 ms.
+
+Inheritance chain: ``MdbLedVirtual → MdbLed → WS2812B``. The virtual
+overrides only the four hardware hooks exposed by ``WS2812B`` (no
+re-implementation of pixel arithmetic or state machine).
+"""
+
+import threading
+from enum import IntEnum
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.drivers.led_strip.ws2812b import (
+    _DEFAULT_DMA_CHANNEL,
+    _DEFAULT_FREQUENCY_HZ,
+    _DEFAULT_PIN,
+    WS2812B,
+    _clamp_unit,
+    _unpack_rgb,
+)
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class MdbLedState(IntEnum):
+    """High-level states the mat-de-balise indicator displays.
+
+    Names mirror the legacy ``LightningMode`` so muscle memory transfers.
+    """
+
+    Off = 0
+    Disabled = 1
+    Loading = 2
+    Running = 3
+    Error = 4
+
+
+# Per-state refresh delay in seconds. ``None`` = static (animator parks
+# until the next state/team-color change).
+_REFRESH_S: dict[MdbLedState, float | None] = {
+    MdbLedState.Off:      None,
+    MdbLedState.Running:  None,
+    MdbLedState.Disabled: 0.25,
+    MdbLedState.Error:    0.50,
+    MdbLedState.Loading:  0.05,
+}
+
+
+class MdbLed(WS2812B):
+    """WS2812B + state-machine animator for the mat-de-balise indicator.
+
+    The animator runs in a daemon thread that idles on a condition variable
+    when the current state is static (``Off`` / ``Running``). State changes
+    wake it up immediately — ``set_state`` returns without blocking.
+
+    A ``set_pixel`` / ``fill`` / ``show`` call from outside while the
+    animator is in a non-static state will race with it and likely be
+    overwritten on the next render. Drive the indicator through state
+    changes; reach for the raw ``LedStrip`` API only when in ``Off`` state.
+    """
+
+    commands = DriverCommands(parents=[WS2812B.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        num_pixels: int,
+        pin: int = _DEFAULT_PIN,
+        brightness: float = 1.0,
+        frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
+        dma_channel: int = _DEFAULT_DMA_CHANNEL,
+        team_color_r: float = 1.0,
+        team_color_g: float = 0.8,
+        team_color_b: float = 0.0,
+        auto_start_animator: bool = True,
+    ):
+        super().__init__(name, logger, num_pixels, pin, brightness, frequency_hz, dma_channel)
+        self._state: MdbLedState = MdbLedState.Off
+        self._team_color: tuple[float, float, float] = (
+            _clamp_unit(team_color_r),
+            _clamp_unit(team_color_g),
+            _clamp_unit(team_color_b),
+        )
+        self._step: int = 0
+        # Lock guards _state / _team_color / _step against animator vs
+        # caller-thread races. Held only briefly — never around hardware
+        # calls — so it never serializes the rpi_ws281x DMA show.
+        self._state_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        # Wakes the animator early when state or team color changes.
+        self._wakeup = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._auto_start_animator = auto_start_animator
+
+    def init(self) -> Task[()]:
+        super().init().wait()
+        if self._auto_start_animator:
+            self._start_animator()
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self._stop_animator()
+        super().close()
+
+    @commands.register(
+        args=[("state", ArgTypes.Enum(MdbLedState, help="Indicator state"))],
+        result=[],
+    )
+    def set_state(self, state: MdbLedState) -> Task[()]:
+        with self._state_lock:
+            if state == self._state:
+                return ImmediateResultTask()
+            self._state = state
+            self._step = 0  # restart any chase / blink phase cleanly
+        self._wakeup.set()
+        return ImmediateResultTask()
+
+    @commands.register(
+        args=[],
+        result=[("state", ArgTypes.Enum(MdbLedState, help="Current indicator state"))],
+    )
+    def get_state(self) -> Task[MdbLedState]:
+        with self._state_lock:
+            return ImmediateResultTask(self._state)
+
+    @commands.register(
+        args=[
+            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
+            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
+            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
+        ],
+        result=[],
+    )
+    def set_team_color(self, r: float, g: float, b: float) -> Task[()]:
+        with self._state_lock:
+            self._team_color = (_clamp_unit(r), _clamp_unit(g), _clamp_unit(b))
+        # Wake the animator so the new color shows up immediately on the
+        # next chase frame — otherwise it'd lag by up to one refresh tick.
+        self._wakeup.set()
+        return ImmediateResultTask()
+
+    @commands.register(
+        args=[],
+        result=[
+            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
+            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
+            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
+        ],
+    )
+    def get_team_color(self) -> Task[float, float, float]:
+        with self._state_lock:
+            r, g, b = self._team_color
+        return ImmediateResultTask(r, g, b)
+
+    # --- Animator lifecycle ------------------------------------------------
+
+    def _start_animator(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop_event.clear()
+        self._wakeup.set()  # render the initial frame immediately
+        self._thread = threading.Thread(
+            target=self._animator_loop,
+            daemon=True,
+            name=f"mdb-led-{self.name}",
+        )
+        self._thread.start()
+
+    def _stop_animator(self) -> None:
+        self._stop_event.set()
+        self._wakeup.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+    def _animator_loop(self) -> None:
+        while not self._stop_event.is_set():
+            self._wakeup.clear()
+            with self._state_lock:
+                state = self._state
+                team_color = self._team_color
+                step = self._step
+                self._step += 1
+
+            try:
+                self._render_frame(state, team_color, step)
+            except Exception as exc:
+                self._log.error(f"MdbLed '{self.name}' render error: {exc}")
+
+            delay = _REFRESH_S.get(state)
+            if delay is None:
+                # Static state — park until something changes.
+                self._wakeup.wait()
+            else:
+                self._wakeup.wait(delay)
+
+    # --- Rendering policy --------------------------------------------------
+    # Pulled out as a regular method so tests can drive it deterministically
+    # (see ``MdbLedVirtual.tick``).
+
+    def _render_frame(
+        self,
+        state: MdbLedState,
+        team_color: tuple[float, float, float],
+        step: int,
+    ) -> None:
+        if state == MdbLedState.Off:
+            self.fill(0.0, 0.0, 0.0).wait()
+        elif state == MdbLedState.Running:
+            # Solid green, the legacy "match in progress" indication.
+            self.fill(0.0, 1.0, 0.0).wait()
+        elif state == MdbLedState.Error:
+            on = (step % 2) == 0
+            if on:
+                self.fill(1.0, 0.0, 0.0).wait()
+            else:
+                self.fill(0.0, 0.0, 0.0).wait()
+        elif state == MdbLedState.Disabled:
+            # Alternating orange/black per-pixel, parity flips every step
+            # — same visual as the legacy "Disabled" mode.
+            on_color = (1.0, 0.5, 0.0)
+            off_color = (0.0, 0.0, 0.0)
+            for i in range(self._num_pixels):
+                lit = ((step + i) % 2) == 0
+                r, g, b = on_color if lit else off_color
+                self.set_pixel(i, r, g, b).wait()
+        elif state == MdbLedState.Loading:
+            # Single-pixel chase in team color. On 3-pixel MDB strips this
+            # boils down to a "running light" cycle through each LED.
+            self.fill(0.0, 0.0, 0.0).wait()
+            tcr, tcg, tcb = team_color
+            self.set_pixel(step % self._num_pixels, tcr, tcg, tcb).wait()
+        self.show().wait()
+
+
+class MdbLedDefinition(DriverDefinition):
+    """Factory for ``MdbLed`` from JSON5 config.
+
+    Inherits the WS2812B argument set (num_pixels, pin, brightness,
+    frequency_hz, dma_channel) and adds team-color defaults.
+    """
+
+    def __init__(self, logger: Logger):
+        super().__init__(MdbLed.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("num_pixels", ArgTypes.U16(help="Number of LEDs in the strip"))
+        defn.add_optional("pin", ArgTypes.U8(help="GPIO pin (BCM)"), _DEFAULT_PIN)
+        defn.add_optional("brightness", ArgTypes.F32(help="Initial brightness 0.0-1.0"), 1.0)
+        defn.add_optional(
+            "frequency_hz",
+            ArgTypes.U32(help="Bit clock; 800 kHz for WS2812B"),
+            _DEFAULT_FREQUENCY_HZ,
+        )
+        defn.add_optional(
+            "dma_channel",
+            ArgTypes.U8(help="DMA channel"),
+            _DEFAULT_DMA_CHANNEL,
+        )
+        defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
+        defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
+        defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> MdbLed:
+        name = args.get_name()
+        return MdbLed(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            num_pixels=args.get("num_pixels"),
+            pin=args.get("pin"),
+            brightness=args.get("brightness"),
+            frequency_hz=args.get("frequency_hz"),
+            dma_channel=args.get("dma_channel"),
+            team_color_r=args.get("team_color_r"),
+            team_color_g=args.get("team_color_g"),
+            team_color_b=args.get("team_color_b"),
+        )
+
+
+class MdbLedVirtual(MdbLed):
+    """Drop-in twin of ``MdbLed`` with an in-memory pixel buffer.
+
+    Inherits ``MdbLed`` for the state machine + animator (no duplication)
+    and overrides ``WS2812B``'s four hardware hooks to back the strip with
+    a buffer instead of rpi_ws281x. Constructor signature is identical to
+    ``MdbLed`` (same swap invariant as ``WS2812BVirtual``).
+    """
+
+    commands = DriverCommands(parents=[MdbLed.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        num_pixels: int,
+        pin: int = _DEFAULT_PIN,
+        brightness: float = 1.0,
+        frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
+        dma_channel: int = _DEFAULT_DMA_CHANNEL,
+        team_color_r: float = 1.0,
+        team_color_g: float = 0.8,
+        team_color_b: float = 0.0,
+        auto_start_animator: bool = True,
+    ):
+        super().__init__(
+            name=name,
+            logger=logger,
+            num_pixels=num_pixels,
+            pin=pin,
+            brightness=brightness,
+            frequency_hz=frequency_hz,
+            dma_channel=dma_channel,
+            team_color_r=team_color_r,
+            team_color_g=team_color_g,
+            team_color_b=team_color_b,
+            auto_start_animator=auto_start_animator,
+        )
+        self._buffer: list[int] = [0] * num_pixels
+        self._shown: list[int] = [0] * num_pixels
+        self._brightness_byte: int = round(self._brightness * 255)
+
+    # --- Hardware hooks (override WS2812B) --------------------------------
+
+    def _hw_init_strip(self) -> None:
+        pass
+
+    def _hw_close_strip(self) -> None:
+        pass
+
+    def _hw_set_pixel(self, index: int, packed: int) -> None:
+        self._buffer[index] = packed
+
+    def _hw_get_pixel(self, index: int) -> int:
+        return self._buffer[index]
+
+    def _hw_show(self) -> None:
+        self._shown = list(self._buffer)
+
+    def _hw_set_brightness(self, byte_value: int) -> None:
+        self._brightness_byte = byte_value
+
+    # --- Test helpers -----------------------------------------------------
+
+    def get_shown_frame(self) -> list[tuple[float, float, float]]:
+        """RGB triplets actually pushed via ``show`` (animator output)."""
+        return [_unpack_rgb(p) for p in self._shown]
+
+    def tick(self) -> None:
+        """Render one animation frame deterministically.
+
+        For tests that want to assert on each step without racing with the
+        background thread. Construct with ``auto_start_animator=False`` to
+        keep the thread offline; then call ``tick`` after each
+        ``set_state`` / ``set_team_color``.
+        """
+        with self._state_lock:
+            state = self._state
+            team_color = self._team_color
+            step = self._step
+            self._step += 1
+        self._render_frame(state, team_color, step)
+
+
+class MdbLedVirtualDefinition(DriverDefinition):
+    """Factory for ``MdbLedVirtual``. Mirrors ``MdbLedDefinition`` so the
+    config can swap real↔virtual by changing only the driver name."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(MdbLedVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("num_pixels", ArgTypes.U16(help="Number of LEDs in the strip"))
+        defn.add_optional("pin", ArgTypes.U8(help="GPIO pin (BCM, ignored)"), _DEFAULT_PIN)
+        defn.add_optional("brightness", ArgTypes.F32(help="Initial brightness 0.0-1.0"), 1.0)
+        defn.add_optional(
+            "frequency_hz",
+            ArgTypes.U32(help="Bit clock (ignored)"),
+            _DEFAULT_FREQUENCY_HZ,
+        )
+        defn.add_optional(
+            "dma_channel",
+            ArgTypes.U8(help="DMA channel (ignored)"),
+            _DEFAULT_DMA_CHANNEL,
+        )
+        defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
+        defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
+        defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        return defn
+
+    def create(self, args: DriverInitArgs) -> MdbLedVirtual:
+        name = args.get_name()
+        return MdbLedVirtual(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            num_pixels=args.get("num_pixels"),
+            pin=args.get("pin"),
+            brightness=args.get("brightness"),
+            frequency_hz=args.get("frequency_hz"),
+            dma_channel=args.get("dma_channel"),
+            team_color_r=args.get("team_color_r"),
+            team_color_g=args.get("team_color_g"),
+            team_color_b=args.get("team_color_b"),
+        )

--- a/src/evo_lib/drivers/led_strip/mdb_led.py
+++ b/src/evo_lib/drivers/led_strip/mdb_led.py
@@ -13,9 +13,9 @@ State semantics, mirroring legacy ``LightningMode``:
 
 - ``Off``      — all pixels black, no animation (default at boot).
 - ``Disabled`` — alternating orange/black per pixel, flips every 250 ms.
-- ``Loading``  — single-pixel chase in the team color, 50 ms / step.
-                 Used during pre-match setup; ``set_team_color`` matters
-                 here.
+- ``Loading``  — wide chase in the team color (configurable width via
+                 ``loading_chase_length``, default 5), 50 ms / step. Used
+                 during pre-match setup; ``set_team_color`` matters here.
 - ``Running``  — solid green, static (refreshed only on state change).
 - ``Error``    — full-strip red blink, 500 ms.
 
@@ -97,6 +97,7 @@ class MdbLed(WS2812B):
         team_color_r: float = 1.0,
         team_color_g: float = 0.8,
         team_color_b: float = 0.0,
+        loading_chase_length: int = 5,
         auto_start_animator: bool = True,
     ):
         super().__init__(name, logger, num_pixels, pin, brightness, frequency_hz, dma_channel)
@@ -106,6 +107,9 @@ class MdbLed(WS2812B):
             _clamp_unit(team_color_g),
             _clamp_unit(team_color_b),
         )
+        # Width of the comet head in Loading state. Clamped so it never
+        # exceeds the strip length (would lit every pixel and look static).
+        self._loading_chase_length: int = max(1, min(loading_chase_length, num_pixels))
         self._step: int = 0
         # Lock guards _state / _team_color / _step against animator vs
         # caller-thread races. Held only briefly — never around hardware
@@ -250,11 +254,14 @@ class MdbLed(WS2812B):
                 r, g, b = on_color if lit else off_color
                 self.set_pixel(i, r, g, b).wait()
         elif state == MdbLedState.Loading:
-            # Single-pixel chase in team color. On 3-pixel MDB strips this
-            # boils down to a "running light" cycle through each LED.
+            # Wide chase in team color: a comet of `loading_chase_length`
+            # consecutive lit pixels advances by one slot per step, with
+            # wrap-around at the strip end.
             self.fill(0.0, 0.0, 0.0).wait()
             tcr, tcg, tcb = team_color
-            self.set_pixel(step % self._num_pixels, tcr, tcg, tcb).wait()
+            for offset in range(self._loading_chase_length):
+                idx = (step + offset) % self._num_pixels
+                self.set_pixel(idx, tcr, tcg, tcb).wait()
         self.show().wait()
 
 
@@ -287,6 +294,11 @@ class MdbLedDefinition(DriverDefinition):
         defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
         defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
         defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        defn.add_optional(
+            "loading_chase_length",
+            ArgTypes.U8(help="Comet width in Loading state (number of lit pixels)"),
+            5,
+        )
         return defn
 
     def create(self, args: DriverInitArgs) -> MdbLed:
@@ -302,6 +314,7 @@ class MdbLedDefinition(DriverDefinition):
             team_color_r=args.get("team_color_r"),
             team_color_g=args.get("team_color_g"),
             team_color_b=args.get("team_color_b"),
+            loading_chase_length=args.get("loading_chase_length"),
         )
 
 
@@ -328,6 +341,7 @@ class MdbLedVirtual(MdbLed):
         team_color_r: float = 1.0,
         team_color_g: float = 0.8,
         team_color_b: float = 0.0,
+        loading_chase_length: int = 5,
         auto_start_animator: bool = True,
     ):
         super().__init__(
@@ -341,6 +355,7 @@ class MdbLedVirtual(MdbLed):
             team_color_r=team_color_r,
             team_color_g=team_color_g,
             team_color_b=team_color_b,
+            loading_chase_length=loading_chase_length,
             auto_start_animator=auto_start_animator,
         )
         self._buffer: list[int] = [0] * num_pixels
@@ -415,6 +430,11 @@ class MdbLedVirtualDefinition(DriverDefinition):
         defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
         defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
         defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        defn.add_optional(
+            "loading_chase_length",
+            ArgTypes.U8(help="Comet width in Loading state (number of lit pixels)"),
+            5,
+        )
         return defn
 
     def create(self, args: DriverInitArgs) -> MdbLedVirtual:
@@ -430,4 +450,5 @@ class MdbLedVirtualDefinition(DriverDefinition):
             team_color_r=args.get("team_color_r"),
             team_color_g=args.get("team_color_g"),
             team_color_b=args.get("team_color_b"),
+            loading_chase_length=args.get("loading_chase_length"),
         )

--- a/src/evo_lib/drivers/led_strip/ws2812b.py
+++ b/src/evo_lib/drivers/led_strip/ws2812b.py
@@ -1,0 +1,322 @@
+"""WS2812B (NeoPixel) addressable LED strip via rpi_ws281x.
+
+The WS2812B uses a single-wire 800 kHz protocol with strict timing that the
+Pi cannot bit-bang reliably from user space. The ``rpi_ws281x`` C library
+handles it via PWM/PCM/SPI DMA depending on the GPIO pin chosen:
+
+- GPIO 12, 18 → PWM channel 0 (default)
+- GPIO 13, 19 → PWM channel 1
+- GPIO 21     → PCM
+- GPIO 10     → SPI MOSI (no root required, but SPI must be enabled)
+
+Same single-file layout as ``tcs34725.py`` / ``pwm_led.py``: real driver,
+its config-driven Definition, the virtual twin, and its Definition all live
+together.
+
+The hardware-touching code is funneled through ``_hw_*`` hook methods so
+subclasses (``WS2812BVirtual``, ``MdbLed`` -> ``MdbLedVirtual``) can swap
+the rpi_ws281x backend out for an in-memory buffer without re-implementing
+the public ``LedStrip`` API on top.
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.interfaces.led_strip import LedStrip
+from evo_lib.logger import Logger
+from evo_lib.task import ImmediateResultTask, Task
+
+# Lazy-loaded inside _hw_init_strip() so this module imports on dev machines
+# without rpi_ws281x installed (it's an optional rpi extra).
+_ws = None
+
+_DEFAULT_FREQUENCY_HZ = 800_000
+_DEFAULT_DMA_CHANNEL = 10
+_DEFAULT_PIN = 12  # PWM0; matches legacy WS2812BLedStrip(42, board.D12, 36, 1.0)
+
+
+def _clamp_unit(v: float) -> float:
+    return 0.0 if v < 0.0 else 1.0 if v > 1.0 else v
+
+
+def _pack_rgb(r: float, g: float, b: float) -> int:
+    """Pack three normalized [0,1] floats into a 0xRRGGBB 24-bit int."""
+    rb = round(_clamp_unit(r) * 255)
+    gb = round(_clamp_unit(g) * 255)
+    bb = round(_clamp_unit(b) * 255)
+    return (rb << 16) | (gb << 8) | bb
+
+
+def _unpack_rgb(packed: int) -> tuple[float, float, float]:
+    return (
+        ((packed >> 16) & 0xFF) / 255.0,
+        ((packed >>  8) & 0xFF) / 255.0,
+        ((packed      ) & 0xFF) / 255.0,
+    )
+
+
+class WS2812B(LedStrip):
+    """WS2812B / NeoPixel strip driven by rpi_ws281x DMA."""
+
+    commands = DriverCommands(parents=[LedStrip.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        num_pixels: int,
+        pin: int = _DEFAULT_PIN,
+        brightness: float = 1.0,
+        frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
+        dma_channel: int = _DEFAULT_DMA_CHANNEL,
+    ):
+        super().__init__(name)
+        if num_pixels <= 0:
+            raise ValueError(f"num_pixels must be > 0, got {num_pixels}")
+        self._log = logger
+        self._num_pixels = num_pixels
+        self._pin = pin
+        self._brightness = _clamp_unit(brightness)
+        self._frequency_hz = frequency_hz
+        self._dma_channel = dma_channel
+        self._strip = None  # set by _hw_init_strip on real hardware
+
+    def init(self) -> Task[()]:
+        self._hw_init_strip()
+        self._log.info(
+            f"{type(self).__name__} '{self.name}' initialized: "
+            f"{self._num_pixels} px on GPIO {self._pin} "
+            f"(freq={self._frequency_hz} Hz, dma={self._dma_channel}, "
+            f"brightness={self._brightness:.2f})"
+        )
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        self._hw_close_strip()
+        self._log.info(f"{type(self).__name__} '{self.name}' closed")
+
+    def set_pixel(self, index: int, r: float, g: float, b: float) -> Task[()]:
+        if not 0 <= index < self._num_pixels:
+            raise IndexError(
+                f"pixel index {index} out of range [0, {self._num_pixels})"
+            )
+        self._hw_set_pixel(index, _pack_rgb(r, g, b))
+        return ImmediateResultTask()
+
+    def get_pixel(self, index: int) -> Task[float, float, float]:
+        if not 0 <= index < self._num_pixels:
+            raise IndexError(
+                f"pixel index {index} out of range [0, {self._num_pixels})"
+            )
+        r, g, b = _unpack_rgb(self._hw_get_pixel(index))
+        return ImmediateResultTask(r, g, b)
+
+    def fill(self, r: float, g: float, b: float) -> Task[()]:
+        packed = _pack_rgb(r, g, b)
+        for i in range(self._num_pixels):
+            self._hw_set_pixel(i, packed)
+        return ImmediateResultTask()
+
+    def set_brightness(self, brightness: float) -> Task[()]:
+        self._brightness = _clamp_unit(brightness)
+        self._hw_set_brightness(round(self._brightness * 255))
+        return ImmediateResultTask()
+
+    def get_brightness(self) -> Task[float]:
+        return ImmediateResultTask(self._brightness)
+
+    def show(self) -> Task[()]:
+        self._hw_show()
+        return ImmediateResultTask()
+
+    def clear(self) -> Task[()]:
+        self.fill(0.0, 0.0, 0.0).wait()
+        return self.show()
+
+    @property
+    def num_pixels(self) -> int:
+        return self._num_pixels
+
+    # --- Hardware boundary -------------------------------------------------
+    # Virtual subclasses override these to swap rpi_ws281x out for an
+    # in-memory buffer. The public API above is purely arithmetic + dispatch.
+
+    def _hw_init_strip(self) -> None:
+        global _ws
+        if _ws is None:
+            import rpi_ws281x  # lazy: only required on the actual robot
+
+            _ws = rpi_ws281x
+
+        self._strip = _ws.PixelStrip(
+            num=self._num_pixels,
+            pin=self._pin,
+            freq_hz=self._frequency_hz,
+            dma=self._dma_channel,
+            invert=False,
+            brightness=round(self._brightness * 255),
+            channel=0,
+            strip_type=_ws.WS2811_STRIP_GRB,
+        )
+        self._strip.begin()
+
+    def _hw_close_strip(self) -> None:
+        if self._strip is None:
+            return
+        # Best-effort blackout so a crash doesn't leave the robot lit.
+        for i in range(self._num_pixels):
+            self._strip.setPixelColor(i, 0)
+        self._strip.show()
+
+    def _hw_set_pixel(self, index: int, packed: int) -> None:
+        self._strip.setPixelColor(index, packed)
+
+    def _hw_get_pixel(self, index: int) -> int:
+        return self._strip.getPixelColor(index)
+
+    def _hw_show(self) -> None:
+        self._strip.show()
+
+    def _hw_set_brightness(self, byte_value: int) -> None:
+        self._strip.setBrightness(byte_value)
+
+
+class WS2812BDefinition(DriverDefinition):
+    """Factory for ``WS2812B`` from JSON5 config."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(WS2812B.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("num_pixels", ArgTypes.U16(help="Number of LEDs in the strip"))
+        defn.add_optional("pin", ArgTypes.U8(help="GPIO pin (BCM)"), _DEFAULT_PIN)
+        defn.add_optional("brightness", ArgTypes.F32(help="Initial brightness 0.0-1.0"), 1.0)
+        defn.add_optional(
+            "frequency_hz",
+            ArgTypes.U32(help="Bit clock; 800 kHz for WS2812B"),
+            _DEFAULT_FREQUENCY_HZ,
+        )
+        defn.add_optional(
+            "dma_channel",
+            ArgTypes.U8(help="DMA channel (avoid 0 — kernel uses it for SD)"),
+            _DEFAULT_DMA_CHANNEL,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> WS2812B:
+        name = args.get_name()
+        return WS2812B(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            num_pixels=args.get("num_pixels"),
+            pin=args.get("pin"),
+            brightness=args.get("brightness"),
+            frequency_hz=args.get("frequency_hz"),
+            dma_channel=args.get("dma_channel"),
+        )
+
+
+class WS2812BVirtual(WS2812B):
+    """In-memory WS2812B twin: same constructor surface as the real driver,
+    so swapping real↔virtual in config is a one-line change.
+
+    The DMA-related arguments (``pin``, ``frequency_hz``, ``dma_channel``)
+    are kept for **signature parity** with ``WS2812B`` and intentionally
+    ignored — orthogonal to simulation. Do not "simplify" them away.
+
+    The wire format (packed 0xRRGGBB ints) matches the real driver, so
+    tests can compare bit-exact.
+    """
+
+    commands = DriverCommands(parents=[WS2812B.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        num_pixels: int,
+        pin: int = _DEFAULT_PIN,
+        brightness: float = 1.0,
+        frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
+        dma_channel: int = _DEFAULT_DMA_CHANNEL,
+    ):
+        super().__init__(name, logger, num_pixels, pin, brightness, frequency_hz, dma_channel)
+        # Buffer (set by set_pixel/fill) and shown frame (set by show), as
+        # packed 0xRRGGBB ints.
+        self._buffer: list[int] = [0] * num_pixels
+        self._shown: list[int] = [0] * num_pixels
+        # Brightness as a 0-255 byte, mirroring rpi_ws281x's internal storage.
+        self._brightness_byte: int = round(self._brightness * 255)
+
+    def _hw_init_strip(self) -> None:
+        # No hardware to acquire.
+        pass
+
+    def _hw_close_strip(self) -> None:
+        pass
+
+    def _hw_set_pixel(self, index: int, packed: int) -> None:
+        self._buffer[index] = packed
+
+    def _hw_get_pixel(self, index: int) -> int:
+        return self._buffer[index]
+
+    def _hw_show(self) -> None:
+        self._shown = list(self._buffer)
+
+    def _hw_set_brightness(self, byte_value: int) -> None:
+        self._brightness_byte = byte_value
+
+    # --- Test helpers, virtual-only ------------------------------------
+
+    def get_shown_frame(self) -> list[tuple[float, float, float]]:
+        """Return the last frame pushed via ``show`` as RGB triplets.
+
+        Lets tests assert the user actually called ``show`` after buffering
+        — buffer-only writes won't show up here.
+        """
+        return [_unpack_rgb(p) for p in self._shown]
+
+
+class WS2812BVirtualDefinition(DriverDefinition):
+    """Factory for ``WS2812BVirtual``. Mirrors ``WS2812BDefinition`` so the
+    config can swap real↔virtual by changing only the driver name."""
+
+    def __init__(self, logger: Logger):
+        super().__init__(WS2812BVirtual.commands)
+        self._logger = logger
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("num_pixels", ArgTypes.U16(help="Number of LEDs in the strip"))
+        defn.add_optional("pin", ArgTypes.U8(help="GPIO pin (BCM, ignored)"), _DEFAULT_PIN)
+        defn.add_optional("brightness", ArgTypes.F32(help="Initial brightness 0.0-1.0"), 1.0)
+        defn.add_optional(
+            "frequency_hz",
+            ArgTypes.U32(help="Bit clock (ignored)"),
+            _DEFAULT_FREQUENCY_HZ,
+        )
+        defn.add_optional(
+            "dma_channel",
+            ArgTypes.U8(help="DMA channel (ignored)"),
+            _DEFAULT_DMA_CHANNEL,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> WS2812BVirtual:
+        name = args.get_name()
+        return WS2812BVirtual(
+            name=name,
+            logger=self._logger.get_sublogger(name),
+            num_pixels=args.get("num_pixels"),
+            pin=args.get("pin"),
+            brightness=args.get("brightness"),
+            frequency_hz=args.get("frequency_hz"),
+            dma_channel=args.get("dma_channel"),
+        )

--- a/src/evo_lib/drivers/pilot/serial_pilot.py
+++ b/src/evo_lib/drivers/pilot/serial_pilot.py
@@ -563,9 +563,9 @@ class HolonomicSerialPilot(DifferentialSerialPilot, HolonomicPilot):
     ) -> Task[PilotMoveStatus]:
         raise NotImplementedError("follow_holonomic_path not implemented yet")
 
-    @commands.register(args=[], result=[])
     def calibrate_otos(self) -> Task[()]:
-        """Calibrate the optical tracking sensor (OTOS)."""
+        """Override `Pilot.calibrate_otos` to forward the calibration
+        request to the firmware via the serial command bus."""
         return self._send_command(Commands.OTOS_CAL)
 
 

--- a/src/evo_lib/interfaces/led_strip.py
+++ b/src/evo_lib/interfaces/led_strip.py
@@ -3,43 +3,89 @@
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import DriverCommands
 from evo_lib.peripheral import Placable
 
 if TYPE_CHECKING:
     from evo_lib.task import Task
-    from evo_lib.types.color import Color
 
 
 class LedStrip(Placable):
-    """An addressable RGB LED strip (e.g. WS2812B / NeoPixel)."""
+    """An addressable RGB LED strip (e.g. WS2812B / NeoPixel).
+
+    Pixel writes (``set_pixel``, ``fill``) are buffered: they only mutate an
+    in-memory framebuffer. Call ``show`` to push the buffer to the hardware in
+    a single shot — this avoids visible tearing during multi-pixel updates.
+
+    Color values are floats in [0.0, 1.0] (clamped). The Clear / alpha channel
+    of the ``Color`` type is ignored here: LED hardware only consumes RGB.
+    """
+
+    commands = DriverCommands()
 
     @abstractmethod
-    def set_pixel(self, index: int, color: Color) -> None:
-        """Set a single pixel color (buffered, call show() to apply)."""
+    @commands.register(
+        args=[
+            ("index", ArgTypes.U16(help="0-based pixel index (< num_pixels)")),
+            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
+            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
+            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
+        ],
+        result=[],
+    )
+    def set_pixel(self, index: int, r: float, g: float, b: float) -> Task[()]:
+        """Buffer one pixel; call ``show`` to apply."""
 
     @abstractmethod
-    def get_pixel(self, index: int) -> Color:
-        """Get the color of the current pixel (in the buffer)."""
+    @commands.register(
+        args=[("index", ArgTypes.U16(help="0-based pixel index"))],
+        result=[
+            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
+            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
+            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
+        ],
+    )
+    def get_pixel(self, index: int) -> Task[float, float, float]:
+        """Read back the buffered RGB triplet at ``index``."""
 
     @abstractmethod
-    def fill(self, color: Color) -> None:
-        """Set all pixels to the same color (buffered, call show() to apply)."""
+    @commands.register(
+        args=[
+            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
+            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
+            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
+        ],
+        result=[],
+    )
+    def fill(self, r: float, g: float, b: float) -> Task[()]:
+        """Buffer the same color into every pixel; call ``show`` to apply."""
 
     @abstractmethod
-    def set_brightness(self, brightness: float) -> None:
-        """Set global brightness (0.0 to 1.0)."""
+    @commands.register(
+        args=[("brightness", ArgTypes.F32(help="Global brightness 0.0-1.0"))],
+        result=[],
+    )
+    def set_brightness(self, brightness: float) -> Task[()]:
+        """Set global brightness multiplier (clamped to 0.0-1.0)."""
 
     @abstractmethod
-    def get_brightness(self) -> float:
-        """Get current global brightness (0.0 to 1.0)."""
+    @commands.register(
+        args=[],
+        result=[("brightness", ArgTypes.F32(help="Current brightness 0.0-1.0"))],
+    )
+    def get_brightness(self) -> Task[float]:
+        """Return the current global brightness multiplier."""
 
     @abstractmethod
-    def show(self) -> Task[None]:
-        """Push the pixel buffer to the hardware."""
+    @commands.register(args=[], result=[])
+    def show(self) -> Task[()]:
+        """Push the pixel buffer to the hardware in one shot."""
 
     @abstractmethod
-    def clear(self) -> Task[None]:
-        """Turn off all pixels and show immediately."""
+    @commands.register(args=[], result=[])
+    def clear(self) -> Task[()]:
+        """Buffer black on every pixel and ``show`` immediately."""
 
     @property
     @abstractmethod

--- a/src/evo_lib/interfaces/pilot.py
+++ b/src/evo_lib/interfaces/pilot.py
@@ -9,6 +9,7 @@ from evo_lib.argtypes import ArgTypes
 from evo_lib.driver_definition import DriverCommands
 from evo_lib.event import Event
 from evo_lib.peripheral import Placable
+from evo_lib.task import ImmediateResultTask
 from evo_lib.types.pose import Pose2D
 from evo_lib.types.vect import Vect2D
 
@@ -102,6 +103,15 @@ class Pilot(Placable):
     @commands.register(args = [("pose", Pose2D.ArgType())], result = [])
     def set_pose(self, pose: Pose2D) -> Task[()]:
         pass
+
+    @commands.register(args = [], result = [])
+    def calibrate_otos(self) -> "Task[()]":
+        """Calibrate an optional optical tracking sensor (OTOS).
+
+        Default: no-op. Pilots backed by a firmware exposing an OTOS
+        calibration command override this to run it on the MCU.
+        """
+        return ImmediateResultTask()
 
     @abstractmethod
     @commands.register(args = [

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -1,0 +1,124 @@
+"""Tests for the WS2812BVirtual LedStrip driver.
+
+The real WS2812B driver is not exercised here: it requires DMA hardware and
+``rpi_ws281x``, which is only available on a Pi with the optional ``rpi``
+extra. The virtual is a faithful in-memory twin and shares the wire format
+(packed 0xRRGGBB ints), so it covers the contract end-to-end.
+"""
+
+import pytest
+
+from evo_lib.drivers.led_strip.ws2812b import (
+    WS2812BVirtual,
+    _pack_rgb,
+    _unpack_rgb,
+)
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def logger():
+    return Logger("test")
+
+
+@pytest.fixture
+def strip(logger):
+    s = WS2812BVirtual(name="strip", logger=logger, num_pixels=8)
+    s.init().wait()
+    return s
+
+
+# ── Packing helpers ──────────────────────────────────────────────────────
+
+class TestPacking:
+    def test_pack_rgb_clamps_above_one(self):
+        assert _pack_rgb(2.0, -0.5, 0.5) == 0xFF0080
+
+    def test_unpack_round_trip(self):
+        # Asymmetric values (not just (1,1,1)) so a R/B-swap bug shows up.
+        for r, g, b in [(0.0, 0.0, 0.0), (1.0, 0.5, 0.25), (0.1, 0.2, 0.3)]:
+            ru, gu, bu = _unpack_rgb(_pack_rgb(r, g, b))
+            # Quantization through 8-bit ints: tolerate ±1/255.
+            assert abs(ru - r) < 1 / 255 + 1e-9
+            assert abs(gu - g) < 1 / 255 + 1e-9
+            assert abs(bu - b) < 1 / 255 + 1e-9
+
+
+# ── WS2812BVirtual ───────────────────────────────────────────────────────
+
+class TestWS2812BVirtual:
+    def test_zero_pixels_is_rejected(self, logger):
+        with pytest.raises(ValueError):
+            WS2812BVirtual(name="bad", logger=logger, num_pixels=0)
+
+    def test_set_pixel_then_get_pixel_round_trips(self, strip):
+        strip.set_pixel(3, 1.0, 0.5, 0.0).wait()
+        r, g, b = strip.get_pixel(3).wait()
+        assert abs(r - 1.0) < 1 / 255 + 1e-9
+        assert abs(g - 0.5) < 1 / 255 + 1e-9
+        assert abs(b - 0.0) < 1 / 255 + 1e-9
+
+    def test_get_pixel_out_of_range_raises(self, strip):
+        with pytest.raises(IndexError):
+            strip.get_pixel(99).wait()
+
+    def test_set_pixel_out_of_range_raises(self, strip):
+        with pytest.raises(IndexError):
+            strip.set_pixel(99, 1.0, 0.0, 0.0).wait()
+
+    def test_fill_writes_every_pixel(self, strip):
+        strip.fill(0.2, 0.4, 0.8).wait()
+        for i in range(strip.num_pixels):
+            r, g, b = strip.get_pixel(i).wait()
+            assert abs(r - 0.2) < 1 / 255 + 1e-9
+            assert abs(g - 0.4) < 1 / 255 + 1e-9
+            assert abs(b - 0.8) < 1 / 255 + 1e-9
+
+    def test_show_required_to_publish_buffer(self, strip):
+        # Buffer-only writes don't update the shown frame.
+        strip.fill(1.0, 0.0, 0.0).wait()
+        for px in strip.get_shown_frame():
+            assert px == (0.0, 0.0, 0.0)
+
+        strip.show().wait()
+        for r, g, b in strip.get_shown_frame():
+            assert abs(r - 1.0) < 1 / 255 + 1e-9
+            assert g == 0.0 and b == 0.0
+
+    def test_clear_blacks_out_and_shows(self, strip):
+        strip.fill(1.0, 1.0, 1.0).wait()
+        strip.show().wait()
+        strip.clear().wait()
+        for px in strip.get_shown_frame():
+            assert px == (0.0, 0.0, 0.0)
+
+    def test_brightness_clamps(self, strip):
+        strip.set_brightness(2.0).wait()
+        (b,) = strip.get_brightness().wait()
+        assert b == 1.0
+        strip.set_brightness(-0.5).wait()
+        (b,) = strip.get_brightness().wait()
+        assert b == 0.0
+
+    def test_pixel_clamps(self, strip):
+        # Out-of-range floats are clamped at the byte boundary, not raised.
+        strip.set_pixel(0, 5.0, -1.0, 0.5).wait()
+        r, g, b = strip.get_pixel(0).wait()
+        assert r == 1.0
+        assert g == 0.0
+        assert abs(b - 0.5) < 1 / 255 + 1e-9
+
+    def test_signature_parity_with_real_driver(self):
+        """The virtual must accept exactly the same kwargs as the real driver,
+        per the swap invariant in CLAUDE.local.md — otherwise a real↔virtual
+        config swap would force edits to other lines."""
+        import inspect
+
+        from evo_lib.drivers.led_strip.ws2812b import WS2812B
+
+        real_params = set(inspect.signature(WS2812B.__init__).parameters)
+        virt_params = set(inspect.signature(WS2812BVirtual.__init__).parameters)
+        assert real_params == virt_params, (
+            f"WS2812B vs WS2812BVirtual ctor mismatch: "
+            f"only-real={real_params - virt_params}, only-virt={virt_params - real_params}"
+        )

--- a/tests/test_mdb_led.py
+++ b/tests/test_mdb_led.py
@@ -29,6 +29,22 @@ def strip(logger):
         name="mdb",
         logger=logger,
         num_pixels=4,
+        loading_chase_length=1,  # legacy width — most rendering tests assume single-pixel chase
+        auto_start_animator=False,
+    )
+    s.init().wait()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def wide_strip(logger):
+    """Strip large enough to observe a 5-pixel chase without wrap."""
+    s = MdbLedVirtual(
+        name="mdb_wide",
+        logger=logger,
+        num_pixels=12,
+        loading_chase_length=5,
         auto_start_animator=False,
     )
     s.init().wait()
@@ -93,6 +109,27 @@ class TestRendering:
                     assert abs(b - 1.0) < 1 / 255 + 1e-9
                 else:
                     assert (r, g, b) == (0.0, 0.0, 0.0)
+
+    def test_loading_chase_width(self, wide_strip):
+        # 12-pixel strip, 5-pixel chase. Step 0 should light pixels 0..4
+        # in team color and leave the other 7 black.
+        wide_strip.set_team_color(0.0, 0.0, 1.0).wait()  # blue
+        wide_strip.set_state(MdbLedState.Loading).wait()
+        wide_strip.tick()
+        frame = wide_strip.get_shown_frame()
+        for i in range(5):
+            assert abs(frame[i][2] - 1.0) < 1 / 255 + 1e-9, f"pixel {i} should be blue"
+        for i in range(5, 12):
+            assert frame[i] == (0.0, 0.0, 0.0), f"pixel {i} should be black"
+
+        # Step 1 → window slides by one (pixels 1..5 lit).
+        wide_strip.tick()
+        frame = wide_strip.get_shown_frame()
+        assert frame[0] == (0.0, 0.0, 0.0)
+        for i in range(1, 6):
+            assert abs(frame[i][2] - 1.0) < 1 / 255 + 1e-9
+        for i in range(6, 12):
+            assert frame[i] == (0.0, 0.0, 0.0)
 
     def test_state_change_resets_step(self, strip):
         # In Loading, step n picks pixel n % num_pixels. After advancing,

--- a/tests/test_mdb_led.py
+++ b/tests/test_mdb_led.py
@@ -1,0 +1,177 @@
+"""Tests for MdbLed (state machine + animator) on the virtual backend.
+
+The animator thread is disabled in most tests via ``auto_start_animator=False``
+so each frame can be inspected deterministically with ``tick()``. A separate
+test exercises the live thread to confirm wakeup signalling actually works.
+"""
+
+import threading
+import time
+
+import pytest
+
+from evo_lib.drivers.led_strip.mdb_led import (
+    MdbLed,
+    MdbLedState,
+    MdbLedVirtual,
+)
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def logger():
+    return Logger("test")
+
+
+@pytest.fixture
+def strip(logger):
+    s = MdbLedVirtual(
+        name="mdb",
+        logger=logger,
+        num_pixels=4,
+        auto_start_animator=False,
+    )
+    s.init().wait()
+    yield s
+    s.close()
+
+
+def _all_pixels_equal(frame, expected, tol=1 / 255 + 1e-9):
+    er, eg, eb = expected
+    for r, g, b in frame:
+        assert abs(r - er) < tol
+        assert abs(g - eg) < tol
+        assert abs(b - eb) < tol
+
+
+class TestRendering:
+    """One test per branch of ``_render_frame``."""
+
+    def test_off_renders_black(self, strip):
+        strip.set_state(MdbLedState.Off).wait()
+        strip.tick()
+        _all_pixels_equal(strip.get_shown_frame(), (0.0, 0.0, 0.0))
+
+    def test_running_renders_solid_green(self, strip):
+        strip.set_state(MdbLedState.Running).wait()
+        strip.tick()
+        _all_pixels_equal(strip.get_shown_frame(), (0.0, 1.0, 0.0))
+
+    def test_error_blinks_red_then_black(self, strip):
+        strip.set_state(MdbLedState.Error).wait()
+        strip.tick()  # step 0 → on
+        _all_pixels_equal(strip.get_shown_frame(), (1.0, 0.0, 0.0))
+        strip.tick()  # step 1 → off
+        _all_pixels_equal(strip.get_shown_frame(), (0.0, 0.0, 0.0))
+
+    def test_disabled_alternates_orange_per_pixel(self, strip):
+        strip.set_state(MdbLedState.Disabled).wait()
+        strip.tick()  # step 0
+        frame = strip.get_shown_frame()
+        assert frame[0][0] > 0.9 and frame[0][1] > 0.4  # orange
+        assert frame[1] == (0.0, 0.0, 0.0)
+        assert frame[2][0] > 0.9
+        assert frame[3] == (0.0, 0.0, 0.0)
+
+        strip.tick()  # step 1, parity flipped
+        frame = strip.get_shown_frame()
+        assert frame[0] == (0.0, 0.0, 0.0)
+        assert frame[1][0] > 0.9 and frame[1][1] > 0.4
+        assert frame[2] == (0.0, 0.0, 0.0)
+        assert frame[3][0] > 0.9
+
+    def test_loading_chases_team_color(self, strip):
+        # Doubles as a check that set_team_color is actually applied.
+        strip.set_team_color(0.0, 0.0, 1.0).wait()  # blue
+        strip.set_state(MdbLedState.Loading).wait()
+        for step in range(strip.num_pixels * 2):
+            strip.tick()
+            frame = strip.get_shown_frame()
+            lit_idx = step % strip.num_pixels
+            for i, (r, g, b) in enumerate(frame):
+                if i == lit_idx:
+                    assert abs(b - 1.0) < 1 / 255 + 1e-9
+                else:
+                    assert (r, g, b) == (0.0, 0.0, 0.0)
+
+    def test_state_change_resets_step(self, strip):
+        # In Loading, step n picks pixel n % num_pixels. After advancing,
+        # switching to a different state must restart the chase from 0.
+        strip.set_state(MdbLedState.Loading).wait()
+        for _ in range(3):
+            strip.tick()
+
+        strip.set_state(MdbLedState.Off).wait()
+        strip.set_state(MdbLedState.Loading).wait()
+        strip.tick()  # should render step 0 → only pixel 0 lit
+
+        frame = strip.get_shown_frame()
+        assert frame[0] != (0.0, 0.0, 0.0)
+        for i in range(1, strip.num_pixels):
+            assert frame[i] == (0.0, 0.0, 0.0)
+
+
+class TestStateRoundTrip:
+    """Cover get_state / get_team_color paths that rendering tests don't hit."""
+
+    def test_state_and_team_color_round_trip(self, strip):
+        strip.set_state(MdbLedState.Loading).wait()
+        strip.set_team_color(0.1, 0.2, 0.3).wait()
+
+        (state,) = strip.get_state().wait()
+        assert state == MdbLedState.Loading
+
+        r, g, b = strip.get_team_color().wait()
+        tol = 1 / 255 + 1e-9
+        assert abs(r - 0.1) < tol
+        assert abs(g - 0.2) < tol
+        assert abs(b - 0.3) < tol
+
+
+class TestAnimatorThread:
+    """End-to-end: the animator thread + wakeup actually drive renders."""
+
+    def test_thread_renders_running_state(self, logger):
+        s = MdbLedVirtual(name="live", logger=logger, num_pixels=3)
+        s.init().wait()
+        try:
+            s.set_state(MdbLedState.Running).wait()
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline:
+                frame = s.get_shown_frame()
+                if frame and frame[0] == (0.0, 1.0, 0.0):
+                    break
+                time.sleep(0.01)
+            else:
+                pytest.fail("animator never rendered Running state within 500 ms")
+            for px in s.get_shown_frame():
+                assert px == (0.0, 1.0, 0.0)
+        finally:
+            s.close()
+
+    def test_close_stops_thread(self, logger):
+        s = MdbLedVirtual(name="live2", logger=logger, num_pixels=3)
+        s.init().wait()
+        s.set_state(MdbLedState.Loading).wait()
+        time.sleep(0.05)
+        s.close()
+        leaked = [
+            t for t in threading.enumerate()
+            if t.name == "mdb-led-live2" and t.is_alive()
+        ]
+        assert leaked == [], f"animator thread leaked: {leaked}"
+
+
+class TestSwapInvariant:
+    def test_signature_parity_real_vs_virtual(self):
+        """Per CLAUDE.local.md: the virtual must accept exactly the same
+        kwargs as the real driver, otherwise a real↔virtual config swap
+        forces edits to other lines."""
+        import inspect
+
+        real_params = set(inspect.signature(MdbLed.__init__).parameters)
+        virt_params = set(inspect.signature(MdbLedVirtual.__init__).parameters)
+        assert real_params == virt_params, (
+            f"only-real={real_params - virt_params}, "
+            f"only-virt={virt_params - real_params}"
+        )


### PR DESCRIPTION
Adds a WS2812B driver via rpi_ws281x with a virtual twin, and MdbLed on top: a state-machine indicator (Off / Disabled / Loading / Running / Error) with a daemon animator. Loading chase width is configurable, default 5 pixels.

Closes #87.