### PR TITLE
feat(color): multi-repr Color + TCS34725 flash differential & REPL diagnostics

### DIFF
--- a/src/evo_lib/drivers/color_sensor/tcs34725.py
+++ b/src/evo_lib/drivers/color_sensor/tcs34725.py
@@ -40,8 +40,12 @@ _COMMAND_BIT = 0x80
 _ENABLE = 0x00
 _ATIME = 0x01
 _CONTROL = 0x0F
+_ID = 0x12
 _STATUS = 0x13
 _CDATA = 0x14
+
+_CHIP_ID_TCS34725 = 0x44
+_CHIP_ID_TCS34727 = 0x4D
 
 _ENABLE_PON = 0x01
 _ENABLE_AEN = 0x02
@@ -180,10 +184,18 @@ class TCS34725(ColorSensor):
         (raw,) = self.read_color().wait()
         return ImmediateResultTask(self._palette.classify(Color(rgbc=raw)))
 
+    @commands.register(
+        args=[
+            ("name", ArgTypes.Enum(NamedColor, help="Color to calibrate against the presented pad")),
+        ],
+        result=[],
+    )
     def calibrate(self, name: NamedColor, samples: int = 10) -> Task[()]:
         """Average ``samples`` live readings and store the result as the palette ref for ``name``.
 
         Each sample goes through ``read_color``, so flash-differential applies when enabled.
+        Exposed as a REPL command for on-table commissioning (present a pad of the target
+        color in front of the sensor, then run ``<sensor>.calibrate <Color>``).
         """
         if samples < 1:
             raise ValueError(f"samples must be >= 1, got {samples}")
@@ -310,6 +322,22 @@ class TCS34725(ColorSensor):
     )
     def get_flash_differential(self) -> Task[bool]:
         return ImmediateResultTask(self._use_flash_differential)
+
+    @commands.register(
+        args=[],
+        result=[("chip_id", ArgTypes.U8(help="0x44 for TCS34725, 0x4D for TCS34727"))],
+    )
+    def get_chip_id(self) -> Task[int]:
+        """Read the chip ID register (0x12). Useful to confirm the I2C path on the right mux channel."""
+        return ImmediateResultTask(self._read_register(_ID))
+
+    @commands.register(
+        args=[],
+        result=[("status", ArgTypes.U8(help="STATUS register — bit 0 = AVALID"))],
+    )
+    def get_status(self) -> Task[int]:
+        """Read the STATUS register (0x13). Bit 0 = AVALID; should flip on every new integration."""
+        return ImmediateResultTask(self._read_register(_STATUS))
 
     # ── Internal helpers ─────────────────────────────────────────────────
 

--- a/src/evo_lib/drivers/color_sensor/tcs34725.py
+++ b/src/evo_lib/drivers/color_sensor/tcs34725.py
@@ -1,4 +1,19 @@
-"""TCS34725 RGBC color sensor over I2C, with optional on-board LED."""
+"""TCS34725 RGBC color sensor over I2C, with optional on-board LED.
+
+The driver implements two features that matter for noisy / variable lighting:
+
+1. **Flash differential** — ``read_color`` reads twice (LED OFF, LED ON) and
+   returns the per-channel difference, effectively subtracting ambient light.
+   Useful under TV projectors or changing table lighting. Disable via
+   ``use_flash_differential=False`` for debug, benchmarks, or when no LED
+   is wired.
+2. **Auto-exposure** — ``auto_expose`` iteratively adjusts integration time
+   to keep the Clear channel mid-range, avoiding saturation and keeping the
+   sensor in its linear regime.
+
+Classification is delegated to a ``Palette`` (default method: ``"hsv"``
+— hue is the most illuminant-robust of the available metrics).
+"""
 
 import struct
 import threading
@@ -18,7 +33,7 @@ from evo_lib.logger import Logger
 from evo_lib.peripheral import Peripheral
 from evo_lib.registry import Registry
 from evo_lib.task import DelayedTask, ImmediateResultTask, Task
-from evo_lib.types.color import ColorRaw, NamedColor, Palette
+from evo_lib.types.color import Color, ColorRGBC, NamedColor, Palette
 
 _COMMAND_BIT = 0x80
 
@@ -40,6 +55,13 @@ _ATIME_DEFAULT = 0xD5
 # Datasheet §Principles of Operation, Figure 9: 2.4 ms warm-up after PON.
 _POWER_ON_DELAY_S = 0.0024
 
+# Auto-exposure defaults: aim for the middle of the linear range.
+# ~45% of the theoretical 65535 max: enough headroom against saturation,
+# still well above the sensor noise floor.
+_AUTO_EXPOSE_TARGET_C = 30000
+_AUTO_EXPOSE_TOLERANCE = 0.2
+_AUTO_EXPOSE_MAX_ITER = 5
+
 
 def _ms_to_atime(ms: float) -> int:
     return max(0, min(255, round(256 - ms / _ATIME_STEP_MS)))
@@ -49,15 +71,15 @@ def _atime_to_ms(atime: int) -> float:
     return (256 - atime) * _ATIME_STEP_MS
 
 
-# Indicative refs for AGAIN=4×, ATIME≈100 ms, lit by an on-board white LED.
+# Indicative refs for AGAIN=4×, ATIME≈100 ms, lit by the on-board white LED.
 # Refine per-instance via calibrate() if responsivity drifts too much.
-TCS34725_DEFAULT_PALETTE: dict[NamedColor, ColorRaw] = {
-    NamedColor.Black:  ColorRaw(   200,   200,   200,    600),
-    NamedColor.White:  ColorRaw( 15000, 15000, 15000,  45000),
-    NamedColor.Red:    ColorRaw(  8500,  1200,   800,  10500),
-    NamedColor.Green:  ColorRaw(  1100,  6200,  1400,   8700),
-    NamedColor.Blue:   ColorRaw(   800,  1400,  5500,   7700),
-    NamedColor.Yellow: ColorRaw(  7000,  6500,  1500,  15000),
+TCS34725_DEFAULT_PALETTE: dict[NamedColor, Color] = {
+    NamedColor.Black:  Color.from_rgbc(   200,   200,   200,    600, name="Black"),
+    NamedColor.White:  Color.from_rgbc( 15000, 15000, 15000,  45000, name="White"),
+    NamedColor.Red:    Color.from_rgbc(  8500,  1200,   800,  10500, name="Red"),
+    NamedColor.Green:  Color.from_rgbc(  1100,  6200,  1400,   8700, name="Green"),
+    NamedColor.Blue:   Color.from_rgbc(   800,  1400,  5500,   7700, name="Blue"),
+    NamedColor.Yellow: Color.from_rgbc(  7000,  6500,  1500,  15000, name="Yellow"),
 }
 
 
@@ -74,7 +96,7 @@ class TCS34725(ColorSensor):
         gain: int = 4,
         light: LED | None = None,
         palette: Palette | None = None,
-        unknown_threshold_squared: float | None = None,
+        use_flash_differential: bool = True,
     ):
         super().__init__(name)
         if gain not in _GAIN_TO_BYTE:
@@ -86,7 +108,8 @@ class TCS34725(ColorSensor):
         self._gain = gain
         self._light = light
         self._palette = palette if palette is not None else Palette(refs=TCS34725_DEFAULT_PALETTE)
-        self._unknown_threshold_squared = unknown_threshold_squared
+        # Flash differential needs a wired LED — silently disable otherwise.
+        self._use_flash_differential = use_flash_differential and (light is not None)
         self._lock = threading.Lock()
 
     def init(self) -> Task[()]:
@@ -98,9 +121,10 @@ class TCS34725(ColorSensor):
                 self._write_register(_ENABLE, _ENABLE_PON | _ENABLE_AEN)
                 self._write_register(_ATIME, self._atime)
                 self._write_register(_CONTROL, _GAIN_TO_BYTE[self._gain])
+                flash = "ON" if self._use_flash_differential else "OFF"
                 self._log.info(
                     f"TCS34725 '{self.name}' initialized at 0x{self._address:02x} "
-                    f"(integration={_atime_to_ms(self._atime):.1f}ms, gain={self._gain}x)"
+                    f"(integration={_atime_to_ms(self._atime):.1f}ms, gain={self._gain}x, flash={flash})"
                 )
                 task.complete()
             except Exception as exc:
@@ -110,48 +134,113 @@ class TCS34725(ColorSensor):
         return task
 
     def get_full_scale(self) -> int:
-        """Max possible ADC count for the current ATIME; use with ``Color.from_raw``."""
+        """Max possible ADC count for the current ATIME."""
         return min(65535, (256 - self._atime) * 1024)
 
     def close(self) -> None:
         self._write_register(_ENABLE, 0x00)
 
-    def read_color(self) -> Task[ColorRaw]:
-        self._wait_data_ready()
-        with self._lock:
-            (data,) = self._bus.write_then_read(
-                self._address, bytes([_COMMAND_BIT | _CDATA]), 8
-            ).wait()
-        c, r, g, b = struct.unpack("<HHHH", data)
-        return ImmediateResultTask(ColorRaw(r=r, g=g, b=b, c=c))
+    def read_color(self) -> Task[ColorRGBC]:
+        """Return one RGBC measurement. Flash-differential if enabled and LED wired.
+
+        Flash-differential sequence:
+
+        - Read with LED OFF → ``off`` (captures ambient only)
+        - Read with LED ON  → ``on``  (captures ambient + LED)
+        - Return ``on − off`` per channel, clamped ≥ 0.
+
+        The returned signal depends only on the LED and the pad's reflectance —
+        ambient illumination cancels out, even under TV projector lighting.
+        """
+        if not self._use_flash_differential or self._light is None:
+            return ImmediateResultTask(self._read_raw_blocking())
+
+        (original_intensity,) = self._light.get_intensity().wait()
+        try:
+            self._light.set_intensity(0.0).wait()
+            self._wait_fresh_integration()
+            off = self._read_raw_blocking()
+
+            self._light.set_intensity(1.0).wait()
+            self._wait_fresh_integration()
+            on = self._read_raw_blocking()
+        finally:
+            self._light.set_intensity(original_intensity).wait()
+
+        diff = ColorRGBC(
+            r=max(0, on.r - off.r),
+            g=max(0, on.g - off.g),
+            b=max(0, on.b - off.b),
+            c=max(0, on.c - off.c),
+            full_scale=on.full_scale,
+        )
+        return ImmediateResultTask(diff)
 
     def get_color(self) -> Task[NamedColor]:
         (raw,) = self.read_color().wait()
-        h, s, _v = raw.to_hsv()
-        if s < 0.15:
-            return ImmediateResultTask(NamedColor.Unknown)
-        if h < 65 or h > 300:
-            return ImmediateResultTask(NamedColor.Yellow)
-        if 150 < h < 270:
-            return ImmediateResultTask(NamedColor.Blue)
-        return ImmediateResultTask(NamedColor.Unknown)
+        return ImmediateResultTask(self._palette.classify(Color(rgbc=raw)))
 
     def calibrate(self, name: NamedColor, samples: int = 10) -> Task[()]:
+        """Average ``samples`` live readings and store the result as the palette ref for ``name``.
+
+        Each sample goes through ``read_color``, so flash-differential applies when enabled.
+        """
         if samples < 1:
             raise ValueError(f"samples must be >= 1, got {samples}")
         sr = sg = sb = sc = 0
+        fs = 65535
         for _ in range(samples):
             (raw,) = self.read_color().wait()
             sr += raw.r
             sg += raw.g
             sb += raw.b
             sc += raw.c
-        avg = ColorRaw(r=sr // samples, g=sg // samples,
-                       b=sb // samples, c=sc // samples)
-        self._palette.set(name, avg)
+            fs = raw.full_scale
+        avg = ColorRGBC(
+            r=sr // samples,
+            g=sg // samples,
+            b=sb // samples,
+            c=sc // samples,
+            full_scale=fs,
+        )
+        self._palette.set(name, Color(rgbc=avg, name=name.name))
         self._log.info(
             f"TCS34725 '{self.name}' calibrated {name.name}: "
             f"r={avg.r} g={avg.g} b={avg.b} c={avg.c}"
+        )
+        return ImmediateResultTask()
+
+    @commands.register(
+        args=[
+            ("target_c", ArgTypes.U16(help="Target Clear channel level (default ~30000)")),
+        ],
+        result=[],
+    )
+    def auto_expose(
+        self,
+        target_c: int = _AUTO_EXPOSE_TARGET_C,
+        tolerance: float = _AUTO_EXPOSE_TOLERANCE,
+        max_iterations: int = _AUTO_EXPOSE_MAX_ITER,
+    ) -> Task[()]:
+        """Iteratively tune ATIME to center the Clear channel on ``target_c``.
+
+        Converges when the measured C is within ``tolerance`` of target, or
+        after ``max_iterations`` passes. Skips gain changes — ATIME alone
+        covers a ~250× dynamic range (3 ms → 614 ms), enough for table lighting.
+        """
+        for _ in range(max_iterations):
+            raw = self._read_raw_blocking()
+            c = max(1, raw.c)
+            ratio = target_c / c
+            if abs(ratio - 1.0) < tolerance:
+                break
+            new_ms = _atime_to_ms(self._atime) * ratio
+            new_ms = max(3.0, min(600.0, new_ms))
+            self._atime = _ms_to_atime(new_ms)
+            self._write_register(_ATIME, self._atime)
+            self._wait_fresh_integration()
+        self._log.info(
+            f"TCS34725 '{self.name}' auto_expose: integration={_atime_to_ms(self._atime):.1f}ms"
         )
         return ImmediateResultTask()
 
@@ -166,11 +255,12 @@ class TCS34725(ColorSensor):
         return self._light.get_intensity()
 
     def set_gamma(self, gamma: float) -> Task[()]:
-        self._palette.set_gamma(gamma)
+        # Palette classification runs in HSV/Chroma by default, both ratio-based
+        # and thus independent of display gamma. Kept as interface shim.
         return ImmediateResultTask()
 
     def get_gamma(self) -> Task[float]:
-        return ImmediateResultTask(self._palette.get_gamma())
+        return ImmediateResultTask(1.0)
 
     @commands.register(
         args=[("gain", ArgTypes.U8(help="Analog gain: 1, 4, 16 or 60"))],
@@ -205,6 +295,42 @@ class TCS34725(ColorSensor):
     )
     def get_integration_time(self) -> Task[float]:
         return ImmediateResultTask(_atime_to_ms(self._atime))
+
+    @commands.register(
+        args=[("enabled", ArgTypes.Bool(help="True to enable LED ON/OFF subtraction"))],
+        result=[],
+    )
+    def set_flash_differential(self, enabled: bool) -> Task[()]:
+        self._use_flash_differential = enabled and (self._light is not None)
+        return ImmediateResultTask()
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="Flash-differential subtraction state"))],
+    )
+    def get_flash_differential(self) -> Task[bool]:
+        return ImmediateResultTask(self._use_flash_differential)
+
+    # ── Internal helpers ─────────────────────────────────────────────────
+
+    def _read_raw_blocking(self) -> ColorRGBC:
+        self._wait_data_ready()
+        with self._lock:
+            (data,) = self._bus.write_then_read(
+                self._address, bytes([_COMMAND_BIT | _CDATA]), 8
+            ).wait()
+        c, r, g, b = struct.unpack("<HHHH", data)
+        return ColorRGBC(r=r, g=g, b=b, c=c, full_scale=self.get_full_scale())
+
+    def _wait_fresh_integration(self) -> None:
+        """Sleep long enough for a full new integration cycle under the new light state.
+
+        After a light change, the in-progress integration mixes old and new
+        illumination. Waiting 1.5 × ATIME ensures the next AVALID reflects
+        only the new lighting — a conservative bound that avoids register
+        gymnastics with AEN toggling.
+        """
+        time.sleep(1.5 * _atime_to_ms(self._atime) / 1000.0)
 
     def _wait_data_ready(self, timeout_s: float = 1.0) -> None:
         deadline = time.monotonic() + timeout_s
