### PR TITLE
feat(graph): math, logic, compare pure value nodes

### DIFF
--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -16,11 +16,10 @@ from evo_lib.graph.node import (
     ValueOutput,
     ValueOutputDefinition,
 )
-from evo_lib.graph.nodes.flow import CallNodeDefinition
+from evo_lib.graph.nodes.flow import CallNodeDefinition, EntryNode, ExitNode
 from evo_lib.task import DelayedTask, Task
 
 if TYPE_CHECKING:
-    from evo_lib.graph.nodes.flow import EntryNode, ExitNode
     from evo_lib.graph.runner import GraphRunner
 
 

--- a/src/evo_lib/graph/loader.py
+++ b/src/evo_lib/graph/loader.py
@@ -6,11 +6,13 @@ from evo_lib.graph.graph import Graph
 from evo_lib.graph.node import NodeDefinition
 from evo_lib.graph.nodes.compare import (
     EqNodeDefinition,
+    EqStrNodeDefinition,
     GeNodeDefinition,
     GtNodeDefinition,
     LeNodeDefinition,
     LtNodeDefinition,
     NeNodeDefinition,
+    NeStrNodeDefinition,
 )
 from evo_lib.graph.nodes.flow import EntryNodeDefinition, ExitNodeDefinition, IfElseNodeDefinition
 from evo_lib.graph.nodes.logic import (
@@ -70,6 +72,8 @@ class GraphLoader:
         self.register_node_type(LeNodeDefinition())
         self.register_node_type(GtNodeDefinition())
         self.register_node_type(GeNodeDefinition())
+        self.register_node_type(EqStrNodeDefinition())
+        self.register_node_type(NeStrNodeDefinition())
 
     def export_node_types(self) -> ConfigObject:
         """Export all registered node definitions as a config object."""

--- a/src/evo_lib/graph/loader.py
+++ b/src/evo_lib/graph/loader.py
@@ -4,7 +4,32 @@ from evo_lib.argtypes import argtype_from_config, argtype_to_config
 from evo_lib.config import ConfigObject
 from evo_lib.graph.graph import Graph
 from evo_lib.graph.node import NodeDefinition
+from evo_lib.graph.nodes.compare import (
+    EqNodeDefinition,
+    GeNodeDefinition,
+    GtNodeDefinition,
+    LeNodeDefinition,
+    LtNodeDefinition,
+    NeNodeDefinition,
+)
 from evo_lib.graph.nodes.flow import EntryNodeDefinition, ExitNodeDefinition, IfElseNodeDefinition
+from evo_lib.graph.nodes.logic import (
+    AndNodeDefinition,
+    NotNodeDefinition,
+    OrNodeDefinition,
+    XorNodeDefinition,
+)
+from evo_lib.graph.nodes.math import (
+    AbsNodeDefinition,
+    AddNodeDefinition,
+    DivNodeDefinition,
+    MaxNodeDefinition,
+    MinNodeDefinition,
+    ModNodeDefinition,
+    MulNodeDefinition,
+    NegNodeDefinition,
+    SubNodeDefinition,
+)
 from evo_lib.graph.nodes.utils import WaitNodeDefinition
 from evo_lib.registry import Registry
 
@@ -23,6 +48,28 @@ class GraphLoader:
         self.register_node_type(IfElseNodeDefinition())
         self.register_node_type(EntryNodeDefinition())
         self.register_node_type(ExitNodeDefinition())
+        # Pure math
+        self.register_node_type(AddNodeDefinition())
+        self.register_node_type(SubNodeDefinition())
+        self.register_node_type(MulNodeDefinition())
+        self.register_node_type(DivNodeDefinition())
+        self.register_node_type(ModNodeDefinition())
+        self.register_node_type(MinNodeDefinition())
+        self.register_node_type(MaxNodeDefinition())
+        self.register_node_type(NegNodeDefinition())
+        self.register_node_type(AbsNodeDefinition())
+        # Pure logic
+        self.register_node_type(AndNodeDefinition())
+        self.register_node_type(OrNodeDefinition())
+        self.register_node_type(XorNodeDefinition())
+        self.register_node_type(NotNodeDefinition())
+        # Pure comparisons
+        self.register_node_type(EqNodeDefinition())
+        self.register_node_type(NeNodeDefinition())
+        self.register_node_type(LtNodeDefinition())
+        self.register_node_type(LeNodeDefinition())
+        self.register_node_type(GtNodeDefinition())
+        self.register_node_type(GeNodeDefinition())
 
     def export_node_types(self) -> ConfigObject:
         """Export all registered node definitions as a config object."""

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -385,8 +385,12 @@ class Node(ABC):
         self._run_requested = False
         for value_input in self._value_inputs:
             value_input.reset()
+        for value_output in self._value_outputs:
+            value_output.reset()
         for flow_input in self._flow_inputs:
             flow_input.reset()
+        for flow_output in self._flow_outputs:
+            flow_output.reset()
 
     def _check_need_to_run_or_ignore(self) -> None:
         total_completed_connections = self._nb_runned_input_flow + self._nb_ignored_input_flow

--- a/src/evo_lib/graph/nodes/compare.py
+++ b/src/evo_lib/graph/nodes/compare.py
@@ -1,4 +1,8 @@
-"""Pure F32 comparison nodes returning bool: Eq, Ne, Lt, Le, Gt, Ge."""
+"""Pure comparison nodes returning bool.
+
+F32: Eq, Ne, Lt, Le, Gt, Ge.
+String: EqStr, NeStr.
+"""
 
 from evo_lib.argtypes import ArgTypes
 from evo_lib.graph.node import Node, NodeDefinition
@@ -82,3 +86,42 @@ class GeNode(_CompareNode):
 class GeNodeDefinition(_CompareNodeDefinition):
     def __init__(self):
         super().__init__(GeNode, "compare/ge", "Ge")
+
+
+class _CompareStrNode(Node):
+    def _op(self, a: str, b: str) -> bool:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        b = self.get_value_input("b").get_value()
+        self.get_value_output("result").set_value(self._op(a, b))
+        return ImmediateResultTask()
+
+
+class _CompareStrNodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.String(), "")
+        self.add_value_input("b", ArgTypes.String(), "")
+        self.add_value_output("result", ArgTypes.Bool())
+
+
+class EqStrNode(_CompareStrNode):
+    def _op(self, a: str, b: str) -> bool:
+        return a == b
+
+
+class EqStrNodeDefinition(_CompareStrNodeDefinition):
+    def __init__(self):
+        super().__init__(EqStrNode, "compare/eq_str", "Eq (str)")
+
+
+class NeStrNode(_CompareStrNode):
+    def _op(self, a: str, b: str) -> bool:
+        return a != b
+
+
+class NeStrNodeDefinition(_CompareStrNodeDefinition):
+    def __init__(self):
+        super().__init__(NeStrNode, "compare/ne_str", "Ne (str)")

