### PR TITLE
feat(gpio): add Button and PowerButton drivers

### DIFF
--- a/src/evo_lib/config.py
+++ b/src/evo_lib/config.py
@@ -59,8 +59,8 @@ class ConfigObject(dict[str, ConfigValue]):
             return argtype.value_from_config(value)
         return value
 
-    def get_bool(self, key: str) -> bool:
-        return self._get_required(key, [bool], "a boolean", None)
+    def get_bool(self, key: str, argtype: "ArgTypes.Bool | None" = None) -> bool:
+        return self._get_required(key, [bool], "a boolean", argtype)
 
     def get_str(self, key: str, argtype: ArgTypes.String | None = None) -> str:
         return self._get_required(key, [str], "a string", argtype)

--- a/src/evo_lib/drivers/gpio/button.py
+++ b/src/evo_lib/drivers/gpio/button.py
@@ -1,0 +1,174 @@
+"""Button driver: wraps a GPIO INPUT to detect press/release transitions.
+
+Both Button and ButtonVirtual take a GPIO peripheral by reference;
+they do not instantiate their own GPIO. This lets a button sit on any
+GPIO source (RPi, MCP23017, virtual, ...) chosen in config.
+
+For the soft-power case (single physical button driving both a shutdown
+signal and a power-latch output), use ``power_button.py`` instead.
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
+from evo_lib.event import Event
+from evo_lib.interfaces.gpio import GPIO, GPIOEdge
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral, Placable
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class Button(Placable):
+    """Listens to a GPIO interrupt to detect press/release events.
+
+    The GPIO is injected and managed externally (by the PeripheralsManager).
+    ``debounce_s`` filters mechanical bouncing on press/release: only a
+    state stable for ``debounce_s`` is propagated to listeners.
+    """
+
+    commands = DriverCommands()
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio: GPIO,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
+        super().__init__(name)
+        self._logger = logger
+        self._gpio = gpio
+        self._active_state = active_state
+        self._debounce_s = debounce_s
+
+    def init(self) -> Task[()]:
+        # GPIO dependency is initialized by the PeripheralsManager.
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        # GPIO dependency is closed by the PeripheralsManager.
+        pass
+
+    def get_trigger_event(self) -> Event[bool]:
+        """Return an event with an argument at True when the button is pressed."""
+        event = self._gpio.interrupt(GPIOEdge.BOTH).transform(
+            lambda x: (x == self._active_state,)
+        )
+        if self._debounce_s > 0:
+            event = event.debounce(self._debounce_s)
+        return event
+
+    @commands.register(
+        args=[],
+        result=[("pressed", ArgTypes.Bool(help="True if the button is currently pressed"))],
+    )
+    def is_pressed(self) -> Task[bool]:
+        """Return True if the button is currently in its active state."""
+        gpio_state = self._gpio.read().wait()[0]
+        return ImmediateResultTask(gpio_state == self._active_state)
+
+
+class ButtonDefinition(DriverDefinition):
+    """Factory for Button. Takes a GPIO peripheral by reference."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(Button.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("gpio", ArgTypes.Component(GPIO, self._peripherals))
+        defn.add_required(
+            "active_state",
+            ArgTypes.Bool(help="True means the button reads HIGH when pressed (active-high)"),
+        )
+        defn.add_optional(
+            "debounce_s",
+            ArgTypes.F32(help="Stability window (s) for mechanical bouncing"),
+            0.0,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> Button:
+        return Button(
+            args.get_name(),
+            self._logger,
+            args.get("gpio"),
+            args.get("active_state"),
+            args.get("debounce_s"),
+        )
+
+
+class ButtonVirtual(Button):
+    """Virtual button: same as Button but adds press/release simulation commands.
+
+    Requires a GPIOPinVirtual (which exposes inject_input) rather than any
+    GPIO interface.
+    """
+
+    commands = DriverCommands(parents=[Button.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio: GPIOPinVirtual,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
+        super().__init__(name, logger, gpio, active_state, debounce_s)
+        self._virtual_gpio = gpio
+
+    @commands.register(args=[], result=[])
+    def press(self) -> Task[()]:
+        """Simulate pressing the button."""
+        self._virtual_gpio.inject_input(self._active_state)
+        self._logger.info(f"Button '{self.name}' pressed (simulated)")
+        return ImmediateResultTask()
+
+    @commands.register(args=[], result=[])
+    def release(self) -> Task[()]:
+        """Simulate releasing the button."""
+        self._virtual_gpio.inject_input(not self._active_state)
+        self._logger.info(f"Button '{self.name}' released (simulated)")
+        return ImmediateResultTask()
+
+
+class ButtonVirtualDefinition(DriverDefinition):
+    """Factory for ButtonVirtual. Takes a GPIOPinVirtual peripheral by reference."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(ButtonVirtual.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("gpio", ArgTypes.Component(GPIOPinVirtual, self._peripherals))
+        defn.add_required(
+            "active_state",
+            ArgTypes.Bool(help="True means the button reads HIGH when pressed (active-high)"),
+        )
+        defn.add_optional(
+            "debounce_s",
+            ArgTypes.F32(help="Stability window (s) for mechanical bouncing"),
+            0.0,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> ButtonVirtual:
+        return ButtonVirtual(
+            args.get_name(),
+            self._logger,
+            args.get("gpio"),
+            args.get("active_state"),
+            args.get("debounce_s"),
+        )

--- a/src/evo_lib/drivers/gpio/power_button.py
+++ b/src/evo_lib/drivers/gpio/power_button.py
@@ -1,0 +1,203 @@
+"""PowerButton driver: soft-power button with shutdown signal + power latch.
+
+A typical Pi/embedded "soft-power" circuit has a single physical button
+wired to two GPIO pins:
+
+- ``gpio_int`` (INPUT): asserted when the user presses the button to ask
+  the robot to shut down. The driver exposes the press as a debounced Event.
+- ``gpio_hold`` (OUTPUT): held HIGH at ``init()`` to keep the robot powered
+  on (latch). The driver exposes ``release_power()`` which sets it LOW;
+  that physically cuts the robot's power.
+
+The driver intentionally does NOT release power on ``close()``: closing the
+peripheral (e.g. lib reload during dev) must not power off the robot. Power
+is cut only via the explicit ``release_power()`` command.
+"""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
+from evo_lib.event import Event
+from evo_lib.interfaces.gpio import GPIO, GPIOEdge
+from evo_lib.logger import Logger
+from evo_lib.peripheral import Peripheral, Placable
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class PowerButton(Placable):
+    """Soft-power button: shutdown event on input, power latch on output.
+
+    The GPIO peripherals are injected and managed externally (by the
+    PeripheralsManager). ``active_state`` is the level that ``gpio_int``
+    reads when the button is pressed.
+    """
+
+    commands = DriverCommands()
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio_int: GPIO,
+        gpio_hold: GPIO,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
+        super().__init__(name)
+        self._logger = logger
+        self._gpio_int = gpio_int
+        self._gpio_hold = gpio_hold
+        self._active_state = active_state
+        self._debounce_s = debounce_s
+
+    def init(self) -> Task[()]:
+        # Latch power immediately. The PeripheralsManager initializes both
+        # GPIO peripherals before us, so writing here is safe.
+        return self._gpio_hold.write(True)
+
+    def close(self) -> None:
+        # Intentional: do NOT touch gpio_hold here. close() runs during lib
+        # teardown; setting it LOW would power-off the robot on every dev
+        # reload. Power is only released via release_power().
+        pass
+
+    def get_trigger_event(self) -> Event[()]:
+        """Return an event that fires (debounced) on every button press."""
+        # Filter to the active edge HW-side: a release is meaningless on a
+        # soft-power button (no metric/strategy reacts to it), so we don't
+        # waste wakeups on it.
+        edge = GPIOEdge.RISING if self._active_state else GPIOEdge.FALLING
+        event = self._gpio_int.interrupt(edge).transform(lambda _: ())
+        if self._debounce_s > 0:
+            event = event.debounce(self._debounce_s)
+        return event
+
+    @commands.register(
+        args=[],
+        result=[("pressed", ArgTypes.Bool(help="True if the button is currently pressed"))],
+    )
+    def is_pressed(self) -> Task[bool]:
+        """Return True if the button is currently in its active state."""
+        gpio_state = self._gpio_int.read().wait()[0]
+        return ImmediateResultTask(gpio_state == self._active_state)
+
+    @commands.register(args=[], result=[])
+    def release_power(self) -> Task[None]:
+        """Release the power latch — the robot will physically power off."""
+        self._logger.warning(
+            f"PowerButton '{self.name}': releasing power latch — robot is shutting down"
+        )
+        return self._gpio_hold.write(False)
+
+
+class PowerButtonDefinition(DriverDefinition):
+    """Factory for PowerButton. Takes two GPIO peripherals by reference."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PowerButton.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("gpio_int", ArgTypes.Component(GPIO, self._peripherals))
+        defn.add_required("gpio_hold", ArgTypes.Component(GPIO, self._peripherals))
+        defn.add_required(
+            "active_state",
+            ArgTypes.Bool(help="True means gpio_int reads HIGH on press (active-high)"),
+        )
+        defn.add_optional(
+            "debounce_s",
+            ArgTypes.F32(help="Stability window (s) for mechanical bouncing"),
+            0.0,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PowerButton:
+        return PowerButton(
+            args.get_name(),
+            self._logger,
+            args.get("gpio_int"),
+            args.get("gpio_hold"),
+            args.get("active_state"),
+            args.get("debounce_s"),
+        )
+
+
+class PowerButtonVirtual(PowerButton):
+    """Virtual PowerButton: adds press/release simulation on the int line.
+
+    Requires GPIOPinVirtual peripherals for both ``gpio_int`` and ``gpio_hold``
+    — the hold pin is kept in the signature for parity with the real driver
+    even though the simulated press/release commands only stimulate the int
+    line. Tests that want to assert on the latch state read ``gpio_hold``
+    directly.
+    """
+
+    commands = DriverCommands(parents=[PowerButton.commands])
+
+    def __init__(
+        self,
+        name: str,
+        logger: Logger,
+        gpio_int: GPIOPinVirtual,
+        gpio_hold: GPIOPinVirtual,
+        active_state: bool,
+        debounce_s: float = 0.0,
+    ):
+        super().__init__(name, logger, gpio_int, gpio_hold, active_state, debounce_s)
+        self._virtual_int = gpio_int
+
+    @commands.register(args=[], result=[])
+    def press(self) -> Task[()]:
+        """Simulate pressing the power button."""
+        self._virtual_int.inject_input(self._active_state)
+        self._logger.info(f"PowerButton '{self.name}' pressed (simulated)")
+        return ImmediateResultTask()
+
+    @commands.register(args=[], result=[])
+    def release(self) -> Task[()]:
+        """Simulate releasing the power button."""
+        self._virtual_int.inject_input(not self._active_state)
+        self._logger.info(f"PowerButton '{self.name}' released (simulated)")
+        return ImmediateResultTask()
+
+
+class PowerButtonVirtualDefinition(DriverDefinition):
+    """Factory for PowerButtonVirtual."""
+
+    def __init__(self, logger: Logger, peripherals: Registry[Peripheral]):
+        super().__init__(PowerButtonVirtual.commands)
+        self._logger = logger
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required("gpio_int", ArgTypes.Component(GPIOPinVirtual, self._peripherals))
+        defn.add_required("gpio_hold", ArgTypes.Component(GPIOPinVirtual, self._peripherals))
+        defn.add_required(
+            "active_state",
+            ArgTypes.Bool(help="True means gpio_int reads HIGH on press (active-high)"),
+        )
+        defn.add_optional(
+            "debounce_s",
+            ArgTypes.F32(help="Stability window (s) for mechanical bouncing"),
+            0.0,
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> PowerButtonVirtual:
+        return PowerButtonVirtual(
+            args.get_name(),
+            self._logger,
+            args.get("gpio_int"),
+            args.get("gpio_hold"),
+            args.get("active_state"),
+            args.get("debounce_s"),
+        )

--- a/src/evo_lib/drivers/gpio/rpi.py
+++ b/src/evo_lib/drivers/gpio/rpi.py
@@ -98,13 +98,13 @@ class RpiGPIO(GPIO):
             return ImmediateErrorTask(NotImplementedError("read() requires INPUT direction"))
         return ImmediateResultTask(self._request.get_value(self._pin) == _gpiod.line.Value.ACTIVE)
 
-    def write(self, state: bool) -> Task[None]:
+    def write(self, state: bool) -> Task[()]:
         self._check_ready()
         if self._direction != GPIODirection.OUTPUT:
             return ImmediateErrorTask(NotImplementedError("write() requires OUTPUT direction"))
         value = _gpiod.line.Value.ACTIVE if state else _gpiod.line.Value.INACTIVE
         self._request.set_value(self._pin, value)
-        return ImmediateResultTask(None)
+        return ImmediateResultTask()
 
     def interrupt(self, edge: GPIOEdge = GPIOEdge.BOTH) -> Event[bool]:
         self._check_ready()
@@ -207,7 +207,7 @@ class RpiGPIOVirtual(GPIO):
     def read(self) -> Task[bool]:
         return self._inner.read()
 
-    def write(self, state: bool) -> Task[None]:
+    def write(self, state: bool) -> Task[()]:
         return self._inner.write(state)
 
     def interrupt(self, edge: GPIOEdge = GPIOEdge.BOTH) -> Event[bool]:

--- a/src/evo_lib/drivers/gpio/virtual.py
+++ b/src/evo_lib/drivers/gpio/virtual.py
@@ -64,9 +64,10 @@ class GPIOPinVirtual(GPIO):
         self._event = None
 
     def read(self) -> Task[bool]:
+        # Works on both INPUT and OUTPUT pins. On OUTPUT, returns the last
+        # value written — matches RPi.GPIO behavior and lets tests assert
+        # on what a driver has written to a virtual output pin.
         self._check_ready()
-        if self._direction != GPIODirection.INPUT:
-            return ImmediateErrorTask(NotImplementedError("read() requires INPUT direction"))
         return ImmediateResultTask(self._state)
 
     def write(self, state: bool) -> Task[None]:

--- a/src/evo_lib/drivers/gpio/virtual.py
+++ b/src/evo_lib/drivers/gpio/virtual.py
@@ -70,12 +70,12 @@ class GPIOPinVirtual(GPIO):
         self._check_ready()
         return ImmediateResultTask(self._state)
 
-    def write(self, state: bool) -> Task[None]:
+    def write(self, state: bool) -> Task[()]:
         self._check_ready()
         if self._direction != GPIODirection.OUTPUT:
             return ImmediateErrorTask(NotImplementedError("write() requires OUTPUT direction"))
         self._state = state
-        return ImmediateResultTask(None)
+        return ImmediateResultTask()
 
     def interrupt(self, edge: GPIOEdge = GPIOEdge.BOTH) -> Event[bool]:
         self._check_ready()

--- a/src/evo_lib/interfaces/gpio.py
+++ b/src/evo_lib/interfaces/gpio.py
@@ -44,7 +44,7 @@ class GPIO(Interface):
     @commands.register(args = [
         ("state", ArgTypes.Bool(help = "The state to set"))
     ], result = [])
-    def write(self, state: bool) -> Task[None]:
+    def write(self, state: bool) -> Task[()]:
         """Set the output state (True = high, False = low)."""
 
     @abstractmethod

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,69 @@
+"""Tests for virtual button driver."""
+
+import pytest
+
+from evo_lib.drivers.gpio.button import ButtonVirtual
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
+from evo_lib.interfaces.gpio import GPIODirection
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def button():
+    logger = Logger("test")
+    gpio = GPIOPinVirtual(name="button_gpio", logger=logger, direction=GPIODirection.INPUT, pin=21)
+    gpio.init().wait()
+    b = ButtonVirtual(name="button", logger=logger, gpio=gpio, active_state=True)
+    b.init().wait()
+    # Button starts released (matches the physical idle state on a pull-down circuit).
+    b.release().wait()
+    yield b
+    b.close()
+    gpio.close()
+
+
+@pytest.fixture
+def active_low_button():
+    """Button wired active-low (POWER_INT-style: pull-up + press pulls to GND)."""
+    logger = Logger("test")
+    gpio = GPIOPinVirtual(name="button_gpio", logger=logger, direction=GPIODirection.INPUT, pin=6)
+    gpio.init().wait()
+    b = ButtonVirtual(name="button", logger=logger, gpio=gpio, active_state=False)
+    b.init().wait()
+    b.release().wait()
+    yield b
+    b.close()
+    gpio.close()
+
+
+class TestButtonVirtual:
+    def test_press_triggers_pressed_event(self, button):
+        received = []
+        button.get_trigger_event().register(lambda pressed: received.append(pressed))
+
+        button.press().wait()
+        assert received == [True]
+
+    def test_release_after_press_triggers_not_pressed(self, button):
+        received = []
+        button.get_trigger_event().register(lambda pressed: received.append(pressed))
+
+        button.press().wait()
+        button.release().wait()
+        assert received == [True, False]
+
+    def test_is_pressed_reflects_state(self, button):
+        assert button.is_pressed().wait() == (False,)
+        button.press().wait()
+        assert button.is_pressed().wait() == (True,)
+        button.release().wait()
+        assert button.is_pressed().wait() == (False,)
+
+    def test_active_low_button_event_polarity(self, active_low_button):
+        """For active-low wiring, the pressed event arg is still True on press."""
+        received = []
+        active_low_button.get_trigger_event().register(lambda pressed: received.append(pressed))
+
+        active_low_button.press().wait()
+        active_low_button.release().wait()
+        assert received == [True, False]

--- a/tests/test_power_button.py
+++ b/tests/test_power_button.py
@@ -1,0 +1,88 @@
+"""Tests for virtual power button driver."""
+
+import pytest
+
+from evo_lib.drivers.gpio.power_button import PowerButtonVirtual
+from evo_lib.drivers.gpio.virtual import GPIOPinVirtual
+from evo_lib.interfaces.gpio import GPIODirection
+from evo_lib.logger import Logger
+
+
+@pytest.fixture
+def power_button():
+    """Soft-power button wired active-low (POWER_INT-style: pull-up, falling = press)."""
+    logger = Logger("test")
+    gpio_int = GPIOPinVirtual(
+        name="power_int", logger=logger, direction=GPIODirection.INPUT, pin=6
+    )
+    gpio_hold = GPIOPinVirtual(
+        name="power_hold", logger=logger, direction=GPIODirection.OUTPUT, pin=5
+    )
+    gpio_int.init().wait()
+    gpio_hold.init().wait()
+    pb = PowerButtonVirtual(
+        name="power_button",
+        logger=logger,
+        gpio_int=gpio_int,
+        gpio_hold=gpio_hold,
+        active_state=False,
+    )
+    pb.init().wait()
+    # Idle state on the int line: HIGH (button not pressed).
+    pb.release().wait()
+    yield pb, gpio_int, gpio_hold
+    pb.close()
+    gpio_int.close()
+    gpio_hold.close()
+
+
+class TestPowerButtonVirtual:
+    def test_init_latches_power_high(self, power_button):
+        """init() must immediately drive gpio_hold HIGH so the robot stays alive."""
+        _, _, gpio_hold = power_button
+        assert gpio_hold.read().wait() == (True,)
+
+    def test_press_triggers_shutdown_event(self, power_button):
+        pb, _, _ = power_button
+        received = []
+        pb.get_trigger_event().register(lambda: received.append(()))
+
+        pb.press().wait()
+        assert received == [()]
+
+    def test_release_does_not_trigger_event(self, power_button):
+        """The trigger event only fires on press (release is meaningless for soft-power)."""
+        pb, _, _ = power_button
+        received = []
+        pb.get_trigger_event().register(lambda: received.append(()))
+
+        pb.press().wait()
+        pb.release().wait()
+        assert received == [()]
+
+    def test_release_power_drops_hold_low(self, power_button):
+        """release_power() must drive gpio_hold LOW (physical power cut)."""
+        pb, _, gpio_hold = power_button
+        assert gpio_hold.read().wait() == (True,)
+
+        pb.release_power().wait()
+        assert gpio_hold.read().wait() == (False,)
+
+    def test_close_does_not_release_power(self, power_button):
+        """close() must NOT touch gpio_hold (would power-off on dev reload)."""
+        pb, _, gpio_hold = power_button
+        assert gpio_hold.read().wait() == (True,)
+
+        pb.close()
+        # gpio_hold not closed yet (would reset _state); the latch must
+        # still be HIGH after PowerButton.close().
+        assert gpio_hold.read().wait() == (True,)
+
+    def test_is_pressed_reflects_int_state(self, power_button):
+        """is_pressed reads gpio_int (not gpio_hold) — verifies wiring."""
+        pb, _, _ = power_button
+        assert pb.is_pressed().wait() == (False,)
+        pb.press().wait()
+        assert pb.is_pressed().wait() == (True,)
+        pb.release().wait()
+        assert pb.is_pressed().wait() == (False,)


### PR DESCRIPTION
- Generic `Button` driver: push-button on a GPIO INPUT, optional debounce, virtual twin
- `PowerButton` driver: soft-power button — shutdown signal + power latch held together in a single driver
- Minor: `GPIOPinVirtual.read()` now returns the last written value on OUTPUT pins (mock parity with `RPi.GPIO`)

Replaces the legacy `services/python/evolutek/utils/service_reset.py` polling loop. Mapping:
- `RESET_GPIO=21` → `Button` instance (active-high)
- `POWER_INT=6` + `POWER_HOLD=5` → single `PowerButton` instance (active-low int, latched output)