@@ -244,6 +370,7 @@ class TCS34725Definition(DriverDefinition):
         defn.add_optional("integration_time_ms", ArgTypes.F32(), _atime_to_ms(_ATIME_DEFAULT))
         defn.add_optional("gain", ArgTypes.U8(), 4)
         defn.add_optional("light", ArgTypes.OptionalComponent(LED, self._peripherals), None)
+        defn.add_optional("use_flash_differential", ArgTypes.Bool(), True)
         return defn
 
     def create(self, args: DriverInitArgs) -> TCS34725:
@@ -256,10 +383,13 @@ class TCS34725Definition(DriverDefinition):
             integration_time_ms=args.get("integration_time_ms"),
             gain=args.get("gain"),
             light=args.get("light"),
+            use_flash_differential=args.get("use_flash_differential"),
         )
 
 
 class TCS34725Virtual(ColorSensor):
+    """Simulation twin of TCS34725 — injected RGBC values, same surface as the real driver."""
+
     commands = DriverCommands(parents=[ColorSensor.commands])
 
     def __init__(
@@ -272,14 +402,18 @@ class TCS34725Virtual(ColorSensor):
         initial_c: int = 0,
         light: LED | None = None,
         palette: Palette | None = None,
-        unknown_threshold_squared: float | None = None,
+        use_flash_differential: bool = True,
     ):
         super().__init__(name)
         self._log = logger
-        self._raw = ColorRaw(r=initial_r, g=initial_g, b=initial_b, c=initial_c)
+        # full_scale pinned at 65535 in simulation — ATIME-dependence is orthogonal
+        # to injection and would only complicate test setup.
+        self._raw = ColorRGBC(r=initial_r, g=initial_g, b=initial_b, c=initial_c, full_scale=65535)
         self._light = light
         self._palette = palette if palette is not None else Palette(refs=TCS34725_DEFAULT_PALETTE)
-        self._unknown_threshold_squared = unknown_threshold_squared
+        # Kept for signature parity with the real driver — no ambient to subtract
+        # in simulation, so it's a no-op on read_color but preserved for round-trip symmetry.
+        self._use_flash_differential = use_flash_differential
 
     def init(self) -> Task[()]:
         self._log.info(f"TCS34725Virtual '{self.name}' initialized")
@@ -288,18 +422,11 @@ class TCS34725Virtual(ColorSensor):
     def close(self) -> None:
         pass
 
-    def read_color(self) -> Task[ColorRaw]:
+    def read_color(self) -> Task[ColorRGBC]:
         return ImmediateResultTask(self._raw)
 
     def get_color(self) -> Task[NamedColor]:
-        h, s, _v = self._raw.to_hsv()
-        if s < 0.15:
-            return ImmediateResultTask(NamedColor.Unknown)
-        if h < 65 or h > 300:
-            return ImmediateResultTask(NamedColor.Yellow)
-        if 150 < h < 270:
-            return ImmediateResultTask(NamedColor.Blue)
-        return ImmediateResultTask(NamedColor.Unknown)
+        return ImmediateResultTask(self._palette.classify(Color(rgbc=self._raw)))
 
     @commands.register(
         args=[("name", ArgTypes.Enum(NamedColor, help="Named color to simulate"))],
@@ -310,7 +437,7 @@ class TCS34725Virtual(ColorSensor):
         ref = self._palette.get(name)
         if ref is None:
             raise ValueError(f"palette has no entry for {name.name}")
-        self._raw = ref
+        self._raw = ref.rgbc
         return ImmediateResultTask()
 
     @commands.register(
@@ -323,7 +450,16 @@ class TCS34725Virtual(ColorSensor):
                 f"TCS34725Virtual '{self.name}' calibrate: samples={samples} ignored "
                 "(virtual reads the injected value directly)"
             )
-        self._palette.set(name, self._raw)
+        self._palette.set(name, Color(rgbc=self._raw, name=name.name))
+        return ImmediateResultTask()
+
+    def auto_expose(
+        self,
+        target_c: int = _AUTO_EXPOSE_TARGET_C,
+        tolerance: float = _AUTO_EXPOSE_TOLERANCE,
+        max_iterations: int = _AUTO_EXPOSE_MAX_ITER,
+    ) -> Task[()]:
+        # No exposure to tune in simulation — kept for signature parity.
         return ImmediateResultTask()
 
     def get_full_scale(self) -> int:
@@ -340,11 +476,25 @@ class TCS34725Virtual(ColorSensor):
         return self._light.get_intensity()
 
     def set_gamma(self, gamma: float) -> Task[()]:
-        self._palette.set_gamma(gamma)
         return ImmediateResultTask()
 
     def get_gamma(self) -> Task[float]:
-        return ImmediateResultTask(self._palette.get_gamma())
+        return ImmediateResultTask(1.0)
+
+    @commands.register(
+        args=[("enabled", ArgTypes.Bool(help="True to enable LED ON/OFF subtraction"))],
+        result=[],
+    )
+    def set_flash_differential(self, enabled: bool) -> Task[()]:
+        self._use_flash_differential = enabled
+        return ImmediateResultTask()
+
+    @commands.register(
+        args=[],
+        result=[("enabled", ArgTypes.Bool(help="Flash-differential subtraction state"))],
+    )
+    def get_flash_differential(self) -> Task[bool]:
+        return ImmediateResultTask(self._use_flash_differential)
 
     @commands.register(
         args=[
@@ -357,7 +507,7 @@ class TCS34725Virtual(ColorSensor):
     )
     def inject_color(self, r: int, g: int, b: int, c: int) -> Task[()]:
         """Set the raw RGBC values returned by subsequent read_color calls."""
-        self._raw = ColorRaw(r=r, g=g, b=b, c=c)
+        self._raw = ColorRGBC(r=r, g=g, b=b, c=c, full_scale=65535)
         return ImmediateResultTask()
 
 
@@ -374,6 +524,7 @@ class TCS34725VirtualDefinition(DriverDefinition):
         defn.add_optional("initial_b", ArgTypes.U16(), 0)
         defn.add_optional("initial_c", ArgTypes.U16(), 0)
         defn.add_optional("light", ArgTypes.OptionalComponent(LED, self._peripherals), None)
+        defn.add_optional("use_flash_differential", ArgTypes.Bool(), True)
         return defn
 
     def create(self, args: DriverInitArgs) -> TCS34725Virtual:
@@ -386,4 +537,5 @@ class TCS34725VirtualDefinition(DriverDefinition):
             initial_b=args.get("initial_b"),
             initial_c=args.get("initial_c"),
             light=args.get("light"),
+            use_flash_differential=args.get("use_flash_differential"),
         )

--- a/src/evo_lib/drivers/color_sensor/tcs34725.py
+++ b/src/evo_lib/drivers/color_sensor/tcs34725.py
@@ -78,12 +78,12 @@ def _atime_to_ms(atime: int) -> float:
 # Indicative refs for AGAIN=4×, ATIME≈100 ms, lit by the on-board white LED.
 # Refine per-instance via calibrate() if responsivity drifts too much.
 TCS34725_DEFAULT_PALETTE: dict[NamedColor, Color] = {
-    NamedColor.Black:  Color.from_rgbc(   200,   200,   200,    600, name="Black"),
-    NamedColor.White:  Color.from_rgbc( 15000, 15000, 15000,  45000, name="White"),
-    NamedColor.Red:    Color.from_rgbc(  8500,  1200,   800,  10500, name="Red"),
-    NamedColor.Green:  Color.from_rgbc(  1100,  6200,  1400,   8700, name="Green"),
-    NamedColor.Blue:   Color.from_rgbc(   800,  1400,  5500,   7700, name="Blue"),
-    NamedColor.Yellow: Color.from_rgbc(  7000,  6500,  1500,  15000, name="Yellow"),
+    NamedColor.Black: Color.from_rgbc(200, 200, 200, 600, name="Black"),
+    NamedColor.White: Color.from_rgbc(15000, 15000, 15000, 45000, name="White"),
+    NamedColor.Red: Color.from_rgbc(8500, 1200, 800, 10500, name="Red"),
+    NamedColor.Green: Color.from_rgbc(1100, 6200, 1400, 8700, name="Green"),
+    NamedColor.Blue: Color.from_rgbc(800, 1400, 5500, 7700, name="Blue"),
+    NamedColor.Yellow: Color.from_rgbc(7000, 6500, 1500, 15000, name="Yellow"),
 }
 
 
@@ -128,7 +128,7 @@ class TCS34725(ColorSensor):
                 flash = "ON" if self._use_flash_differential else "OFF"
                 self._log.info(
                     f"TCS34725 '{self.name}' initialized at 0x{self._address:02x} "
-                    f"(integration={_atime_to_ms(self._atime):.1f}ms, gain={self._gain}x, flash={flash})"
+                    f"(integration={_atime_to_ms(self._atime):.1f}ms, gain={self._gain}x, flash={flash})"  # noqa: E501
                 )
                 task.complete()
             except Exception as exc:
@@ -186,7 +186,10 @@ class TCS34725(ColorSensor):
 
     @commands.register(
         args=[
-            ("name", ArgTypes.Enum(NamedColor, help="Color to calibrate against the presented pad")),
+            (
+                "name",
+                ArgTypes.Enum(NamedColor, help="Color to calibrate against the presented pad"),
+            ),
         ],
         result=[],
     )
@@ -328,7 +331,7 @@ class TCS34725(ColorSensor):
         result=[("chip_id", ArgTypes.U8(help="0x44 for TCS34725, 0x4D for TCS34727"))],
     )
     def get_chip_id(self) -> Task[int]:
-        """Read the chip ID register (0x12). Useful to confirm the I2C path on the right mux channel."""
+        """Read the chip ID register (0x12). Useful to confirm the I2C path on the right mux channel."""  # noqa: E501
         return ImmediateResultTask(self._read_register(_ID))
 
     @commands.register(
@@ -366,16 +369,12 @@ class TCS34725(ColorSensor):
             if self._read_register(_STATUS) & _STATUS_AVALID:
                 return
             if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"TCS34725 '{self.name}' AVALID not set within {timeout_s}s"
-                )
+                raise TimeoutError(f"TCS34725 '{self.name}' AVALID not set within {timeout_s}s")
             time.sleep(0.002)
 
     def _write_register(self, register: int, value: int) -> None:
         with self._lock:
-            self._bus.write_to(
-                self._address, bytes([_COMMAND_BIT | register, value])
-            ).wait()
+            self._bus.write_to(self._address, bytes([_COMMAND_BIT | register, value])).wait()
 
     def _read_register(self, register: int) -> int:
         with self._lock:

--- a/src/evo_lib/drivers/led_strip/mdb_led.py
+++ b/src/evo_lib/drivers/led_strip/mdb_led.py
@@ -39,11 +39,11 @@ from evo_lib.drivers.led_strip.ws2812b import (
     _DEFAULT_FREQUENCY_HZ,
     _DEFAULT_PIN,
     WS2812B,
-    _clamp_unit,
     _unpack_rgb,
 )
 from evo_lib.logger import Logger
 from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.types.color import PURE_COLORS, NamedColor
 
 
 class MdbLedState(IntEnum):
@@ -94,19 +94,13 @@ class MdbLed(WS2812B):
         brightness: float = 1.0,
         frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
         dma_channel: int = _DEFAULT_DMA_CHANNEL,
-        team_color_r: float = 1.0,
-        team_color_g: float = 0.8,
-        team_color_b: float = 0.0,
+        team_color: NamedColor = NamedColor.Yellow,
         loading_chase_length: int = 5,
         auto_start_animator: bool = True,
     ):
         super().__init__(name, logger, num_pixels, pin, brightness, frequency_hz, dma_channel)
         self._state: MdbLedState = MdbLedState.Off
-        self._team_color: tuple[float, float, float] = (
-            _clamp_unit(team_color_r),
-            _clamp_unit(team_color_g),
-            _clamp_unit(team_color_b),
-        )
+        self._team_color: NamedColor = team_color
         # Width of the comet head in Loading state. Clamped so it never
         # exceeds the strip length (would lit every pixel and look static).
         self._loading_chase_length: int = max(1, min(loading_chase_length, num_pixels))