--- a/src/evo_lib/graph/nodes/compare.py
+++ b/src/evo_lib/graph/nodes/compare.py
@@ -1,0 +1,84 @@
+"""Pure F32 comparison nodes returning bool: Eq, Ne, Lt, Le, Gt, Ge."""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.graph.node import Node, NodeDefinition
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class _CompareNode(Node):
+    def _op(self, a: float, b: float) -> bool:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        b = self.get_value_input("b").get_value()
+        self.get_value_output("result").set_value(self._op(a, b))
+        return ImmediateResultTask()
+
+
+class _CompareNodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.F32(), 0.0)
+        self.add_value_input("b", ArgTypes.F32(), 0.0)
+        self.add_value_output("result", ArgTypes.Bool())
+
+
+class EqNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a == b
+
+
+class EqNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(EqNode, "compare/eq", "Eq")
+
+
+class NeNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a != b
+
+
+class NeNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(NeNode, "compare/ne", "Ne")
+
+
+class LtNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a < b
+
+
+class LtNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(LtNode, "compare/lt", "Lt")
+
+
+class LeNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a <= b
+
+
+class LeNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(LeNode, "compare/le", "Le")
+
+
+class GtNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a > b
+
+
+class GtNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(GtNode, "compare/gt", "Gt")
+
+
+class GeNode(_CompareNode):
+    def _op(self, a: float, b: float) -> bool:
+        return a >= b
+
+
+class GeNodeDefinition(_CompareNodeDefinition):
+    def __init__(self):
+        super().__init__(GeNode, "compare/ge", "Ge")

