### PR TITLE
feat(graph): pre-scheduling Events on Graph

### DIFF
--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -8,6 +8,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from evo_lib.argtypes import ArgType
+from evo_lib.event import Event
 from evo_lib.graph.node import (
     FlowInput,
     Node,
@@ -32,7 +33,19 @@ class Graph:
         self._running_graph_task: DelayedTask | None = None
         self._running_nodes_tasks: set[Task] = set()
         self._nb_scheduled_things = 0
+        self._on_run_node_event: Event[Node] = Event()
+        self._on_run_flow_input_event: Event[FlowInput, float] = Event()
+        self._on_ignore_flow_input_event: Event[FlowInput] = Event()
         self._lock = Lock()
+
+    def get_on_run_node_event(self) -> Event[Node]:
+        return self._on_run_node_event
+
+    def get_on_run_flow_input_event(self) -> Event[FlowInput, float]:
+        return self._on_run_flow_input_event
+
+    def get_on_ignore_flow_input_event(self) -> Event[FlowInput]:
+        return self._on_ignore_flow_input_event
 
     def get_name(self) -> str:
         return self._name
@@ -95,6 +108,7 @@ class Graph:
             self._running_nodes_tasks.add(task)
 
     def schedule_run_node(self, node: Node) -> None:
+        self._on_run_node_event.trigger(node)
         task = node.on_run()
         self._add_node_run_task(task)
         task.on_complete(lambda: self._on_node_run_complete(task))
@@ -109,6 +123,7 @@ class Graph:
 
     def schedule_run_flow_input(self, input_flow: FlowInput, delay: float = 0) -> None:
         assert self._runner is not None
+        self._on_run_flow_input_event.trigger(input_flow, delay)
         with self._lock:
             self._nb_scheduled_things += 1
         self._runner.get_scheduler().schedule_after(
@@ -124,6 +139,7 @@ class Graph:
 
     def schedule_ignore_flow_input(self, input_flow: FlowInput) -> None:
         assert self._runner is not None
+        self._on_ignore_flow_input_event.trigger(input_flow)
         with self._lock:
             self._nb_scheduled_things += 1
         self._runner.get_scheduler().schedule_now(

--- a/tests/test_graph_events.py
+++ b/tests/test_graph_events.py
@@ -1,0 +1,107 @@
+"""Tests for the pre-scheduling events on Graph (run_node, run_flow_input, ignore_flow_input)."""
+
+from evo_lib.graph.graph import Graph
+from evo_lib.graph.node import FlowInput, Node, NodeDefinition
+from evo_lib.graph.runner import GraphRunner
+from evo_lib.logger import Logger
+from evo_lib.scheduler import Scheduler
+from evo_lib.task import ImmediateResultTask, Task
+
+
+class _NoopNode(Node):
+    on_run_calls: int = 0
+
+    def on_run(self) -> Task[()]:
+        type(self).on_run_calls += 1
+        return ImmediateResultTask()
+
+
+def _make_node_with_flow_input(graph: Graph, name: str = "n") -> Node:
+    node_def = NodeDefinition(_NoopNode, "test/noop", "Noop")
+    node_def.add_flow_input("flow")
+    node = _NoopNode(node_def, name)
+    node_def.create_node_endpoints(node, None)
+    graph.add_node(node)
+    return node
+
+
+def _activate(graph: Graph) -> None:
+    logger = Logger("test")
+    scheduler = Scheduler(logger)
+    graph.activate(GraphRunner(logger, scheduler))
+
+
+def test_run_node_event_fires_before_on_run():
+    _NoopNode.on_run_calls = 0
+    graph = Graph("g")
+    node = _make_node_with_flow_input(graph)
+    _activate(graph)
+
+    seen: list[tuple[Node, int]] = []
+    graph.get_on_run_node_event().register(
+        lambda n: seen.append((n, _NoopNode.on_run_calls))
+    )
+
+    graph.schedule_run_node(node)
+
+    assert seen == [(node, 0)]
+    assert _NoopNode.on_run_calls == 1
+
+
+def test_run_flow_input_event_fires_with_delay():
+    graph = Graph("g")
+    node = _make_node_with_flow_input(graph)
+    _activate(graph)
+
+    seen: list[tuple[FlowInput, float]] = []
+    graph.get_on_run_flow_input_event().register(
+        lambda fi, d: seen.append((fi, d))
+    )
+
+    fi = node.get_flow_input("flow")
+    graph.schedule_run_flow_input(fi, delay=0.25)
+
+    assert seen == [(fi, 0.25)]
+
+
+def test_ignore_flow_input_event_fires():
+    graph = Graph("g")
+    node = _make_node_with_flow_input(graph)
+    _activate(graph)
+
+    seen: list[FlowInput] = []
+    graph.get_on_ignore_flow_input_event().register(seen.append)
+
+    fi = node.get_flow_input("flow")
+    graph.schedule_ignore_flow_input(fi)
+
+    assert seen == [fi]
+
+
+def test_listener_can_unregister_and_stop_receiving():
+    graph = Graph("g")
+    node = _make_node_with_flow_input(graph)
+    _activate(graph)
+
+    seen: list[Node] = []
+    listener = graph.get_on_run_node_event().register(seen.append)
+
+    graph.schedule_run_node(node)
+    graph.get_on_run_node_event().unregister(listener)
+    graph.schedule_run_node(node)
+
+    assert seen == [node]
+
+
+def test_onetime_listener_fires_once():
+    graph = Graph("g")
+    node = _make_node_with_flow_input(graph)
+    _activate(graph)
+
+    seen: list[Node] = []
+    graph.get_on_run_node_event().register(seen.append, onetime=True)
+
+    graph.schedule_run_node(node)
+    graph.schedule_run_node(node)
+
+    assert seen == [node]


### PR DESCRIPTION
- Adds three `Event[*T]` hooks fired synchronously before each `schedule_*` call: `get_on_run_node_event`, `get_on_run_flow_input_event`, `get_on_ignore_flow_input_event`
- Reuses the existing `evo_lib.event.Event` primitive (same pattern as `button.get_trigger_event()` etc.) — register/unregister/onetime, thread-safe
- Listeners run on the caller thread before the underlying schedule, so a blocking listener stalls that step (intentional for stepped debugging)
- Enables external callers (e.g. omnissiah `/graph --step`) to step a graph without monkey-patching `Graph.schedule_*` methods
- Now standalone on `master` (was chained behind #112, merged in 5/2026); consumed by evo-hl-omnissiah PR #65