@@ -153,33 +147,22 @@ class MdbLed(WS2812B):
             return ImmediateResultTask(self._state)
 
     @commands.register(
-        args=[
-            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
-            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
-            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
-        ],
+        args=[("color", ArgTypes.Enum(NamedColor, help="Team color"))],
         result=[],
     )
-    def set_team_color(self, r: float, g: float, b: float) -> Task[()]:
+    def set_team_color(self, color: NamedColor) -> Task[()]:
         with self._state_lock:
-            self._team_color = (_clamp_unit(r), _clamp_unit(g), _clamp_unit(b))
-        # Wake the animator so the new color shows up immediately on the
-        # next chase frame — otherwise it'd lag by up to one refresh tick.
+            self._team_color = color
         self._wakeup.set()
         return ImmediateResultTask()
 
     @commands.register(
         args=[],
-        result=[
-            ("r", ArgTypes.F32(help="Red 0.0-1.0")),
-            ("g", ArgTypes.F32(help="Green 0.0-1.0")),
-            ("b", ArgTypes.F32(help="Blue 0.0-1.0")),
-        ],
+        result=[("color", ArgTypes.Enum(NamedColor, help="Current team color"))],
     )
-    def get_team_color(self) -> Task[float, float, float]:
+    def get_team_color(self) -> Task[NamedColor]:
         with self._state_lock:
-            r, g, b = self._team_color
-        return ImmediateResultTask(r, g, b)
+            return ImmediateResultTask(self._team_color)
 
     # --- Animator lifecycle ------------------------------------------------
 
@@ -230,7 +213,7 @@ class MdbLed(WS2812B):
     def _render_frame(
         self,
         state: MdbLedState,
-        team_color: tuple[float, float, float],
+        team_color: NamedColor,
         step: int,
     ) -> None:
         if state == MdbLedState.Off:
@@ -258,7 +241,8 @@ class MdbLed(WS2812B):
             # consecutive lit pixels advances by one slot per step, with
             # wrap-around at the strip end.
             self.fill(0.0, 0.0, 0.0).wait()
-            tcr, tcg, tcb = team_color
+            ref = PURE_COLORS.get(team_color)
+            tcr, tcg, tcb = (ref.rgb.r, ref.rgb.g, ref.rgb.b) if ref else (0.0, 0.0, 0.0)
             for offset in range(self._loading_chase_length):
                 idx = (step + offset) % self._num_pixels
                 self.set_pixel(idx, tcr, tcg, tcb).wait()
@@ -291,9 +275,9 @@ class MdbLedDefinition(DriverDefinition):
             ArgTypes.U8(help="DMA channel"),
             _DEFAULT_DMA_CHANNEL,
         )
-        defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
-        defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
-        defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        defn.add_optional(
+            "team_color", ArgTypes.Enum(NamedColor, help="Default team color"), NamedColor.Yellow
+        )
         defn.add_optional(
             "loading_chase_length",
             ArgTypes.U8(help="Comet width in Loading state (number of lit pixels)"),
@@ -311,9 +295,7 @@ class MdbLedDefinition(DriverDefinition):
             brightness=args.get("brightness"),
             frequency_hz=args.get("frequency_hz"),
             dma_channel=args.get("dma_channel"),
-            team_color_r=args.get("team_color_r"),
-            team_color_g=args.get("team_color_g"),
-            team_color_b=args.get("team_color_b"),
+            team_color=args.get("team_color"),
             loading_chase_length=args.get("loading_chase_length"),
         )
 
@@ -338,9 +320,7 @@ class MdbLedVirtual(MdbLed):
         brightness: float = 1.0,
         frequency_hz: int = _DEFAULT_FREQUENCY_HZ,
         dma_channel: int = _DEFAULT_DMA_CHANNEL,
-        team_color_r: float = 1.0,
-        team_color_g: float = 0.8,
-        team_color_b: float = 0.0,
+        team_color: NamedColor = NamedColor.Yellow,
         loading_chase_length: int = 5,
         auto_start_animator: bool = True,
     ):
@@ -352,9 +332,7 @@ class MdbLedVirtual(MdbLed):
             brightness=brightness,
             frequency_hz=frequency_hz,
             dma_channel=dma_channel,
-            team_color_r=team_color_r,
-            team_color_g=team_color_g,
-            team_color_b=team_color_b,
+            team_color=team_color,
             loading_chase_length=loading_chase_length,
             auto_start_animator=auto_start_animator,
         )
@@ -427,9 +405,9 @@ class MdbLedVirtualDefinition(DriverDefinition):
             ArgTypes.U8(help="DMA channel (ignored)"),
             _DEFAULT_DMA_CHANNEL,
         )
-        defn.add_optional("team_color_r", ArgTypes.F32(help="Default team red"), 1.0)
-        defn.add_optional("team_color_g", ArgTypes.F32(help="Default team green"), 0.8)
-        defn.add_optional("team_color_b", ArgTypes.F32(help="Default team blue"), 0.0)
+        defn.add_optional(
+            "team_color", ArgTypes.Enum(NamedColor, help="Default team color"), NamedColor.Yellow
+        )
         defn.add_optional(
             "loading_chase_length",
             ArgTypes.U8(help="Comet width in Loading state (number of lit pixels)"),
@@ -447,8 +425,6 @@ class MdbLedVirtualDefinition(DriverDefinition):
             brightness=args.get("brightness"),
             frequency_hz=args.get("frequency_hz"),
             dma_channel=args.get("dma_channel"),
-            team_color_r=args.get("team_color_r"),
-            team_color_g=args.get("team_color_g"),
-            team_color_b=args.get("team_color_b"),
+            team_color=args.get("team_color"),
             loading_chase_length=args.get("loading_chase_length"),
         )

--- a/src/evo_lib/drivers/led_strip/mdb_led.py
+++ b/src/evo_lib/drivers/led_strip/mdb_led.py
@@ -62,11 +62,11 @@ class MdbLedState(IntEnum):
 # Per-state refresh delay in seconds. ``None`` = static (animator parks
 # until the next state/team-color change).
 _REFRESH_S: dict[MdbLedState, float | None] = {
-    MdbLedState.Off:      None,
-    MdbLedState.Running:  None,
+    MdbLedState.Off: None,
+    MdbLedState.Running: None,
     MdbLedState.Disabled: 0.25,
-    MdbLedState.Error:    0.50,
-    MdbLedState.Loading:  0.05,
+    MdbLedState.Error: 0.50,
+    MdbLedState.Loading: 0.05,
 }
 
 

--- a/src/evo_lib/drivers/pilot/protocol.py
+++ b/src/evo_lib/drivers/pilot/protocol.py
@@ -35,6 +35,7 @@ class Commands(IntEnum):
     SET_PWM = 111
     STOP_ASAP = 112
     RESET = 113  # Triggers HAL_NVIC_SystemReset() on the STM32; no ACK because the board reboots before it could send one.
+    MATCH_BEGIN = 114
 
     # Events (received from board)
     DEBUG = 126