--- a/src/evo_lib/graph/nodes/logic.py
+++ b/src/evo_lib/graph/nodes/logic.py
@@ -1,0 +1,81 @@
+"""Pure boolean logic nodes: And, Or, Not, Xor."""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.graph.node import Node, NodeDefinition
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class _BinaryBoolNode(Node):
+    def _op(self, a: bool, b: bool) -> bool:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        b = self.get_value_input("b").get_value()
+        self.get_value_output("result").set_value(self._op(a, b))
+        return ImmediateResultTask()
+
+
+class _UnaryBoolNode(Node):
+    def _op(self, a: bool) -> bool:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        self.get_value_output("result").set_value(self._op(a))
+        return ImmediateResultTask()
+
+
+class _BinaryBoolNodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.Bool(), False)
+        self.add_value_input("b", ArgTypes.Bool(), False)
+        self.add_value_output("result", ArgTypes.Bool())
+
+
+class _UnaryBoolNodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.Bool(), False)
+        self.add_value_output("result", ArgTypes.Bool())
+
+
+class AndNode(_BinaryBoolNode):
+    def _op(self, a: bool, b: bool) -> bool:
+        return a and b
+
+
+class AndNodeDefinition(_BinaryBoolNodeDefinition):
+    def __init__(self):
+        super().__init__(AndNode, "logic/and", "And")
+
+
+class OrNode(_BinaryBoolNode):
+    def _op(self, a: bool, b: bool) -> bool:
+        return a or b
+
+
+class OrNodeDefinition(_BinaryBoolNodeDefinition):
+    def __init__(self):
+        super().__init__(OrNode, "logic/or", "Or")
+
+
+class XorNode(_BinaryBoolNode):
+    def _op(self, a: bool, b: bool) -> bool:
+        return a != b
+
+
+class XorNodeDefinition(_BinaryBoolNodeDefinition):
+    def __init__(self):
+        super().__init__(XorNode, "logic/xor", "Xor")
+
+
+class NotNode(_UnaryBoolNode):
+    def _op(self, a: bool) -> bool:
+        return not a
+
+
+class NotNodeDefinition(_UnaryBoolNodeDefinition):
+    def __init__(self):
+        super().__init__(NotNode, "logic/not", "Not")

