### PR TITLE
fix(ax12): remove torque enable from init(), add explicit enable()

### DIFF
--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -9,6 +9,8 @@ Layout:
 - AX12 (SmartServo): one instance per servo ID on the bus.
 - AX12BusVirtual: drop-in replacement for AX12Bus with an in-memory
   servo state dict. Same constructor signature so configs can swap.
+
+init() does no bus I/O — torque arming is in enable().
 """
 
 import threading
@@ -26,7 +28,7 @@ from evo_lib.interfaces.smart_servo import SmartServo
 from evo_lib.logger import Logger
 from evo_lib.peripheral import InterfaceHolder, Peripheral
 from evo_lib.registry import Registry
-from evo_lib.task import ImmediateErrorTask, ImmediateResultTask, Task
+from evo_lib.task import ImmediateResultTask, Task
 
 # Dynamixel 1.0 instructions
 _INST_READ = 0x02
@@ -389,15 +391,17 @@ class AX12(SmartServo):
         return self._id
 
     def init(self) -> Task[()]:
-        # Route failures through ImmediateErrorTask instead of raising
-        # synchronously: that keeps PeripheralsInitializer.on_error() reachable,
-        # which lets this servo (and its dependents) be marked as skipped
-        # rather than crashing the whole boot sequence.
-        try:
-            self._bus.write_register(self._id, _TORQUE_ENABLE, bytes([1]))
-        except OSError as err:
-            self._log.error(f"AX12 '{self.name}' (ID {self._id}) init failed: {err}")
-            return ImmediateErrorTask(err)
+        # No bus I/O: torque is armed later via enable().
+        return ImmediateResultTask()
+
+    @commands.register(args=[], result=[])
+    def enable(self) -> Task[()]:
+        """Power torque so the servo can hold or move to a position.
+
+        AX-12A boots with Torque Enable = 0 (datasheet). Call after the
+        12V motor rail is up.
+        """
+        self._bus.write_register(self._id, _TORQUE_ENABLE, bytes([1]))
         self._log.info(f"AX12 '{self.name}' (ID {self._id}) torque enabled")
         return ImmediateResultTask()
 

--- a/tests/test_smart_servo.py
+++ b/tests/test_smart_servo.py
@@ -20,7 +20,6 @@ from evo_lib.drivers.smart_servo.ax12 import (
 )
 from evo_lib.drivers.smart_servo.virtual import SmartServoVirtual
 from evo_lib.logger import Logger
-from evo_lib.task import ImmediateErrorTask
 
 
 @pytest.fixture
@@ -264,25 +263,22 @@ class TestAX12WithVirtualBus:
         servo.mode_joint().wait()
         assert bus.read_register(1, 8, 2) == bytes([1023 & 0xFF, 1023 >> 8])
 
-    def test_init_returns_error_task_on_bus_failure(self, log, monkeypatch):
-        # AX12.init() must NOT raise synchronously when the bus is unreachable:
-        # a sync raise bypasses PeripheralsInitializer.on_error() and crashes
-        # the whole boot. Wrapping in ImmediateErrorTask lets the initializer
-        # skip the servo cleanly.
+    def test_init_does_no_bus_io(self, log, monkeypatch):
+        # init() must not touch the bus: the 12V rail may be down at boot.
         bus = self._bus(log)
         servo = AX12("s", log, bus, servo_id=42)
 
         def boom(servo_id, register, data):
-            raise DynamixelBusError("no reply")
+            raise AssertionError("init() must not write to the bus")
 
         monkeypatch.setattr(bus, "write_register", boom)
+        servo.init().wait()
 
-        task = servo.init()
-        assert isinstance(task, ImmediateErrorTask)
-        seen: list[Exception] = []
-        task.on_error(seen.append)
-        assert len(seen) == 1
-        assert isinstance(seen[0], DynamixelBusError)
+    def test_enable_writes_torque_register(self, log):
+        bus = self._bus(log)
+        servo = AX12("s", log, bus, servo_id=7)
+        servo.enable().wait()
+        assert bus.read_register(7, 24, 1) == b"\x01"
 
     def test_turn_sets_direction_bit(self, log):
         bus = self._bus(log)


### PR DESCRIPTION
Driver init must not depend on field hardware state. `AX12.init()` did a `write_register(_TORQUE_ENABLE, 1)`, which times out when the 12V motor rail is down (BAU engaged at boot).

- `AX12.init()` is now a no-op (no bus I/O)
- Torque arming moves to a new `AX12.enable()`, exposed as a REPL command — the application layer calls it after the operator releases the BAU
- Tests cover the new contract (init does no bus I/O, enable writes the torque register)

Replaces the workaround attempted in evolutek/evo-hl-omnissiah#58 (now closed).