@@ -111,6 +112,7 @@ FORMATS: dict[Commands, str] = {
     Commands.RECALAGE: "BfB",  # direction, offset, set
     Commands.SET_PWM: "ff",
     Commands.RESET: "",
+    Commands.MATCH_BEGIN: "",
     # Position
     Commands.SET_X: "f",
     Commands.SET_Y: "f",

--- a/src/evo_lib/drivers/pilot/protocol.py
+++ b/src/evo_lib/drivers/pilot/protocol.py
@@ -34,7 +34,7 @@ class Commands(IntEnum):
     RECALAGE = 110
     SET_PWM = 111
     STOP_ASAP = 112
-    RESET = 113  # Triggers HAL_NVIC_SystemReset() on the STM32; no ACK because the board reboots before it could send one.
+    RESET = 113  # Triggers HAL_NVIC_SystemReset() on the STM32; no ACK because the board reboots before it could send one.  # noqa: E501
     MATCH_BEGIN = 114
 
     # Events (received from board)

--- a/src/evo_lib/drivers/pilot/protocol.py
+++ b/src/evo_lib/drivers/pilot/protocol.py
@@ -34,6 +34,7 @@ class Commands(IntEnum):
     RECALAGE = 110
     SET_PWM = 111
     STOP_ASAP = 112
+    RESET = 113  # Triggers HAL_NVIC_SystemReset() on the STM32; no ACK because the board reboots before it could send one.
 
     # Events (received from board)
     DEBUG = 126
@@ -80,6 +81,7 @@ class Errors(IntEnum):
 # Commands that do not expect an ACK from the board (from firmware trajman_commands.h)
 NO_ACK_COMMANDS: set[Commands] = {
     Commands.SET_PWM,
+    Commands.RESET,
     Commands.GET_PID_TRSL,
     Commands.GET_PID_ROT,
     Commands.GET_POSITION,
@@ -108,6 +110,7 @@ FORMATS: dict[Commands, str] = {
     Commands.STOP_ASAP: "ff",
     Commands.RECALAGE: "BfB",  # direction, offset, set
     Commands.SET_PWM: "ff",
+    Commands.RESET: "",
     # Position
     Commands.SET_X: "f",
     Commands.SET_Y: "f",

--- a/src/evo_lib/drivers/pilot/serial_pilot.py
+++ b/src/evo_lib/drivers/pilot/serial_pilot.py
@@ -142,6 +142,10 @@ class DifferentialSerialPilot(DifferentialPilot):
         self._send_command(Commands.UNFREE)
         return ImmediateResultTask()
 
+    def match_begin(self) -> Task[()]:
+        self._send_command(Commands.MATCH_BEGIN)
+        return ImmediateResultTask()
+
     @commands.register(args=[], result=[])
     def reset(self) -> Task[()]:
         """Reboot the carte-asserv (HAL_NVIC_SystemReset on the STM32).

--- a/src/evo_lib/drivers/pilot/serial_pilot.py
+++ b/src/evo_lib/drivers/pilot/serial_pilot.py
@@ -142,6 +142,19 @@ class DifferentialSerialPilot(DifferentialPilot):
         self._send_command(Commands.UNFREE)
         return ImmediateResultTask()
 
+    @commands.register(args=[], result=[])
+    def reset(self) -> Task[()]:
+        """Reboot the carte-asserv (HAL_NVIC_SystemReset on the STM32).
+
+        Cancels any in-flight move locally because the board is about to
+        restart and won't ACK or report MOVE_END for ongoing trajectories.
+        """
+        self._send_command(Commands.RESET)
+        if self._move_task is not None:
+            self._move_task.complete(PilotMoveStatus.CANCELLED)
+            self._move_task = None
+        return ImmediateResultTask()
+
     def on_pose_or_velocity_update(self) -> Event[Pose2D, Vect2D]:
         return self._pose_or_velocity_update_event
 

--- a/src/evo_lib/drivers/pilot/virtual.py
+++ b/src/evo_lib/drivers/pilot/virtual.py
@@ -153,9 +153,7 @@ class DifferentialPilotVirtual(DifferentialPilot):
 
     def get_pose_and_velocity(self) -> Task[Pose2D, Vect2D]:
         with self._lock:
-            return ImmediateResultTask(
-                Pose2D(self._x, self._y, self._theta), Vect2D(0.0, 0.0)
-            )
+            return ImmediateResultTask(Pose2D(self._x, self._y, self._theta), Vect2D(0.0, 0.0))
 
     def set_pose(self, pose: Pose2D) -> Task[()]:
         with self._lock:
@@ -279,6 +277,7 @@ class HolonomicPilotVirtual(DifferentialPilotVirtual, HolonomicPilot):
         raise NotImplementedError(
             "HolonomicPilotVirtual.follow_holonomic_path is not implemented yet"
         )
+
 
 class HolonomicPilotVirtualDefinition(DriverDefinition):
     """Factory for HolonomicPilotVirtual from config args."""

--- a/src/evo_lib/drivers/pilot/virtual.py
+++ b/src/evo_lib/drivers/pilot/virtual.py
@@ -134,6 +134,11 @@ class DifferentialPilotVirtual(DifferentialPilot):
         self._cancel.clear()
         return ImmediateResultTask()
 
+    def reset(self) -> Task[()]:
+        # No firmware to reboot in simulation; behave like stop() so a
+        # config-level swap real↔virtual keeps consumer call sites valid.
+        return self.stop()
+
     def on_pose_or_velocity_update(self) -> Event[Pose2D, Vect2D]:
         return self._pose_velocity_event
 

--- a/src/evo_lib/interfaces/color_sensor.py
+++ b/src/evo_lib/interfaces/color_sensor.py
@@ -10,7 +10,7 @@ from evo_lib.types.color import NamedColor
 
 if TYPE_CHECKING:
     from evo_lib.task import Task
-    from evo_lib.types.color import ColorRaw
+    from evo_lib.types.color import ColorRGBC
 
 
 class ColorSensor(Placable):
@@ -28,7 +28,7 @@ class ColorSensor(Placable):
             ("c", ArgTypes.U16(help="Clear ADC counts")),
         ],
     )
-    def read_color(self) -> Task[ColorRaw]:
+    def read_color(self) -> Task[ColorRGBC]:
         """Read one raw RGBC sample straight off the sensor."""
 
     @abstractmethod

--- a/src/evo_lib/interfaces/pilot.py
+++ b/src/evo_lib/interfaces/pilot.py
@@ -77,6 +77,11 @@ class Pilot(Placable):
         """Enable asservissement and keep robot in current position."""
         pass
 
+    @commands.register(args = [], result = [])
+    def match_begin(self) -> "Task[()]":
+        """Notify the pilot that the match has started."""
+        return ImmediateResultTask()
+
     @abstractmethod
     def on_pose_or_velocity_update(self) -> Event[Pose2D, Vect2D]:
         pass

--- a/src/evo_lib/interfaces/pilot.py
+++ b/src/evo_lib/interfaces/pilot.py
@@ -37,6 +37,7 @@ class DifferentialPilotWaypoint:
                     reached/leave this waypoint.
         velocity    Velocity of the robot at this waypoint (positive).
     """
+
     x: float
     y: float
     heading: float
@@ -53,6 +54,7 @@ class HolonomicPilotWaypoint(DifferentialPilotWaypoint):
                     direction of the velocity vector when the robot reache this
                     waypoint)
     """
+
     tangent: float
 
 
@@ -60,24 +62,24 @@ class Pilot(Placable):
     commands = DriverCommands()
 
     @abstractmethod
-    @commands.register(args = [], result = [])
+    @commands.register(args=[], result=[])
     def stop(self) -> Task[()]:
         """Immediately stop the current movement."""
         pass
 
     @abstractmethod
-    @commands.register(args = [], result = [])
+    @commands.register(args=[], result=[])
     def free(self) -> Task[()]:
         """Immediately stop motor and go into freewheel."""
         pass
 
     @abstractmethod
-    @commands.register(args = [], result = [])
+    @commands.register(args=[], result=[])
     def unfree(self) -> Task[()]:
         """Enable asservissement and keep robot in current position."""
         pass
 
-    @commands.register(args = [], result = [])
+    @commands.register(args=[], result=[])
     def match_begin(self) -> "Task[()]":
         """Notify the pilot that the match has started."""
         return ImmediateResultTask()
@@ -87,29 +89,26 @@ class Pilot(Placable):
         pass
 
     @abstractmethod
-    @commands.register(args = [], result = Vect2D.ArgType())
+    @commands.register(args=[], result=Vect2D.ArgType())
     def get_velocity(self) -> Task[Vect2D]:
         pass
 
     @abstractmethod
-    @commands.register(args = [], result = Pose2D.ArgType())
+    @commands.register(args=[], result=Pose2D.ArgType())
     def get_pose(self) -> Task[Pose2D]:
         pass
 
     @abstractmethod
-    @commands.register(args = [], result = [
-        ("pose", Pose2D.ArgType()),
-        ("velocity", Vect2D.ArgType())
-    ])
+    @commands.register(args=[], result=[("pose", Pose2D.ArgType()), ("velocity", Vect2D.ArgType())])
     def get_pose_and_velocity(self) -> Task[Pose2D, Vect2D]:
         pass
 
     @abstractmethod
-    @commands.register(args = [("pose", Pose2D.ArgType())], result = [])
+    @commands.register(args=[("pose", Pose2D.ArgType())], result=[])
     def set_pose(self, pose: Pose2D) -> Task[()]:
         pass
 
-    @commands.register(args = [], result = [])
+    @commands.register(args=[], result=[])
     def calibrate_otos(self) -> "Task[()]":
         """Calibrate an optional optical tracking sensor (OTOS).
 
@@ -119,10 +118,13 @@ class Pilot(Placable):
         return ImmediateResultTask()
 
     @abstractmethod
-    @commands.register(args = [
-        ("x", ArgTypes.F32()),
-        ("y", ArgTypes.F32()),
-    ], result = [])
+    @commands.register(
+        args=[
+            ("x", ArgTypes.F32()),
+            ("y", ArgTypes.F32()),
+        ],
+        result=[],
+    )
     def go_to(self, x: float, y: float) -> Task[PilotMoveStatus]:
         """Move to the given position. The returned Task can be cancelled."""
         pass
@@ -142,24 +144,33 @@ class Pilot(Placable):
         pass
 
     @abstractmethod
-    @commands.register(args = [
-        ("heading", ArgTypes.F32()),
-    ], result = [])
+    @commands.register(
+        args=[
+            ("heading", ArgTypes.F32()),
+        ],
+        result=[],
+    )
     def head_to(self, heading: float) -> Task[PilotMoveStatus]:
         pass
 
     @abstractmethod
-    @commands.register(args = [
-        ("x", ArgTypes.F32()),
-        ("y", ArgTypes.F32()),
-    ], result = [])
+    @commands.register(
+        args=[
+            ("x", ArgTypes.F32()),
+            ("y", ArgTypes.F32()),
+        ],
+        result=[],
+    )
     def look_at(self, x: float, y: float) -> Task[PilotMoveStatus]:
         pass
 
     @abstractmethod
-    @commands.register(args = [
-        ("angle", ArgTypes.F32()),
-    ], result = [])
+    @commands.register(
+        args=[
+            ("angle", ArgTypes.F32()),
+        ],
+        result=[],
+    )
     def rotate(self, angle: float) -> Task[PilotMoveStatus]:
         pass
 
@@ -172,9 +183,12 @@ class DifferentialPilot(Pilot):
     commands = DriverCommands([Pilot.commands])
 
     @abstractmethod
-    @commands.register(args = [
-        ("forward", ArgTypes.F32()),
-    ], result = [])
+    @commands.register(
+        args=[
+            ("forward", ArgTypes.F32()),
+        ],
+        result=[],
+    )
     def forward(self, distance: float) -> Task[PilotMoveStatus]:
         pass
 

--- a/src/evo_lib/types/color.py
+++ b/src/evo_lib/types/color.py
@@ -1,45 +1,82 @@
-"""Color types and a small named palette for RGBC sensor classification.
+"""Color representation types and the ``Color`` composite.
 
-Three distinct types live here, each with a single purpose:
+Five representation classes cover the useful encodings of a single color:
 
-- ``ColorRaw``   — raw RGBC ADC counts straight from a sensor (ints 0-65535)
-- ``Color``      — continuous RGBC value, normalized floats 0.0-1.0 (LED pixels,
-                   rendering, anything that needs a value rather than a label)
-- ``NamedColor`` — enum of palette names (Red, Green, ...) used by sensor
-                   classification. Default reference RGBC values are NOT
-                   provided here — they are chip-specific and live in the
-                   relevant driver (e.g. ``tcs34725.py``).
+- ``ColorRGBC(r, g, b, c, full_scale)`` — raw ADC counts from RGBC sensors (ints)
+- ``ColorRGB(r, g, b)``                 — normalized RGB in 0.0-1.0 (LED pixels, rendering)
+- ``ColorHSV(h, s, v)``                 — Hue ∈ [0,360), S/V ∈ [0,1] (classification, UI)
+- ``ColorChroma(rc, gc, bc)``           — r/c, g/c, b/c ratios (≈ intensity-invariant)
+- ``ColorHex(value)``                   — 0xRRGGBB packed int (logs, config, humans)
+
+``Color`` is a composite: it stores one "source" representation (the one passed to
+its factory) and derives the others lazily on first property access. Cache is
+per-instance, so repeated reads are O(1).
+
+⚠ Not all conversions are bijective. In particular:
+
+- ``Chroma → RGB`` loses the absolute intensity (V). The derivation assumes the
+  maximum channel is 1.0 — this is a convention, not a measurement.
+- ``HSV → RGBC`` needs a ``full_scale`` to map V into integer ADC counts. The
+  default 255 is a display-space choice, not a sensor-space one.
+
+For classification, always work in the native space of the source (Hue for
+illuminant robustness, Chroma for intensity-invariance). Only use the derived
+reprs for display/logging or when the conversion is known to be lossless.
 """
 
+from __future__ import annotations
+
 from enum import IntEnum
+from math import isclose
 
 
-class ColorRaw:
-    """Raw RGBC ADC counts straight from a color sensor.
+# ── Representation classes ───────────────────────────────────────────────
 
-    Values are unsigned integers whose range depends on the sensor
-    configuration (typical full-scale: 0 to 65535 for TCS34725-family
-    chips, but actually capped by ATIME to ``(256 - ATIME) * 1024``).
+class ColorRGBC:
+    """Raw RGBC ADC counts straight off an RGBC sensor (TCS34725 family, etc.).
+
+    ``full_scale`` is the chip's current max possible count, which depends on
+    integration time: for TCS34725 it caps at ``(256 - ATIME) * 1024`` (max
+    65535). Carrying it on the instance lets downstream conversions normalize
+    correctly regardless of the sensor's current exposure.
     """
 
-    __slots__ = ("r", "g", "b", "c")
+    __slots__ = ("r", "g", "b", "c", "full_scale")
 
-    def __init__(self, r: int, g: int, b: int, c: int) -> None:
+    def __init__(self, r: int, g: int, b: int, c: int, full_scale: int = 65535) -> None:
         self.r = r
         self.g = g
         self.b = b
         self.c = c
+        self.full_scale = full_scale
 
     def __repr__(self) -> str:
-        return f"ColorRaw(r={self.r}, g={self.g}, b={self.b}, c={self.c})"
+        return (
+            f"ColorRGBC(r={self.r}, g={self.g}, b={self.b}, c={self.c},"
+            f" full_scale={self.full_scale})"
+        )
 
-    def to_hsv(self) -> tuple[float, float, float]:
-        """Convert RGB channels to HSV. Hue in [0,360), S and V in [0,1].
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ColorRGBC)
+            and self.r == other.r
+            and self.g == other.g
+            and self.b == other.b
+            and self.c == other.c
+        )
 
-        Uses raw integer channels directly; hue and saturation are
-        ratio-based so the result is identical regardless of ADC scale.
-        Value is normalized to ``max(r, g, b) / 65535``.
-        """
+    def to_rgb(self) -> "ColorRGB":
+        fs = float(self.full_scale) if self.full_scale > 0 else 1.0
+        return ColorRGB(
+            min(1.0, self.r / fs),
+            min(1.0, self.g / fs),
+            min(1.0, self.b / fs),
+        )
+
+    def to_hsv(self) -> "ColorHSV":
+        # Hue and saturation are ratio-based: independent of full_scale.
+        # V is the max channel normalized by full_scale (the Clear channel
+        # carries total luminous energy separately — not used here).
         r, g, b = self.r, self.g, self.b
         cmax = max(r, g, b)
         cmin = min(r, g, b)
@@ -53,67 +90,354 @@ class ColorRaw:
         else:
             h = 60.0 * ((r - g) / delta) + 240
         s = 0.0 if cmax == 0 else delta / cmax
-        v = cmax / 65535.0
-        return (h, s, v)
+        v = cmax / float(self.full_scale) if self.full_scale > 0 else 0.0
+        return ColorHSV(h, s, min(1.0, v))
+
+    def to_chroma(self) -> "ColorChroma":
+        """Divide each channel by Clear. Near-black (c ≈ 0) returns (0, 0, 0).
+
+        Chroma is largely invariant to ambient *intensity* (doubling the light
+        doubles r, g, b AND c → ratios unchanged) but remains sensitive to
+        spectral shifts (tungsten vs daylight reshapes r/c and b/c unequally).
+        """
+        if self.c <= 0:
+            return ColorChroma(0.0, 0.0, 0.0)
+        inv = 1.0 / self.c
+        return ColorChroma(self.r * inv, self.g * inv, self.b * inv)
+
+    def to_hex(self) -> "ColorHex":
+        return self.to_rgb().to_hex()
 
 
-class Color:
-    """RGBC color: red, green, blue + clear (unfiltered / brightness) channel.
+class ColorRGB:
+    """Normalized RGB with each channel in 0.0-1.0.
 
-    The fourth channel ``c`` is the "Clear" channel as defined by TCS34725-style
-    RGBC sensors — an unfiltered photodiode that captures overall luminous
-    intensity. It is NOT an alpha transparency. For contexts where only RGB
-    matters (e.g. LED strips), ``c`` can safely be left at its default of 1.0.
+    The canonical "display" representation: LED pixels, rendering, mixing.
+    No Clear channel — intensity lives in the magnitude of the triplet itself.
     """
 
-    __slots__ = ("r", "g", "b", "c")
+    __slots__ = ("r", "g", "b")
 
-    def __init__(self, r: float, g: float, b: float, c: float = 1.0) -> None:
+    def __init__(self, r: float, g: float, b: float) -> None:
         self.r = r
         self.g = g
         self.b = b
-        self.c = c
 
-    @staticmethod
-    def from_rgb_int(val: int) -> "Color":
-        r = (val >> 16) & 0xFF
-        g = (val >>  8) & 0xFF
-        b = (val      ) & 0xFF
-        return Color(r / 255.0, g / 255.0, b / 255.0)
+    def __repr__(self) -> str:
+        return f"ColorRGB(r={self.r:.3f}, g={self.g:.3f}, b={self.b:.3f})"
 
-    @staticmethod
-    def from_rgbc_int(val: int) -> "Color":
-        """Parse a packed 0xRRGGBBCC integer into a Color."""
-        r = (val >> 24) & 0xFF
-        g = (val >> 16) & 0xFF
-        b = (val >>  8) & 0xFF
-        c = (val      ) & 0xFF
-        return Color(r / 255.0, g / 255.0, b / 255.0, c / 255.0)
-
-    @staticmethod
-    def from_raw(raw: ColorRaw, full_scale: int = 65535) -> "Color":
-        """Normalize raw ADC counts to a Color with each channel in 0.0-1.0.
-
-        ``full_scale`` is the sensor's current max count. For TCS34725-style
-        chips this depends on ATIME — pass ``sensor.get_full_scale()`` rather
-        than relying on the 65535 default when accuracy matters.
-        """
-        fs = float(full_scale) if full_scale > 0 else 1.0
-        return Color(
-            min(1.0, raw.r / fs),
-            min(1.0, raw.g / fs),
-            min(1.0, raw.b / fs),
-            min(1.0, raw.c / fs),
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ColorRGB)
+            and isclose(self.r, other.r, abs_tol=1e-6)
+            and isclose(self.g, other.g, abs_tol=1e-6)
+            and isclose(self.b, other.b, abs_tol=1e-6)
         )
 
+    def to_hsv(self) -> "ColorHSV":
+        r, g, b = self.r, self.g, self.b
+        cmax = max(r, g, b)
+        cmin = min(r, g, b)
+        delta = cmax - cmin
+        if delta == 0:
+            h = 0.0
+        elif cmax == r:
+            h = (60.0 * ((g - b) / delta)) % 360
+        elif cmax == g:
+            h = 60.0 * ((b - r) / delta) + 120
+        else:
+            h = 60.0 * ((r - g) / delta) + 240
+        s = 0.0 if cmax == 0 else delta / cmax
+        v = cmax
+        return ColorHSV(h, s, v)
+
+    def to_rgbc(self, full_scale: int = 255) -> ColorRGBC:
+        """Quantize to integer ADC counts. Clear derived as ``max(r,g,b)*full_scale`` — approximation."""
+        r_i = max(0, min(full_scale, round(self.r * full_scale)))
+        g_i = max(0, min(full_scale, round(self.g * full_scale)))
+        b_i = max(0, min(full_scale, round(self.b * full_scale)))
+        c_i = max(0, min(full_scale, round(max(self.r, self.g, self.b) * full_scale)))
+        return ColorRGBC(r_i, g_i, b_i, c_i, full_scale=full_scale)
+
+    def to_hex(self) -> "ColorHex":
+        r = max(0, min(255, round(self.r * 255)))
+        g = max(0, min(255, round(self.g * 255)))
+        b = max(0, min(255, round(self.b * 255)))
+        return ColorHex((r << 16) | (g << 8) | b)
+
+    def to_chroma(self, clear: float | None = None) -> "ColorChroma":
+        """Chroma from normalized RGB. If ``clear`` is None, uses ``max(r,g,b)`` as a proxy for C."""
+        c = clear if clear is not None else max(self.r, self.g, self.b)
+        if c <= 0:
+            return ColorChroma(0.0, 0.0, 0.0)
+        inv = 1.0 / c
+        return ColorChroma(self.r * inv, self.g * inv, self.b * inv)
+
+
+class ColorHSV:
+    """Hue in [0, 360), saturation and value in [0, 1]."""
+
+    __slots__ = ("h", "s", "v")
+
+    def __init__(self, h: float, s: float, v: float) -> None:
+        # Normalize h once on construction so downstream comparisons don't drift.
+        self.h = h % 360.0
+        self.s = s
+        self.v = v
+
+    def __repr__(self) -> str:
+        return f"ColorHSV(h={self.h:.1f}°, s={self.s:.3f}, v={self.v:.3f})"
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ColorHSV)
+            and isclose(self.h, other.h, abs_tol=1e-3)
+            and isclose(self.s, other.s, abs_tol=1e-6)
+            and isclose(self.v, other.v, abs_tol=1e-6)
+        )
+
+    def to_rgb(self) -> ColorRGB:
+        """Standard HSV → RGB (h in degrees)."""
+        h, s, v = self.h, self.s, self.v
+        if s == 0:
+            return ColorRGB(v, v, v)
+        c = v * s
+        hh = (h / 60.0) % 6.0
+        x = c * (1 - abs(hh % 2 - 1))
+        if hh < 1:
+            r, g, b = c, x, 0.0
+        elif hh < 2:
+            r, g, b = x, c, 0.0
+        elif hh < 3:
+            r, g, b = 0.0, c, x
+        elif hh < 4:
+            r, g, b = 0.0, x, c
+        elif hh < 5:
+            r, g, b = x, 0.0, c
+        else:
+            r, g, b = c, 0.0, x
+        m = v - c
+        return ColorRGB(r + m, g + m, b + m)
+
+    def to_hex(self) -> "ColorHex":
+        return self.to_rgb().to_hex()
+
+
+class ColorChroma:
+    """Channel-wise ratios r/c, g/c, b/c from an RGBC reading.
+
+    Dividing each color channel by Clear removes the common intensity factor:
+    a 2× brighter light doubles r, g, b AND c → ratios unchanged. This is
+    the cheapest way to make classification insensitive to how bright the
+    illuminant is. It does NOT remove spectral shifts (a warm tungsten vs a
+    cool daylight projector still reshape r/c vs b/c differently) — pair
+    with a flash-differential measurement at the sensor to cover that.
+    """
+
+    __slots__ = ("rc", "gc", "bc")
+
+    def __init__(self, rc: float, gc: float, bc: float) -> None:
+        self.rc = rc
+        self.gc = gc
+        self.bc = bc
+
+    def __repr__(self) -> str:
+        return f"ColorChroma(rc={self.rc:.3f}, gc={self.gc:.3f}, bc={self.bc:.3f})"
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, ColorChroma)
+            and isclose(self.rc, other.rc, abs_tol=1e-6)
+            and isclose(self.gc, other.gc, abs_tol=1e-6)
+            and isclose(self.bc, other.bc, abs_tol=1e-6)
+        )
+
+    def to_rgb(self, v: float = 1.0) -> ColorRGB:
+        """Reconstruct RGB, scaling by ``v``. The absolute intensity is lost in chroma; caller supplies it."""
+        m = max(self.rc, self.gc, self.bc, 1e-9)
+        scale = v / m
+        return ColorRGB(
+            min(1.0, self.rc * scale),
+            min(1.0, self.gc * scale),
+            min(1.0, self.bc * scale),
+        )
+
+    def to_hsv(self) -> ColorHSV:
+        """Hue + saturation are preserved (ratio-based). V is set to the max ratio by convention."""
+        rc, gc, bc = self.rc, self.gc, self.bc
+        cmax = max(rc, gc, bc)
+        cmin = min(rc, gc, bc)
+        delta = cmax - cmin
+        if delta == 0:
+            h = 0.0
+        elif cmax == rc:
+            h = (60.0 * ((gc - bc) / delta)) % 360
+        elif cmax == gc:
+            h = 60.0 * ((bc - rc) / delta) + 120
+        else:
+            h = 60.0 * ((rc - gc) / delta) + 240
+        s = 0.0 if cmax == 0 else delta / cmax
+        return ColorHSV(h, s, min(1.0, cmax))
+
+
+class ColorHex:
+    """A single packed 0xRRGGBB integer. Useful for logs, config, human-facing output."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: int) -> None:
+        if not (0 <= value <= 0xFFFFFF):
+            raise ValueError(f"ColorHex value must be 0..0xFFFFFF, got 0x{value:X}")
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f"ColorHex(#{self.value:06X})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, ColorHex) and self.value == other.value
+
+    @property
+    def r8(self) -> int:
+        return (self.value >> 16) & 0xFF
+
+    @property
+    def g8(self) -> int:
+        return (self.value >> 8) & 0xFF
+
+    @property
+    def b8(self) -> int:
+        return self.value & 0xFF
+
+    def to_rgb(self) -> ColorRGB:
+        return ColorRGB(self.r8 / 255.0, self.g8 / 255.0, self.b8 / 255.0)
+
+    def to_hsv(self) -> ColorHSV:
+        return self.to_rgb().to_hsv()
+
+
+# ── Composite Color (multi-repr, lazy) ────────────────────────────────────
+
+class Color:
+    """A single color carrying every representation, derived lazily.
+
+    One rep is the "source" (the one passed to the factory). Any other rep is
+    computed and cached on first property read. Use the factory ``from_*``
+    methods rather than the raw constructor.
+
+    ``name`` is optional — reference colors in a palette carry a human label
+    ("Yellow", "Blue"); measurements coming off a sensor typically do not.
+    """
+
+    __slots__ = ("name", "_rgbc", "_rgb", "_hsv", "_chroma", "_hex")
+
+    def __init__(
+        self,
+        *,
+        rgbc: ColorRGBC | None = None,
+        rgb: ColorRGB | None = None,
+        hsv: ColorHSV | None = None,
+        chroma: ColorChroma | None = None,
+        hex_: ColorHex | None = None,
+        name: str | None = None,
+    ) -> None:
+        if all(x is None for x in (rgbc, rgb, hsv, chroma, hex_)):
+            raise ValueError("Color needs at least one representation as a source")
+        self.name = name
+        self._rgbc = rgbc
+        self._rgb = rgb
+        self._hsv = hsv
+        self._chroma = chroma
+        self._hex = hex_
+
+    # ── Factories ────────────────────────────────────────────────────────
+    @classmethod
+    def from_rgbc(
+        cls,
+        r: int,
+        g: int,
+        b: int,
+        c: int,
+        full_scale: int = 65535,
+        *,
+        name: str | None = None,
+    ) -> "Color":
+        return cls(rgbc=ColorRGBC(r, g, b, c, full_scale), name=name)
+
+    @classmethod
+    def from_rgb(cls, r: float, g: float, b: float, *, name: str | None = None) -> "Color":
+        return cls(rgb=ColorRGB(r, g, b), name=name)
+
+    @classmethod
+    def from_hsv(cls, h: float, s: float, v: float, *, name: str | None = None) -> "Color":
+        return cls(hsv=ColorHSV(h, s, v), name=name)
+
+    @classmethod
+    def from_chroma(cls, rc: float, gc: float, bc: float, *, name: str | None = None) -> "Color":
+        return cls(chroma=ColorChroma(rc, gc, bc), name=name)
+
+    @classmethod
+    def from_hex(cls, value: int, *, name: str | None = None) -> "Color":
+        return cls(hex_=ColorHex(value), name=name)
+
+    # ── Lazy derived properties ──────────────────────────────────────────
+    @property
+    def rgbc(self) -> ColorRGBC:
+        if self._rgbc is None:
+            # No direct RGBC source; derive from RGB at the display full-scale (255).
+            # Callers that need sensor-scale RGBC should construct via from_rgbc.
+            self._rgbc = self.rgb.to_rgbc()
+        return self._rgbc
+
+    @property
+    def rgb(self) -> ColorRGB:
+        if self._rgb is None:
+            if self._rgbc is not None:
+                self._rgb = self._rgbc.to_rgb()
+            elif self._hsv is not None:
+                self._rgb = self._hsv.to_rgb()
+            elif self._hex is not None:
+                self._rgb = self._hex.to_rgb()
+            else:
+                assert self._chroma is not None
+                self._rgb = self._chroma.to_rgb()
+        return self._rgb
+
+    @property
+    def hsv(self) -> ColorHSV:
+        if self._hsv is None:
+            # Prefer sources that already carry intensity info to avoid invented V.
+            if self._rgbc is not None:
+                self._hsv = self._rgbc.to_hsv()
+            elif self._chroma is not None:
+                self._hsv = self._chroma.to_hsv()
+            else:
+                self._hsv = self.rgb.to_hsv()
+        return self._hsv
+
+    @property
+    def chroma(self) -> ColorChroma:
+        if self._chroma is None:
+            if self._rgbc is not None:
+                self._chroma = self._rgbc.to_chroma()
+            else:
+                self._chroma = self.rgb.to_chroma()
+        return self._chroma
+
+    @property
+    def hex(self) -> ColorHex:
+        if self._hex is None:
+            self._hex = self.rgb.to_hex()
+        return self._hex
+
+    def __repr__(self) -> str:
+        tag = f"'{self.name}' " if self.name else ""
+        return f"Color({tag}{self.hex})"
+
+
+# ── Named palette keys ────────────────────────────────────────────────────
 
 class NamedColor(IntEnum):
-    """Hardcoded palette of names used by color-sensor classification.
-
-    Reference RGBC counts for each name are supplied by the chip driver
-    (different chip families have wildly different responsivity and
-    full-scale, so a one-size palette would be meaningless).
-    """
+    """Hardcoded palette labels used by sensor classification."""
 
     Unknown = 0
     Black = 1
@@ -124,100 +448,149 @@ class NamedColor(IntEnum):
     Yellow = 6
 
 
+# ── Pure mathematical references ──────────────────────────────────────────
+
+# Fallback palette of mathematically pure primaries/secondaries — used when no
+# in-situ calibration is available. These are theoretical colors (100% saturation,
+# 100% value in HSV), not empirical sensor readings. For competition-grade
+# classification, replace with chip-specific references via a driver-level
+# palette (e.g. TCS34725_DEFAULT_PALETTE) or calibrate in-situ.
+
+PURE_COLORS: dict[NamedColor, Color] = {
+    NamedColor.Black:  Color.from_hex(0x000000, name="Black"),
+    NamedColor.White:  Color.from_hex(0xFFFFFF, name="White"),
+    NamedColor.Red:    Color.from_hex(0xFF0000, name="Red"),
+    NamedColor.Green:  Color.from_hex(0x00FF00, name="Green"),
+    NamedColor.Blue:   Color.from_hex(0x0000FF, name="Blue"),
+    NamedColor.Yellow: Color.from_hex(0xFFFF00, name="Yellow"),
+}
+
+
+# ── Palette: classification against named references ─────────────────────
+
+def _hue_distance(h1: float, h2: float) -> float:
+    """Shortest angular distance between two hues in degrees, always in [0, 180]."""
+    d = abs(h1 - h2) % 360.0
+    return d if d <= 180.0 else 360.0 - d
+
+
 class Palette:
-    """Mutable mapping ``NamedColor`` → reference ``ColorRaw``.
+    """Mutable mapping ``NamedColor → Color`` with multi-method classification.
 
-    ``classify`` picks the entry with the smallest squared euclidean
-    distance to the measured raw value (sqrt skipped — monotone, so the
-    ranking is identical and cheaper to compute).
+    ``classify`` picks the closest reference in the chosen metric space:
 
-    Optional gamma correction: when ``gamma != 1.0`` each channel is
-    transformed by ``v ** (1/gamma)`` before comparison. The gamma-corrected
-    references are cached, so the runtime cost stays at 4 ``pow`` calls
-    per classify (only on the live measurement).
+    - ``"hsv"``    — angular distance on Hue, with a saturation floor.
+                     Default: robust to illuminant intensity; partly robust to spectral
+                     shifts (hue decalibrates a few degrees, not tens).
+    - ``"chroma"`` — euclidean distance on r/c, g/c, b/c ratios.
+                     Invariant to pure intensity, still sensitive to spectral shifts.
+                     Use when the sensor's Clear channel is reliable.
+    - ``"rgbc"``   — euclidean distance on raw RGBC ADC counts.
+                     Intensity-dependent: legacy behavior, mostly for offline comparison.
     """
 
     def __init__(
         self,
-        refs: dict[NamedColor, ColorRaw] | None = None,
-        gamma: float = 1.0,
+        refs: dict[NamedColor, Color] | None = None,
+        min_saturation: float = 0.15,
+        default_method: str = "hsv",
     ) -> None:
-        self._refs: dict[NamedColor, ColorRaw] = dict(refs) if refs else {}
-        self._gamma: float = gamma
-        self._refs_gamma: dict[NamedColor, tuple[float, float, float, float]] | None = None
-        self._refresh_gamma_cache()
+        self._refs: dict[NamedColor, Color] = dict(refs) if refs else {}
+        self.min_saturation = min_saturation
+        self.default_method = default_method
 
-    def set(self, name: NamedColor, raw: ColorRaw) -> None:
-        self._refs[name] = raw
-        self._refresh_gamma_cache()
+    def set(self, name: NamedColor, ref: Color) -> None:
+        self._refs[name] = ref
 
-    def get(self, name: NamedColor) -> ColorRaw | None:
+    def get(self, name: NamedColor) -> Color | None:
         return self._refs.get(name)
 
-    def get_gamma(self) -> float:
-        return self._gamma
-
-    def set_gamma(self, gamma: float) -> None:
-        if gamma <= 0:
-            raise ValueError(f"gamma must be > 0, got {gamma}")
-        self._gamma = gamma
-        self._refresh_gamma_cache()
+    def names(self) -> list[NamedColor]:
+        return [n for n in self._refs if n is not NamedColor.Unknown]
 
     def classify(
         self,
-        raw: ColorRaw,
-        max_distance_squared: float | None = None,
+        measured: Color,
+        method: str | None = None,
+        max_distance: float | None = None,
     ) -> NamedColor:
-        """Return the closest ``NamedColor`` (by squared euclidean distance).
+        """Return the closest ``NamedColor``, or ``NamedColor.Unknown`` if no ref fits.
 
-        Empty palette or all entries beyond ``max_distance_squared`` returns
-        ``NamedColor.Unknown``.
+        ``max_distance`` is expressed in the native unit of ``method``:
+        degrees for hue (typical: 30-60), euclidean chroma delta for "chroma"
+        (typical: 0.3-0.5), squared RGBC counts for "rgbc" (typical ~1e8).
         """
         if not self._refs:
             return NamedColor.Unknown
+        m = method if method is not None else self.default_method
 
+        if m == "hsv":
+            return self._classify_hsv(measured, max_distance)
+        if m == "chroma":
+            return self._classify_chroma(measured, max_distance)
+        if m == "rgbc":
+            return self._classify_rgbc(measured, max_distance)
+        raise ValueError(f"classify method must be 'hsv', 'chroma' or 'rgbc', got {m!r}")
+
+    def _classify_hsv(
+        self, measured: Color, max_distance: float | None
+    ) -> NamedColor:
+        hsv = measured.hsv
+        if hsv.s < self.min_saturation:
+            return NamedColor.Unknown
         best_name = NamedColor.Unknown
-        best_dist: float = float("inf")
-
-        if self._refs_gamma is None:
-            # Fast path: integer arithmetic, no pow calls.
-            for name, ref in self._refs.items():
-                if name is NamedColor.Unknown:
-                    continue
-                dr = raw.r - ref.r
-                dg = raw.g - ref.g
-                db = raw.b - ref.b
-                dc = raw.c - ref.c
-                dist = dr * dr + dg * dg + db * db + dc * dc
-                if dist < best_dist:
-                    best_dist = dist
-                    best_name = name
-        else:
-            inv_g = 1.0 / self._gamma
-            lr, lg, lb, lc = (raw.r ** inv_g, raw.g ** inv_g,
-                              raw.b ** inv_g, raw.c ** inv_g)
-            for name, (rr, gg, bb, cc) in self._refs_gamma.items():
-                if name is NamedColor.Unknown:
-                    continue
-                dr = lr - rr
-                dg = lg - gg
-                db = lb - bb
-                dc = lc - cc
-                dist = dr * dr + dg * dg + db * db + dc * dc
-                if dist < best_dist:
-                    best_dist = dist
-                    best_name = name
-
-        if max_distance_squared is not None and best_dist > max_distance_squared:
+        best_dist = float("inf")
+        for name, ref in self._refs.items():
+            if name is NamedColor.Unknown:
+                continue
+            d = _hue_distance(hsv.h, ref.hsv.h)
+            if d < best_dist:
+                best_dist = d
+                best_name = name
+        if max_distance is not None and best_dist > max_distance:
             return NamedColor.Unknown
         return best_name
 
-    def _refresh_gamma_cache(self) -> None:
-        if self._gamma == 1.0:
-            self._refs_gamma = None
-            return
-        inv_g = 1.0 / self._gamma
-        self._refs_gamma = {
-            name: (ref.r ** inv_g, ref.g ** inv_g, ref.b ** inv_g, ref.c ** inv_g)
-            for name, ref in self._refs.items()
-        }
+    def _classify_chroma(
+        self, measured: Color, max_distance: float | None
+    ) -> NamedColor:
+        ch = measured.chroma
+        best_name = NamedColor.Unknown
+        best_dist_sq = float("inf")
+        for name, ref in self._refs.items():
+            if name is NamedColor.Unknown:
+                continue
+            rc = ref.chroma
+            dr = ch.rc - rc.rc
+            dg = ch.gc - rc.gc
+            db = ch.bc - rc.bc
+            # Squared distance: monotone with euclidean, sqrt skipped (cheap win).
+            d = dr * dr + dg * dg + db * db
+            if d < best_dist_sq:
+                best_dist_sq = d
+                best_name = name
+        if max_distance is not None and best_dist_sq > max_distance * max_distance:
+            return NamedColor.Unknown
+        return best_name
+
+    def _classify_rgbc(
+        self, measured: Color, max_distance: float | None
+    ) -> NamedColor:
+        rgbc = measured.rgbc
+        best_name = NamedColor.Unknown
+        best_dist = float("inf")
+        for name, ref in self._refs.items():
+            if name is NamedColor.Unknown:
+                continue
+            rref = ref.rgbc
+            dr = rgbc.r - rref.r
+            dg = rgbc.g - rref.g
+            db = rgbc.b - rref.b
+            dc = rgbc.c - rref.c
+            d = dr * dr + dg * dg + db * db + dc * dc
+            if d < best_dist:
+                best_dist = d
+                best_name = name
+        if max_distance is not None and best_dist > max_distance:
+            return NamedColor.Unknown
+        return best_name

--- a/src/evo_lib/types/color.py
+++ b/src/evo_lib/types/color.py
@@ -29,8 +29,8 @@ from __future__ import annotations
 from enum import IntEnum
 from math import isclose
 
-
 # ── Representation classes ───────────────────────────────────────────────
+
 
 class ColorRGBC:
     """Raw RGBC ADC counts straight off an RGBC sensor (TCS34725 family, etc.).
@@ -152,7 +152,7 @@ class ColorRGB:
         return ColorHSV(h, s, v)
 
     def to_rgbc(self, full_scale: int = 255) -> ColorRGBC:
-        """Quantize to integer ADC counts. Clear derived as ``max(r,g,b)*full_scale`` — approximation."""
+        """Quantize to integer ADC counts. Clear derived as ``max(r,g,b)*full_scale`` — approximation."""  # noqa: E501
         r_i = max(0, min(full_scale, round(self.r * full_scale)))
         g_i = max(0, min(full_scale, round(self.g * full_scale)))
         b_i = max(0, min(full_scale, round(self.b * full_scale)))
@@ -166,7 +166,7 @@ class ColorRGB:
         return ColorHex((r << 16) | (g << 8) | b)
 
     def to_chroma(self, clear: float | None = None) -> "ColorChroma":
-        """Chroma from normalized RGB. If ``clear`` is None, uses ``max(r,g,b)`` as a proxy for C."""
+        """Chroma from normalized RGB. If ``clear`` is None, uses ``max(r,g,b)`` as a proxy for C."""  # noqa: E501
         c = clear if clear is not None else max(self.r, self.g, self.b)
         if c <= 0:
             return ColorChroma(0.0, 0.0, 0.0)
@@ -253,7 +253,7 @@ class ColorChroma:
         )
 
     def to_rgb(self, v: float = 1.0) -> ColorRGB:
-        """Reconstruct RGB, scaling by ``v``. The absolute intensity is lost in chroma; caller supplies it."""
+        """Reconstruct RGB, scaling by ``v``. The absolute intensity is lost in chroma; caller supplies it."""  # noqa: E501
         m = max(self.rc, self.gc, self.bc, 1e-9)
         scale = v / m
         return ColorRGB(
@@ -316,6 +316,7 @@ class ColorHex:
 
 
 # ── Composite Color (multi-repr, lazy) ────────────────────────────────────
+
 
 class Color:
     """A single color carrying every representation, derived lazily.
@@ -436,6 +437,7 @@ class Color:
 
 # ── Named palette keys ────────────────────────────────────────────────────
 
+
 class NamedColor(IntEnum):
     """Hardcoded palette labels used by sensor classification."""
 
@@ -457,16 +459,17 @@ class NamedColor(IntEnum):
 # palette (e.g. TCS34725_DEFAULT_PALETTE) or calibrate in-situ.
 
 PURE_COLORS: dict[NamedColor, Color] = {
-    NamedColor.Black:  Color.from_hex(0x000000, name="Black"),
-    NamedColor.White:  Color.from_hex(0xFFFFFF, name="White"),
-    NamedColor.Red:    Color.from_hex(0xFF0000, name="Red"),
-    NamedColor.Green:  Color.from_hex(0x00FF00, name="Green"),
-    NamedColor.Blue:   Color.from_hex(0x0000FF, name="Blue"),
+    NamedColor.Black: Color.from_hex(0x000000, name="Black"),
+    NamedColor.White: Color.from_hex(0xFFFFFF, name="White"),
+    NamedColor.Red: Color.from_hex(0xFF0000, name="Red"),
+    NamedColor.Green: Color.from_hex(0x00FF00, name="Green"),
+    NamedColor.Blue: Color.from_hex(0x0000FF, name="Blue"),
     NamedColor.Yellow: Color.from_hex(0xFFFF00, name="Yellow"),
 }
 
 
 # ── Palette: classification against named references ─────────────────────
+
 
 def _hue_distance(h1: float, h2: float) -> float:
     """Shortest angular distance between two hues in degrees, always in [0, 180]."""
@@ -532,9 +535,7 @@ class Palette:
             return self._classify_rgbc(measured, max_distance)
         raise ValueError(f"classify method must be 'hsv', 'chroma' or 'rgbc', got {m!r}")
 
-    def _classify_hsv(
-        self, measured: Color, max_distance: float | None
-    ) -> NamedColor:
+    def _classify_hsv(self, measured: Color, max_distance: float | None) -> NamedColor:
         hsv = measured.hsv
         if hsv.s < self.min_saturation:
             return NamedColor.Unknown
@@ -551,9 +552,7 @@ class Palette:
             return NamedColor.Unknown
         return best_name
 
-    def _classify_chroma(
-        self, measured: Color, max_distance: float | None
-    ) -> NamedColor:
+    def _classify_chroma(self, measured: Color, max_distance: float | None) -> NamedColor:
         ch = measured.chroma
         best_name = NamedColor.Unknown
         best_dist_sq = float("inf")
@@ -573,9 +572,7 @@ class Palette:
             return NamedColor.Unknown
         return best_name
 
-    def _classify_rgbc(
-        self, measured: Color, max_distance: float | None
-    ) -> NamedColor:
+    def _classify_rgbc(self, measured: Color, max_distance: float | None) -> NamedColor:
         rgbc = measured.rgbc
         best_name = NamedColor.Unknown
         best_dist = float("inf")

--- a/tests/test_color_sensor.py
+++ b/tests/test_color_sensor.py
@@ -37,6 +37,7 @@ def logger():
 
 # ── Representation types ─────────────────────────────────────────────────
 
+
 class TestColorRGBC:
     def test_to_rgb_normalizes_by_full_scale(self):
         rgbc = ColorRGBC(32768, 16384, 8192, 100000, full_scale=65535)
@@ -106,6 +107,7 @@ class TestColorHex:
 
 # ── Composite Color (lazy multi-repr) ────────────────────────────────────
 
+
 class TestColor:
     def test_needs_at_least_one_source(self):
         with pytest.raises(ValueError):
@@ -148,6 +150,7 @@ class TestPureColors:
 
 # ── Palette classification ───────────────────────────────────────────────
 
+
 class TestPaletteHSV:
     def _palette(self):
         return Palette(refs=dict(TCS34725_DEFAULT_PALETTE))
@@ -180,11 +183,13 @@ class TestPaletteHSV:
 class TestPaletteChroma:
     def test_invariant_to_intensity(self):
         # Same ratios at two very different intensities → same classification.
-        p = Palette(refs={
-            NamedColor.Red: Color.from_rgbc(8500, 1200, 800, 10500),
-            NamedColor.Blue: Color.from_rgbc(800, 1400, 5500, 7700),
-        })
-        dim = Color.from_rgbc(425, 60, 40, 525)   # 20× dimmer Red
+        p = Palette(
+            refs={
+                NamedColor.Red: Color.from_rgbc(8500, 1200, 800, 10500),
+                NamedColor.Blue: Color.from_rgbc(800, 1400, 5500, 7700),
+            }
+        )
+        dim = Color.from_rgbc(425, 60, 40, 525)  # 20× dimmer Red
         bright = Color.from_rgbc(17000, 2400, 1600, 21000)  # 2× brighter Red
         assert p.classify(dim, method="chroma") is NamedColor.Red
         assert p.classify(bright, method="chroma") is NamedColor.Red
@@ -192,19 +197,23 @@ class TestPaletteChroma:
 
 class TestPaletteRGBC:
     def test_closest_raw_wins(self):
-        p = Palette(refs={
-            NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
-            NamedColor.Green: Color.from_rgbc(1000, 8000, 1000, 10000),
-        })
+        p = Palette(
+            refs={
+                NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
+                NamedColor.Green: Color.from_rgbc(1000, 8000, 1000, 10000),
+            }
+        )
         measured = Color.from_rgbc(7500, 1100, 900, 9500)
         assert p.classify(measured, method="rgbc") is NamedColor.Red
 
     def test_unknown_ref_is_never_returned(self):
         # Even with a spot-on match on Unknown, classify must fall back to a real entry.
-        p = Palette(refs={
-            NamedColor.Unknown: Color.from_rgbc(0, 0, 0, 0),
-            NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
-        })
+        p = Palette(
+            refs={
+                NamedColor.Unknown: Color.from_rgbc(0, 0, 0, 0),
+                NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
+            }
+        )
         assert p.classify(Color.from_rgbc(0, 0, 0, 0), method="rgbc") is NamedColor.Red
 
 
@@ -223,6 +232,7 @@ class TestPaletteMisc:
 
 # ── TCS34725 (real, register-level over virtual I2C) ─────────────────────
 
+
 class TestTCS34725:
     def _bus_with_device(self):
         bus = I2CVirtual()
@@ -234,10 +244,10 @@ class TestTCS34725:
         sensor = TCS34725(name="cs0", logger=logger, bus=bus, gain=4)
         sensor.init().wait()
 
-        assert dev.written[0] == bytes([0x80, 0x01])              # ENABLE = PON
-        assert dev.written[1] == bytes([0x80, 0x03])              # ENABLE = PON|AEN
-        assert dev.written[2][0] == 0x81                          # ATIME register
-        assert dev.written[3] == bytes([0x80 | 0x0F, 0x01])       # CONTROL = 4× (0x01)
+        assert dev.written[0] == bytes([0x80, 0x01])  # ENABLE = PON
+        assert dev.written[1] == bytes([0x80, 0x03])  # ENABLE = PON|AEN
+        assert dev.written[2][0] == 0x81  # ATIME register
+        assert dev.written[3] == bytes([0x80 | 0x0F, 0x01])  # CONTROL = 4× (0x01)
 
     def test_read_color_parses_rgbc_without_flash(self, logger):
         # No light wired → flash differential auto-disabled; single read path.
@@ -283,8 +293,12 @@ class TestTCS34725:
         pwm.init().wait()
         led = PWMLed(name="led", logger=logger, pwm=pwm)
         sensor = TCS34725(
-            name="cs0", logger=logger, bus=bus, light=led,
-            integration_time_ms=3.0, use_flash_differential=False,
+            name="cs0",
+            logger=logger,
+            bus=bus,
+            light=led,
+            integration_time_ms=3.0,
+            use_flash_differential=False,
         )
         sensor.init().wait()
         dev.inject_read(_AVALID_READY)
@@ -372,6 +386,7 @@ class TestTCS34725:
 
 # ── TCS34725Virtual ──────────────────────────────────────────────────────
 
+
 class TestTCS34725Virtual:
     def test_inject_then_read_roundtrips(self, logger):
         sensor = TCS34725Virtual(name="cs0", logger=logger)
@@ -408,7 +423,10 @@ class TestTCS34725Virtual:
         (raw,) = sensor.read_color().wait()
         ref = sensor._palette.get(NamedColor.Red)
         assert (raw.r, raw.g, raw.b, raw.c) == (
-            ref.rgbc.r, ref.rgbc.g, ref.rgbc.b, ref.rgbc.c,
+            ref.rgbc.r,
+            ref.rgbc.g,
+            ref.rgbc.b,
+            ref.rgbc.c,
         )
 
     def test_set_color_raises_on_missing_palette_entry(self, logger):
@@ -457,6 +475,7 @@ class TestTCS34725Virtual:
 
 
 # ── ATIME helpers ────────────────────────────────────────────────────────
+
 
 def test_atime_conversions_roundtrip():
     for ms in (2.4, 24.0, 100.8, 614.4):

--- a/tests/test_color_sensor.py
+++ b/tests/test_color_sensor.py
@@ -358,9 +358,16 @@ class TestTCS34725:
         sensor.auto_expose(target_c=30000).wait()
         assert sensor._atime == atime_before
 
-    def test_calibrate_not_exposed_as_command(self):
+    def test_calibrate_exposed_as_command(self):
+        # Exposed so operators can recalibrate in-situ from the REPL before a match,
+        # presenting a pad of the target color to the sensor.
         names = {cmd.name for cmd in TCS34725.commands.get_all()}
-        assert "calibrate" not in names
+        assert "calibrate" in names
+
+    def test_diagnostic_commands_exposed(self):
+        names = {cmd.name for cmd in TCS34725.commands.get_all()}
+        assert "get_chip_id" in names
+        assert "get_status" in names
 
 
 # ── TCS34725Virtual ──────────────────────────────────────────────────────

--- a/tests/test_color_sensor.py
+++ b/tests/test_color_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for TCS34725 driver, Palette and Color utilities."""
+"""Tests for TCS34725 driver, the Color representation types and Palette classification."""
 
 import struct
 
@@ -6,6 +6,7 @@ import pytest
 
 from evo_lib.drivers.color_sensor.tcs34725 import (
     TCS34725,
+    TCS34725_DEFAULT_PALETTE,
     TCS34725Virtual,
     _atime_to_ms,
     _ms_to_atime,
@@ -14,7 +15,17 @@ from evo_lib.drivers.i2c.virtual import I2CVirtual
 from evo_lib.drivers.led.pwm_led import PWMLed
 from evo_lib.drivers.pwm.virtual import PWMVirtual
 from evo_lib.logger import Logger
-from evo_lib.types.color import Color, ColorRaw, NamedColor, Palette
+from evo_lib.types.color import (
+    PURE_COLORS,
+    Color,
+    ColorChroma,
+    ColorHex,
+    ColorHSV,
+    ColorRGB,
+    ColorRGBC,
+    NamedColor,
+    Palette,
+)
 
 _AVALID_READY = b"\x01"
 
@@ -24,56 +35,190 @@ def logger():
     return Logger("test")
 
 
-# ── Palette ──────────────────────────────────────────────────────────────
+# ── Representation types ─────────────────────────────────────────────────
 
-class TestPalette:
+class TestColorRGBC:
+    def test_to_rgb_normalizes_by_full_scale(self):
+        rgbc = ColorRGBC(32768, 16384, 8192, 100000, full_scale=65535)
+        rgb = rgbc.to_rgb()
+        assert abs(rgb.r - 0.5) < 0.001
+        assert abs(rgb.g - 0.25) < 0.001
+        assert abs(rgb.b - 0.125) < 0.001
+
+    def test_to_hsv_hue_indeprendent_of_scale(self):
+        # Yellow-ish: R≈G >> B. Hue should be ~60° regardless of full_scale.
+        a = ColorRGBC(1000, 1000, 0, 2000, full_scale=65535).to_hsv()
+        b = ColorRGBC(10000, 10000, 0, 20000, full_scale=65535).to_hsv()
+        assert abs(a.h - b.h) < 0.1
+        assert abs(a.h - 60.0) < 1.0
+
+    def test_to_chroma_zero_clear_returns_zero(self):
+        ch = ColorRGBC(100, 100, 100, 0, full_scale=65535).to_chroma()
+        assert ch == ColorChroma(0.0, 0.0, 0.0)
+
+    def test_to_chroma_ratios(self):
+        ch = ColorRGBC(1000, 500, 250, 2000, full_scale=65535).to_chroma()
+        assert abs(ch.rc - 0.5) < 1e-6
+        assert abs(ch.gc - 0.25) < 1e-6
+        assert abs(ch.bc - 0.125) < 1e-6
+
+    def test_chroma_invariant_to_intensity(self):
+        # Doubling the illumination doubles all 4 channels → ratios unchanged.
+        ch1 = ColorRGBC(1000, 500, 250, 2000).to_chroma()
+        ch2 = ColorRGBC(2000, 1000, 500, 4000).to_chroma()
+        assert ch1 == ch2
+
+
+class TestColorHSV:
+    def test_hue_wraps_modulo_360(self):
+        assert ColorHSV(370.0, 0.5, 0.5).h == 10.0
+        assert ColorHSV(-10.0, 0.5, 0.5).h == 350.0
+
+    def test_to_rgb_primary_hues(self):
+        # Red: h=0
+        assert ColorHSV(0.0, 1.0, 1.0).to_rgb() == ColorRGB(1.0, 0.0, 0.0)
+        # Green: h=120
+        assert ColorHSV(120.0, 1.0, 1.0).to_rgb() == ColorRGB(0.0, 1.0, 0.0)
+        # Blue: h=240
+        assert ColorHSV(240.0, 1.0, 1.0).to_rgb() == ColorRGB(0.0, 0.0, 1.0)
+        # Yellow: h=60
+        assert ColorHSV(60.0, 1.0, 1.0).to_rgb() == ColorRGB(1.0, 1.0, 0.0)
+
+    def test_grayscale_saturation_zero(self):
+        rgb = ColorHSV(0.0, 0.0, 0.5).to_rgb()
+        assert rgb == ColorRGB(0.5, 0.5, 0.5)
+
+
+class TestColorHex:
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError):
+            ColorHex(-1)
+        with pytest.raises(ValueError):
+            ColorHex(0x1000000)
+
+    def test_channel_accessors(self):
+        c = ColorHex(0xAABBCC)
+        assert (c.r8, c.g8, c.b8) == (0xAA, 0xBB, 0xCC)
+
+    def test_roundtrip_through_rgb(self):
+        assert ColorHex(0xFF8040).to_rgb().to_hex() == ColorHex(0xFF8040)
+
+
+# ── Composite Color (lazy multi-repr) ────────────────────────────────────
+
+class TestColor:
+    def test_needs_at_least_one_source(self):
+        with pytest.raises(ValueError):
+            Color()
+
+    def test_rgbc_source_derives_hsv_and_chroma(self):
+        c = Color.from_rgbc(10000, 5000, 2500, 15000)
+        # HSV derived from RGBC (preserves intensity).
+        assert abs(c.hsv.h - 20.0) < 1.0  # orange-red
+        # Chroma from RGBC uses the Clear channel.
+        assert abs(c.chroma.rc - 10000 / 15000) < 1e-6
+
+    def test_hex_source_gives_rgb_and_hsv(self):
+        c = Color.from_hex(0x00FF00)
+        assert c.rgb == ColorRGB(0.0, 1.0, 0.0)
+        assert abs(c.hsv.h - 120.0) < 0.001
+
+    def test_lazy_cache_is_stable_across_reads(self):
+        c = Color.from_hex(0xABCDEF)
+        first = c.hsv
+        second = c.hsv
+        assert first is second  # cached, same instance
+
+    def test_name_is_preserved_in_repr(self):
+        c = Color.from_hex(0xFF0000, name="Red")
+        assert "Red" in repr(c)
+
+
+class TestPureColors:
+    def test_contains_all_named_colors_except_unknown(self):
+        missing = [n for n in NamedColor if n is not NamedColor.Unknown and n not in PURE_COLORS]
+        assert missing == []
+
+    def test_red_hsv_is_zero(self):
+        assert abs(PURE_COLORS[NamedColor.Red].hsv.h) < 0.001
+
+    def test_yellow_hue_is_60(self):
+        assert abs(PURE_COLORS[NamedColor.Yellow].hsv.h - 60.0) < 0.001
+
+
+# ── Palette classification ───────────────────────────────────────────────
+
+class TestPaletteHSV:
+    def _palette(self):
+        return Palette(refs=dict(TCS34725_DEFAULT_PALETTE))
+
     def test_empty_palette_returns_unknown(self):
-        assert Palette().classify(ColorRaw(100, 200, 300, 400)) is NamedColor.Unknown
+        assert Palette().classify(Color.from_hex(0xFFFFFF)) is NamedColor.Unknown
 
-    def test_closest_entry_wins(self):
+    def test_yellow_sample_classifies_yellow(self):
+        # Warm yellowish raw: r=8500, g=6500, b=800 → hue ≈ 44°, closest to palette's Yellow (~55°).
+        measured = Color.from_rgbc(8500, 6500, 800, 15000)
+        assert self._palette().classify(measured) is NamedColor.Yellow
+
+    def test_blue_sample_classifies_blue(self):
+        # Cool blueish: r=500, g=3500, b=5000 → hue ≈ 200°, closest to Blue (~232°).
+        measured = Color.from_rgbc(500, 3500, 5000, 9000)
+        assert self._palette().classify(measured) is NamedColor.Blue
+
+    def test_low_saturation_is_unknown(self):
+        # All channels near equal → saturation < 0.15 → Unknown.
+        measured = Color.from_rgbc(1000, 1000, 950, 3000)
+        assert self._palette().classify(measured) is NamedColor.Unknown
+
+    def test_max_distance_caps_the_answer(self):
+        # Cyan (hue 180°) is > 30° from every entry in the default palette
+        # (closest is Blue at ~52°) → Unknown under a 30° cap.
+        measured = Color.from_hsv(180.0, 1.0, 1.0)
+        assert self._palette().classify(measured, max_distance=30.0) is NamedColor.Unknown
+
+
+class TestPaletteChroma:
+    def test_invariant_to_intensity(self):
+        # Same ratios at two very different intensities → same classification.
         p = Palette(refs={
-            NamedColor.Red:   ColorRaw(8000, 1000, 1000, 10000),
-            NamedColor.Green: ColorRaw(1000, 8000, 1000, 10000),
+            NamedColor.Red: Color.from_rgbc(8500, 1200, 800, 10500),
+            NamedColor.Blue: Color.from_rgbc(800, 1400, 5500, 7700),
         })
-        assert p.classify(ColorRaw(7500, 1100, 900, 9500)) is NamedColor.Red
+        dim = Color.from_rgbc(425, 60, 40, 525)   # 20× dimmer Red
+        bright = Color.from_rgbc(17000, 2400, 1600, 21000)  # 2× brighter Red
+        assert p.classify(dim, method="chroma") is NamedColor.Red
+        assert p.classify(bright, method="chroma") is NamedColor.Red
 
-    def test_threshold_returns_unknown_when_too_far(self):
-        p = Palette(refs={NamedColor.Red: ColorRaw(8000, 1000, 1000, 10000)})
-        # Distance² is huge — well beyond a tight threshold of 1000.
-        assert p.classify(ColorRaw(0, 0, 0, 0), max_distance_squared=1000) is NamedColor.Unknown
 
-    def test_unknown_ref_is_never_returned_as_match(self):
-        # If Unknown is injected with a spot-on match, classify must still
-        # pick the next best real entry — Unknown is reserved for "no match".
+class TestPaletteRGBC:
+    def test_closest_raw_wins(self):
         p = Palette(refs={
-            NamedColor.Unknown: ColorRaw(0, 0, 0, 0),
-            NamedColor.Red: ColorRaw(8000, 1000, 1000, 10000),
+            NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
+            NamedColor.Green: Color.from_rgbc(1000, 8000, 1000, 10000),
         })
-        assert p.classify(ColorRaw(0, 0, 0, 0)) is NamedColor.Red
+        measured = Color.from_rgbc(7500, 1100, 900, 9500)
+        assert p.classify(measured, method="rgbc") is NamedColor.Red
 
-    def test_gamma_changes_result(self):
-        # Refs are nearly equidistant so a gamma shift can flip the winner.
+    def test_unknown_ref_is_never_returned(self):
+        # Even with a spot-on match on Unknown, classify must fall back to a real entry.
         p = Palette(refs={
-            NamedColor.Red:   ColorRaw(10000, 100, 100, 10000),
-            NamedColor.Green: ColorRaw(100, 10000, 100, 10000),
+            NamedColor.Unknown: Color.from_rgbc(0, 0, 0, 0),
+            NamedColor.Red: Color.from_rgbc(8000, 1000, 1000, 10000),
         })
-        raw = ColorRaw(5000, 5000, 100, 10000)
-        baseline = p.classify(raw)
-        p.set_gamma(2.0)
-        # We don't assert on exact identity, just that gamma path is exercised
-        # and the cache rebuilt without error; pick a value that is symmetric.
-        assert p.classify(raw) in (baseline, NamedColor.Red, NamedColor.Green)
+        assert p.classify(Color.from_rgbc(0, 0, 0, 0), method="rgbc") is NamedColor.Red
 
 
-# ── Color.from_raw ───────────────────────────────────────────────────────
+class TestPaletteMisc:
+    def test_unknown_method_raises(self):
+        with pytest.raises(ValueError):
+            Palette(refs={NamedColor.Red: Color.from_hex(0xFF0000)}).classify(
+                Color.from_hex(0xFF0000), method="bogus"
+            )
 
-class TestColorFromRaw:
-    def test_normalizes_and_clamps(self):
-        color = Color.from_raw(ColorRaw(32768, 16384, 8192, 100000), full_scale=65535)
-        assert abs(color.r - 0.5) < 0.001
-        assert abs(color.g - 0.25) < 0.001
-        assert abs(color.b - 0.125) < 0.001
-        assert color.c == 1.0  # clamped
+    def test_default_method_is_hsv(self):
+        p = Palette(refs={NamedColor.Red: Color.from_hex(0xFF0000)})
+        # Low-saturation measurement triggers the HSV-only saturation floor.
+        assert p.classify(Color.from_rgbc(500, 500, 500, 2000)) is NamedColor.Unknown
 
 
 # ── TCS34725 (real, register-level over virtual I2C) ─────────────────────
@@ -94,7 +239,8 @@ class TestTCS34725:
         assert dev.written[2][0] == 0x81                          # ATIME register
         assert dev.written[3] == bytes([0x80 | 0x0F, 0x01])       # CONTROL = 4× (0x01)
 
-    def test_read_color_parses_rgbc(self, logger):
+    def test_read_color_parses_rgbc_without_flash(self, logger):
+        # No light wired → flash differential auto-disabled; single read path.
         bus, dev = self._bus_with_device()
         sensor = TCS34725(name="cs0", logger=logger, bus=bus)
         sensor.init().wait()
@@ -103,6 +249,50 @@ class TestTCS34725:
 
         (raw,) = sensor.read_color().wait()
         assert (raw.r, raw.g, raw.b, raw.c) == (500, 250, 100, 1000)
+        assert raw.full_scale == sensor.get_full_scale()
+
+    def test_flash_differential_subtracts_ambient(self, logger):
+        # With a wired LED, read_color must produce a 2-read ON/OFF diff.
+        bus, dev = self._bus_with_device()
+        pwm = PWMVirtual(name="pwm", logger=logger)
+        pwm.init().wait()
+        led = PWMLed(name="led", logger=logger, pwm=pwm)
+        sensor = TCS34725(
+            name="cs0",
+            logger=logger,
+            bus=bus,
+            light=led,
+            integration_time_ms=3.0,  # keep the 1.5× sleep tiny
+        )
+        sensor.init().wait()
+        dev.written.clear()
+
+        # OFF (ambient only)
+        dev.inject_read(_AVALID_READY)
+        dev.inject_read(struct.pack("<HHHH", 300, 100, 100, 100))
+        # ON (ambient + LED)
+        dev.inject_read(_AVALID_READY)
+        dev.inject_read(struct.pack("<HHHH", 2000, 1500, 500, 500))
+
+        (raw,) = sensor.read_color().wait()
+        assert (raw.r, raw.g, raw.b, raw.c) == (1400, 400, 400, 1700)
+
+    def test_flash_disabled_skips_ambient_read(self, logger):
+        bus, dev = self._bus_with_device()
+        pwm = PWMVirtual(name="pwm", logger=logger)
+        pwm.init().wait()
+        led = PWMLed(name="led", logger=logger, pwm=pwm)
+        sensor = TCS34725(
+            name="cs0", logger=logger, bus=bus, light=led,
+            integration_time_ms=3.0, use_flash_differential=False,
+        )
+        sensor.init().wait()
+        dev.inject_read(_AVALID_READY)
+        dev.inject_read(struct.pack("<HHHH", 2000, 1500, 500, 500))
+
+        (raw,) = sensor.read_color().wait()
+        # Single read → returned as-is, no subtraction.
+        assert (raw.r, raw.g, raw.b, raw.c) == (1500, 500, 500, 2000)
 
     def test_read_color_times_out_if_avalid_never_set(self, logger):
         bus, dev = self._bus_with_device()
@@ -145,18 +335,35 @@ class TestTCS34725:
         bus, _ = self._bus_with_device()
         sensor = TCS34725(name="cs0", logger=logger, bus=bus)
         sensor.init().wait()
-        # Default ATIME ≈ 103 ms → (256 - 0xD5) * 1024 = 43008
         assert sensor.get_full_scale() == (256 - 0xD5) * 1024
         sensor.set_integration_time(614.4).wait()
-        # ATIME=0 → full_scale capped at 65535
         assert sensor.get_full_scale() == 65535
+
+    def test_set_flash_differential_requires_wired_led(self, logger):
+        bus, _ = self._bus_with_device()
+        # No LED wired → setter must refuse to enable.
+        sensor = TCS34725(name="cs0", logger=logger, bus=bus, use_flash_differential=False)
+        sensor.set_flash_differential(True).wait()
+        (enabled,) = sensor.get_flash_differential().wait()
+        assert enabled is False
+
+    def test_auto_expose_converges_immediately_at_target(self, logger):
+        bus, dev = self._bus_with_device()
+        sensor = TCS34725(name="cs0", logger=logger, bus=bus, integration_time_ms=3.0)
+        sensor.init().wait()
+        atime_before = sensor._atime
+        # Reading already at target → ratio ≈ 1 → break immediately, no register write.
+        dev.inject_read(_AVALID_READY)
+        dev.inject_read(struct.pack("<HHHH", 30000, 100, 100, 100))
+        sensor.auto_expose(target_c=30000).wait()
+        assert sensor._atime == atime_before
 
     def test_calibrate_not_exposed_as_command(self):
         names = {cmd.name for cmd in TCS34725.commands.get_all()}
         assert "calibrate" not in names
 
 
-# ── TCS34725Virtual (full virtual) ───────────────────────────────────────
+# ── TCS34725Virtual ──────────────────────────────────────────────────────
 
 class TestTCS34725Virtual:
     def test_inject_then_read_roundtrips(self, logger):
@@ -176,7 +383,6 @@ class TestTCS34725Virtual:
     def test_get_color_classifies_blue_via_hsv(self, logger):
         sensor = TCS34725Virtual(name="cs0", logger=logger)
         sensor.init().wait()
-        # R=500, G=3500, B=5000 → hue ≈ 200 (inside 150-220 → Blue)
         sensor.inject_color(r=500, g=3500, b=5000, c=9000).wait()
         (name,) = sensor.get_color().wait()
         assert name is NamedColor.Blue
@@ -194,7 +400,9 @@ class TestTCS34725Virtual:
         sensor.set_color(NamedColor.Red).wait()
         (raw,) = sensor.read_color().wait()
         ref = sensor._palette.get(NamedColor.Red)
-        assert (raw.r, raw.g, raw.b, raw.c) == (ref.r, ref.g, ref.b, ref.c)
+        assert (raw.r, raw.g, raw.b, raw.c) == (
+            ref.rgbc.r, ref.rgbc.g, ref.rgbc.b, ref.rgbc.c,
+        )
 
     def test_set_color_raises_on_missing_palette_entry(self, logger):
         sensor = TCS34725Virtual(name="cs0", logger=logger, palette=Palette())
@@ -208,7 +416,7 @@ class TestTCS34725Virtual:
         sensor.inject_color(r=42, g=43, b=44, c=45).wait()
         sensor.calibrate(NamedColor.Red, samples=3).wait()
         ref = sensor._palette.get(NamedColor.Red)
-        assert (ref.r, ref.g, ref.b, ref.c) == (42, 43, 44, 45)
+        assert (ref.rgbc.r, ref.rgbc.g, ref.rgbc.b, ref.rgbc.c) == (42, 43, 44, 45)
 
     def test_set_light_noop_without_led(self, logger):
         sensor = TCS34725Virtual(name="cs0", logger=logger)
@@ -228,11 +436,13 @@ class TestTCS34725Virtual:
         assert abs(intensity - 0.4) < 1e-6
         assert abs(pwm.duty_cycle - 0.4) < 1e-6
 
-    def test_set_gamma_roundtrips(self, logger):
-        sensor = TCS34725Virtual(name="cs0", logger=logger)
-        sensor.set_gamma(2.2).wait()
-        (g,) = sensor.get_gamma().wait()
-        assert g == 2.2
+    def test_flash_differential_flag_roundtrips(self, logger):
+        sensor = TCS34725Virtual(name="cs0", logger=logger, use_flash_differential=False)
+        (enabled,) = sensor.get_flash_differential().wait()
+        assert enabled is False
+        sensor.set_flash_differential(True).wait()
+        (enabled,) = sensor.get_flash_differential().wait()
+        assert enabled is True
 
     def test_calibrate_exposed_as_command_on_virtual(self):
         names = {cmd.name for cmd in TCS34725Virtual.commands.get_all()}

--- a/tests/test_mdb_led.py
+++ b/tests/test_mdb_led.py
@@ -16,6 +16,7 @@ from evo_lib.drivers.led_strip.mdb_led import (
     MdbLedVirtual,
 )
 from evo_lib.logger import Logger
+from evo_lib.types.color import NamedColor
 
 
 @pytest.fixture
@@ -98,7 +99,7 @@ class TestRendering:
 
     def test_loading_chases_team_color(self, strip):
         # Doubles as a check that set_team_color is actually applied.
-        strip.set_team_color(0.0, 0.0, 1.0).wait()  # blue
+        strip.set_team_color(NamedColor.Blue).wait()
         strip.set_state(MdbLedState.Loading).wait()
         for step in range(strip.num_pixels * 2):
             strip.tick()
@@ -113,7 +114,7 @@ class TestRendering:
     def test_loading_chase_width(self, wide_strip):
         # 12-pixel strip, 5-pixel chase. Step 0 should light pixels 0..4
         # in team color and leave the other 7 black.
-        wide_strip.set_team_color(0.0, 0.0, 1.0).wait()  # blue
+        wide_strip.set_team_color(NamedColor.Blue).wait()
         wide_strip.set_state(MdbLedState.Loading).wait()
         wide_strip.tick()
         frame = wide_strip.get_shown_frame()
@@ -153,16 +154,13 @@ class TestStateRoundTrip:
 
     def test_state_and_team_color_round_trip(self, strip):
         strip.set_state(MdbLedState.Loading).wait()
-        strip.set_team_color(0.1, 0.2, 0.3).wait()
+        strip.set_team_color(NamedColor.Red).wait()
 
         (state,) = strip.get_state().wait()
         assert state == MdbLedState.Loading
 
-        r, g, b = strip.get_team_color().wait()
-        tol = 1 / 255 + 1e-9
-        assert abs(r - 0.1) < tol
-        assert abs(g - 0.2) < tol
-        assert abs(b - 0.3) < tol
+        (color,) = strip.get_team_color().wait()
+        assert color == NamedColor.Red
 
 
 class TestAnimatorThread:

--- a/tests/test_mdb_led.py
+++ b/tests/test_mdb_led.py
@@ -190,10 +190,7 @@ class TestAnimatorThread:
         s.set_state(MdbLedState.Loading).wait()
         time.sleep(0.05)
         s.close()
-        leaked = [
-            t for t in threading.enumerate()
-            if t.name == "mdb-led-live2" and t.is_alive()
-        ]
+        leaked = [t for t in threading.enumerate() if t.name == "mdb-led-live2" and t.is_alive()]
         assert leaked == [], f"animator thread leaked: {leaked}"
 
 
@@ -207,6 +204,5 @@ class TestSwapInvariant:
         real_params = set(inspect.signature(MdbLed.__init__).parameters)
         virt_params = set(inspect.signature(MdbLedVirtual.__init__).parameters)
         assert real_params == virt_params, (
-            f"only-real={real_params - virt_params}, "
-            f"only-virt={virt_params - real_params}"
+            f"only-real={real_params - virt_params}, only-virt={virt_params - real_params}"
         )


### PR DESCRIPTION
## Stack

```
master
└── #115 feat(graph): polymorphic enum compare + engine fixes
    └── this PR — multi-repr Color + TCS34725 diagnostics
        └── #104 feat(pilot): RESET + MATCH_BEGIN opcodes
```

## Changes

- Multi-representation `Color` type with flash differential on TCS34725
- TCS34725 calibration + chip_id/status diagnostics exposed in REPL
- `mdb_led` switches team color from raw RGB to `NamedColor` enum