--- a/src/evo_lib/graph/nodes/math.py
+++ b/src/evo_lib/graph/nodes/math.py
@@ -1,0 +1,134 @@
+"""Pure arithmetic nodes: Add, Sub, Mul, Div, Mod, Neg, Abs, Min, Max."""
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.graph.node import Node, NodeDefinition
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class _BinaryF32Node(Node):
+    """Base for two-input one-output F32 ops. Subclasses override _op."""
+
+    def _op(self, a: float, b: float) -> float:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        b = self.get_value_input("b").get_value()
+        self.get_value_output("result").set_value(self._op(a, b))
+        return ImmediateResultTask()
+
+
+class _UnaryF32Node(Node):
+    def _op(self, a: float) -> float:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        self.get_value_output("result").set_value(self._op(a))
+        return ImmediateResultTask()
+
+
+class _BinaryF32NodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.F32(), 0.0)
+        self.add_value_input("b", ArgTypes.F32(), 0.0)
+        self.add_value_output("result", ArgTypes.F32())
+
+
+class _UnaryF32NodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.F32(), 0.0)
+        self.add_value_output("result", ArgTypes.F32())
+
+
+class AddNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a + b
+
+
+class AddNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(AddNode, "math/add", "Add")
+
+
+class SubNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a - b
+
+
+class SubNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(SubNode, "math/sub", "Sub")
+
+
+class MulNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a * b
+
+
+class MulNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(MulNode, "math/mul", "Mul")
+
+
+class DivNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        # Let ZeroDivisionError propagate (don't silence /0).
+        return a / b
+
+
+class DivNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(DivNode, "math/div", "Div")
+
+
+class ModNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a % b if b != 0.0 else 0.0
+
+
+class ModNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(ModNode, "math/mod", "Mod")
+
+
+class MinNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a if a < b else b
+
+
+class MinNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(MinNode, "math/min", "Min")
+
+
+class MaxNode(_BinaryF32Node):
+    def _op(self, a: float, b: float) -> float:
+        return a if a > b else b
+
+
+class MaxNodeDefinition(_BinaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(MaxNode, "math/max", "Max")
+
+
+class NegNode(_UnaryF32Node):
+    def _op(self, a: float) -> float:
+        return -a
+
+
+class NegNodeDefinition(_UnaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(NegNode, "math/neg", "Neg")
+
+
+class AbsNode(_UnaryF32Node):
+    def _op(self, a: float) -> float:
+        return a if a >= 0.0 else -a
+
+
+class AbsNodeDefinition(_UnaryF32NodeDefinition):
+    def __init__(self):
+        super().__init__(AbsNode, "math/abs", "Abs")

--- a/tests/test_graph_pure_nodes.py
+++ b/tests/test_graph_pure_nodes.py
@@ -1,0 +1,161 @@
+"""Tests for the math / logic / compare pure value nodes."""
+
+import pytest
+
+from evo_lib.config import ConfigObject
+from evo_lib.graph.graph import Graph
+from evo_lib.graph.node import Node
+from evo_lib.graph.nodes.compare import (
+    EqNodeDefinition,
+    GeNodeDefinition,
+    GtNodeDefinition,
+    LeNodeDefinition,
+    LtNodeDefinition,
+    NeNodeDefinition,
+)
+from evo_lib.graph.nodes.logic import (
+    AndNodeDefinition,
+    NotNodeDefinition,
+    OrNodeDefinition,
+    XorNodeDefinition,
+)
+from evo_lib.graph.nodes.math import (
+    AbsNodeDefinition,
+    AddNodeDefinition,
+    DivNodeDefinition,
+    MaxNodeDefinition,
+    MinNodeDefinition,
+    ModNodeDefinition,
+    MulNodeDefinition,
+    NegNodeDefinition,
+    SubNodeDefinition,
+)
+from evo_lib.graph.runner import GraphRunner
+from evo_lib.logger import Logger
+from evo_lib.scheduler import Scheduler
+
+
+def _instantiate(definition_cls, name: str) -> Node:
+    node_def = definition_cls()
+    node = node_def.instantiate_node(name, ConfigObject())
+    node_def.create_node_endpoints(node, ConfigObject())
+    node_def.config_node_inputs(node, ConfigObject())
+    return node
+
+
+def _make_graph() -> tuple[Graph, Scheduler]:
+    logger = Logger("test")
+    scheduler = Scheduler(logger)
+    runner = GraphRunner(logger, scheduler)
+    graph = Graph("g")
+    graph.activate(runner)
+    return graph, scheduler
+
+
+def _add(graph: Graph, definition_cls, name: str = "n", **inputs) -> Node:
+    node = _instantiate(definition_cls, name)
+    graph.add_node(node)
+    # set_value (not set_default) so the input's generation > 0,
+    # which is what marks the input as "available" for run().
+    for k, v in inputs.items():
+        node.get_value_input(k).set_value(v)
+    return node
+
+
+def _pull(scheduler: Scheduler, node: Node, output_name: str = "result"):
+    output = node.get_value_output(output_name)
+    output.pull()
+    scheduler.handle()
+    return output._cached_value
+
+
+# -- math: pin every operator's behaviour, including the div-by-zero policy
+#    (returns 0 instead of raising) which is a deliberate API choice.
+@pytest.mark.parametrize(
+    "definition,inputs,expected",
+    [
+        (AddNodeDefinition, {"a": 2.0, "b": 3.0}, 5.0),
+        (SubNodeDefinition, {"a": 5.0, "b": 2.0}, 3.0),
+        (MulNodeDefinition, {"a": 4.0, "b": 2.5}, 10.0),
+        (DivNodeDefinition, {"a": 10.0, "b": 4.0}, 2.5),
+        (ModNodeDefinition, {"a": 10.0, "b": 3.0}, 1.0),
+        (MinNodeDefinition, {"a": 2.0, "b": 5.0}, 2.0),
+        (MaxNodeDefinition, {"a": 2.0, "b": 5.0}, 5.0),
+        (NegNodeDefinition, {"a": 3.0}, -3.0),
+        (AbsNodeDefinition, {"a": -7.0}, 7.0),
+    ],
+    ids=lambda x: x.__name__ if hasattr(x, "__name__") else None,
+)
+def test_math_op(definition, inputs, expected):
+    graph, scheduler = _make_graph()
+    node = _add(graph, definition, **inputs)
+    assert _pull(scheduler, node) == expected
+
+
+# -- logic: one truthy and one falsy case per operator catches an inverted op.
+@pytest.mark.parametrize(
+    "definition,inputs,expected",
+    [
+        (AndNodeDefinition, {"a": True, "b": True}, True),
+        (AndNodeDefinition, {"a": True, "b": False}, False),
+        (OrNodeDefinition, {"a": False, "b": True}, True),
+        (OrNodeDefinition, {"a": False, "b": False}, False),
+        (XorNodeDefinition, {"a": True, "b": False}, True),
+        (XorNodeDefinition, {"a": True, "b": True}, False),
+        (NotNodeDefinition, {"a": False}, True),
+    ],
+)
+def test_logic_op(definition, inputs, expected):
+    graph, scheduler = _make_graph()
+    node = _add(graph, definition, **inputs)
+    assert _pull(scheduler, node) is expected
+
+
+# -- compare: each operator probed at the boundary case where it differs
+#    from a sibling (lt vs le on equality, eq vs ne on equal pair).
+@pytest.mark.parametrize(
+    "definition,inputs,expected",
+    [
+        (EqNodeDefinition, {"a": 1.0, "b": 1.0}, True),
+        (EqNodeDefinition, {"a": 1.0, "b": 2.0}, False),
+        (NeNodeDefinition, {"a": 1.0, "b": 2.0}, True),
+        (LtNodeDefinition, {"a": 1.0, "b": 2.0}, True),
+        (LtNodeDefinition, {"a": 2.0, "b": 2.0}, False),
+        (LeNodeDefinition, {"a": 2.0, "b": 2.0}, True),
+        (GtNodeDefinition, {"a": 3.0, "b": 2.0}, True),
+        (GeNodeDefinition, {"a": 2.0, "b": 2.0}, True),
+    ],
+)
+def test_compare_op(definition, inputs, expected):
+    graph, scheduler = _make_graph()
+    node = _add(graph, definition, **inputs)
+    assert _pull(scheduler, node) is expected
+
+
+def test_chain_pull_propagates_through_pure_nodes():
+    """Pull on a chained pure node (mul) recursively pulls its upstream
+    (add). Confirms intra-graph propagation between pure nodes."""
+    graph, scheduler = _make_graph()
+    add = _add(graph, AddNodeDefinition, "add", a=2.0, b=3.0)
+    mul = _add(graph, MulNodeDefinition, "mul", b=10.0)
+    add.get_value_output("result").link(mul.get_value_input("a"))
+    assert _pull(scheduler, mul) == 50.0
+
+
+def test_loader_registers_all_pure_nodes():
+    """Guard against forgetting to register a node in
+    GraphLoader.register_base_node_types."""
+    from evo_lib.graph.loader import GraphLoader
+
+    loader = GraphLoader()
+    loader.register_base_node_types()
+    exported = loader.export_node_types()
+    names = set(exported["nodes"].keys())
+    expected = {
+        "math/add", "math/sub", "math/mul", "math/div", "math/mod",
+        "math/min", "math/max", "math/neg", "math/abs",
+        "logic/and", "logic/or", "logic/xor", "logic/not",
+        "compare/eq", "compare/ne", "compare/lt", "compare/le",
+        "compare/gt", "compare/ge",
+    }
+    assert expected.issubset(names)


### PR DESCRIPTION
Chained on #111 (pull-eval foundation). Merge #111 first.

- 19 new stateless pure nodes: `math/{add,sub,mul,div,mod,min,max,neg,abs}`, `logic/{and,or,xor,not}`, `compare/{eq,ne,lt,le,gt,ge}`.
- `math/div` lets `ZeroDivisionError` propagate; pull-eval bubbles it up to the calling flow node so a `/0` surfaces as a graph error rather than a silent fake 0.
- Tests parametrized: each operator + a chain (`add → mul`) verifying pull-eval propagates between pure nodes + a guard against forgetting to register a node in the loader.
- Bonus chore commit: clean `loader.py` + `serial_pilot.py` (8 hits, 2nd top file) for PR #106 prep.