### PR TITLE
feat(graph): polymorphic enum compare nodes (eq_enum, ne_enum)

### DIFF
--- a/src/evo_lib/argtypes.py
+++ b/src/evo_lib/argtypes.py
@@ -13,6 +13,25 @@ if TYPE_CHECKING:
     from evo_lib.registry import Registry
 
 
+class UnresolvedTypeError(TypeError):
+    """Raised when an unresolved AnyEnum reaches a binary-serialization callsite."""
+
+
+class TypeMismatchError(TypeError):
+    """Raised when unification finds two incompatible concrete slot types."""
+
+
+def _int_enum_only(method):
+    """Guard binary serialization methods of ArgTypes.Enum: refuse non-IntEnum classes."""
+    def wrapper(self, *args, **kwargs):
+        if not issubclass(self.enum_type, IntEnum):
+            raise TypeError(
+                f"binary serialization requires IntEnum, got {self.enum_type.__name__}"
+            )
+        return method(self, *args, **kwargs)
+    return wrapper
+
+
 class ArgType(ABC):
     def __init__(self, help: str | None = None):
         self.help = help
@@ -648,15 +667,17 @@ class ArgTypes:
         def value_from_str(self, v: str) -> IntEnum:
             return self.enum_type[v]
 
+        @_int_enum_only
         def value_from_stream(self, s: io.RawIOBase) -> IntEnum:
             index = struct.unpack("I", s.read(4))[0]
             return self.enum_type(index)
 
+        @_int_enum_only
         def value_to_stream(self, v: IntEnum, s: io.RawIOBase) -> None:
             s.write(struct.pack("I", v.value))
 
+        @_int_enum_only
         def self_to_stream(self, s: io.RawIOBase) -> None:
-            # Serialize enum type name and members
             type_name = self.enum_type.__name__.encode("utf-8")
             s.write(struct.pack("I", len(type_name)))
             s.write(type_name)
@@ -692,42 +713,32 @@ class ArgTypes:
             return f"enum({self.enum_type.__name__})"
 
     class AnyEnum(ArgType):
-        """Untyped enum slot. Carries no specific enum class — the value flows
-        through as-is and equality is delegated to Python's ``==``.
+        """Polymorphic enum slot bound at graph build time by ``resolve``.
 
-        Used by polymorphic graph nodes that operate on any enum class
-        (``compare/eq_enum``, ``compare/ne_enum``). The editor populates the
-        constant-side widget choices dynamically from the upstream wire.
+        Carries no concrete type until unified with an ArgTypes.Enum upstream.
+        Binary serialization on an unresolved instance raises UnresolvedTypeError.
         """
 
+        def _unresolved(self) -> UnresolvedTypeError:
+            return UnresolvedTypeError("AnyEnum is unresolved")
+
         def value_from_config(self, v: ConfigValue) -> Any:
-            # Accept int (raw enum value), str (enum name), or already-resolved
-            # IntEnum/Enum. Equality at runtime works across all combinations
-            # because IntEnum members compare equal to their int value.
-            if isinstance(v, (int, str)) or hasattr(v, "value"):
-                return v
-            raise ConfigValidationError(
-                f"AnyEnum: expected int / str / Enum, got {type(v).__name__}"
-            )
+            return v
 
         def value_from_str(self, v: str) -> Any:
-            try:
-                return int(v)
-            except ValueError:
-                return v
+            return v
 
-        def value_from_stream(self, s: io.RawIOBase) -> int:
-            return struct.unpack("I", s.read(4))[0]
+        def value_from_stream(self, s: io.RawIOBase) -> Any:
+            raise self._unresolved()
 
         def value_to_stream(self, v: Any, s: io.RawIOBase) -> None:
-            n = v.value if hasattr(v, "value") else int(v)
-            s.write(struct.pack("I", n))
+            raise self._unresolved()
 
         def self_to_stream(self, s: io.RawIOBase) -> None:
-            pass
+            raise self._unresolved()
 
         def self_from_stream(self, s: io.RawIOBase) -> None:
-            pass
+            raise self._unresolved()
 
         def self_from_config(self, c: ConfigObject) -> None:
             pass
@@ -735,7 +746,7 @@ class ArgTypes:
         def self_to_config(self, c: ConfigObject) -> None:
             pass
 
-        def __str__(self):
+        def __str__(self) -> str:
             return "enum_any"
 
     # Reference to a device
@@ -878,6 +889,10 @@ def argtype_from_stream(s: io.RawIOBase) -> ArgType:
 
 
 def argtype_to_stream(argtype: ArgType, s: io.RawIOBase) -> None:
+    if isinstance(argtype, ArgTypes.AnyEnum):
+        raise UnresolvedTypeError(
+            f"cannot serialize unresolved {argtype}; resolve graph types first"
+        )
     argtype_id = ARGTYPE_TO_ID[type(argtype)]
     s.write(bytes([argtype_id]))
     argtype.self_to_stream(s)

--- a/src/evo_lib/argtypes.py
+++ b/src/evo_lib/argtypes.py
@@ -23,12 +23,12 @@ class TypeMismatchError(TypeError):
 
 def _int_enum_only(method):
     """Guard binary serialization methods of ArgTypes.Enum: refuse non-IntEnum classes."""
+
     def wrapper(self, *args, **kwargs):
         if not issubclass(self.enum_type, IntEnum):
-            raise TypeError(
-                f"binary serialization requires IntEnum, got {self.enum_type.__name__}"
-            )
+            raise TypeError(f"binary serialization requires IntEnum, got {self.enum_type.__name__}")
         return method(self, *args, **kwargs)
+
     return wrapper
 
 

--- a/src/evo_lib/argtypes.py
+++ b/src/evo_lib/argtypes.py
@@ -691,6 +691,53 @@ class ArgTypes:
         def __str__(self):
             return f"enum({self.enum_type.__name__})"
 
+    class AnyEnum(ArgType):
+        """Untyped enum slot. Carries no specific enum class — the value flows
+        through as-is and equality is delegated to Python's ``==``.
+
+        Used by polymorphic graph nodes that operate on any enum class
+        (``compare/eq_enum``, ``compare/ne_enum``). The editor populates the
+        constant-side widget choices dynamically from the upstream wire.
+        """
+
+        def value_from_config(self, v: ConfigValue) -> Any:
+            # Accept int (raw enum value), str (enum name), or already-resolved
+            # IntEnum/Enum. Equality at runtime works across all combinations
+            # because IntEnum members compare equal to their int value.
+            if isinstance(v, (int, str)) or hasattr(v, "value"):
+                return v
+            raise ConfigValidationError(
+                f"AnyEnum: expected int / str / Enum, got {type(v).__name__}"
+            )
+
+        def value_from_str(self, v: str) -> Any:
+            try:
+                return int(v)
+            except ValueError:
+                return v
+
+        def value_from_stream(self, s: io.RawIOBase) -> int:
+            return struct.unpack("I", s.read(4))[0]
+
+        def value_to_stream(self, v: Any, s: io.RawIOBase) -> None:
+            n = v.value if hasattr(v, "value") else int(v)
+            s.write(struct.pack("I", n))
+
+        def self_to_stream(self, s: io.RawIOBase) -> None:
+            pass
+
+        def self_from_stream(self, s: io.RawIOBase) -> None:
+            pass
+
+        def self_from_config(self, c: ConfigObject) -> None:
+            pass
+
+        def self_to_config(self, c: ConfigObject) -> None:
+            pass
+
+        def __str__(self):
+            return "enum_any"
+
     # Reference to a device
     class Component(ArgType):
         def __init__(self, base_type: type[Peripheral], components: Registry[Peripheral]):
@@ -793,6 +840,7 @@ NAME_TO_ARGTYPE: dict[str, type[ArgType]] = {
     "array": ArgTypes.Array,
     "struct": ArgTypes.Struct,
     "enum": ArgTypes.Enum,
+    "enum_any": ArgTypes.AnyEnum,
     "bool": ArgTypes.Bool,
     "bytes": ArgTypes.Bytes,
 }

--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -97,7 +97,9 @@ class Graph:
     def schedule_run_node(self, node: Node) -> None:
         task = node.on_run()
         self._add_node_run_task(task)
-        task.on_complete(lambda: self._on_node_run_complete(task))
+        # Task.on_complete spreads the result tuple via *self._result, so the
+        # callback must absorb whatever arity the producing node emits.
+        task.on_complete(lambda *_args: self._on_node_run_complete(task))
         task.on_error(lambda error: self._on_node_run_error(task, error))
 
     def _do_run_flow_input(self, input_flow: FlowInput) -> None:

--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -11,10 +11,12 @@ from evo_lib.argtypes import ArgType
 from evo_lib.graph.node import (
     FlowInput,
     Node,
+    TypeEnv,
     ValueInput,
     ValueInputDefinition,
     ValueOutput,
     ValueOutputDefinition,
+    resolve,
 )
 from evo_lib.graph.nodes.flow import CallNodeDefinition, EntryNode, ExitNode
 from evo_lib.task import DelayedTask, Task
@@ -254,3 +256,6 @@ class Graph:
             raise RuntimeError(f"Node '{node.get_name()}' is already part of a graph")
         node.set_graph(self)
         self._nodes[node.get_name()] = node
+
+    def resolve_types(self) -> TypeEnv:
+        return resolve(self)

--- a/src/evo_lib/graph/loader.py
+++ b/src/evo_lib/graph/loader.py
@@ -5,12 +5,14 @@ from evo_lib.config import ConfigObject
 from evo_lib.graph.graph import Graph
 from evo_lib.graph.node import NodeDefinition
 from evo_lib.graph.nodes.compare import (
+    EqEnumNodeDefinition,
     EqNodeDefinition,
     EqStrNodeDefinition,
     GeNodeDefinition,
     GtNodeDefinition,
     LeNodeDefinition,
     LtNodeDefinition,
+    NeEnumNodeDefinition,
     NeNodeDefinition,
     NeStrNodeDefinition,
 )
@@ -74,6 +76,8 @@ class GraphLoader:
         self.register_node_type(GeNodeDefinition())
         self.register_node_type(EqStrNodeDefinition())
         self.register_node_type(NeStrNodeDefinition())
+        self.register_node_type(EqEnumNodeDefinition())
+        self.register_node_type(NeEnumNodeDefinition())
 
     def export_node_types(self) -> ConfigObject:
         """Export all registered node definitions as a config object."""

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -200,15 +200,21 @@ class ValueOutput(ValueEndpoint):
         super().__init__(node, name, type)
         self._connections: list[ValueInput] = []
         self._cached_value: Any = None
+        self._has_been_set: bool = False
 
     def get_connections(self) -> list[ValueInput]:
         return self._connections
 
+    def has_been_set(self) -> bool:
+        return self._has_been_set
+
     def use_cached_value(self) -> None:
-        self.set_value(self._cached_value)
+        for inp in self._connections:
+            inp.set_value(self._cached_value)
 
     def set_value(self, value: Any) -> None:
         self._cached_value = value
+        self._has_been_set = True
         for inp in self._connections:
             inp.set_value(value)
 
@@ -228,6 +234,7 @@ class ValueOutput(ValueEndpoint):
 
     def reset(self) -> None:
         self._cached_value = None
+        self._has_been_set = False
 
     def clone(self, new_node: Node) -> ValueOutput:
         return self.__class__(new_node, self._name, self._type)
@@ -343,18 +350,22 @@ class Node(ABC):
 
     def run(self) -> None:
         if self._run_requested:
-            raise RuntimeError(
-                "Trying to request node to run twice, check if there are cycles in the graph"
-            )
+            # Multi-consumer pure outputs schedule one pull per consumer; the
+            # first run already populated and propagated the cache.
+            return
         self._run_requested = True
 
         need_to_run = False
         if self.is_pure():
-            # Only run pure node if its value inputs have been updated
-            for value_input in self._value_inputs:
-                if value_input.get_generation() > 0:
-                    value_input.reset_generation()
-                    need_to_run = True
+            # No output set yet => cache is the post-reset None and would poison
+            # downstream (e.g. an `if`'s condition silently falsy). Force compute.
+            if not any(out.has_been_set() for out in self._value_outputs):
+                need_to_run = True
+            else:
+                for value_input in self._value_inputs:
+                    if value_input.get_generation() > 0:
+                        value_input.reset_generation()
+                        need_to_run = True
         else:
             need_to_run = True
 

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from evo_lib.argtypes import ArgType
+from evo_lib.argtypes import ArgType, ArgTypes, TypeMismatchError
 from evo_lib.config import ConfigObject, ConfigValidationError
 from evo_lib.task import ImmediateResultTask, Task
 
@@ -622,3 +622,84 @@ class NodeDefinition:
                 )
             default_value = endpoint.get_type().value_from_config(raw_default_value)
             endpoint.set_default(default_value)
+
+
+# -- Type inference --
+
+
+class TypeEnv:
+    """Mapping ``(node_name, slot_name) -> concrete ArgType``, built by ``resolve``."""
+
+    def __init__(self) -> None:
+        self._by_slot: dict[tuple[str, str], ArgType] = {}
+
+    def bind(self, node_name: str, slot_name: str, t: ArgType) -> None:
+        self._by_slot[(node_name, slot_name)] = t
+
+    def get(self, node_name: str, slot_name: str) -> ArgType | None:
+        return self._by_slot.get((node_name, slot_name))
+
+    def items(self) -> list[tuple[tuple[str, str], ArgType]]:
+        return list(self._by_slot.items())
+
+
+def unify(a: ArgType, b: ArgType) -> ArgType:
+    """Pick the most specific type compatible with both ``a`` and ``b``, else raise."""
+    a_var = isinstance(a, ArgTypes.AnyEnum)
+    b_var = isinstance(b, ArgTypes.AnyEnum)
+    if a_var and b_var:
+        return a
+    if a_var:
+        _check_enum(b)
+        return b
+    if b_var:
+        _check_enum(a)
+        return a
+    if type(a) is not type(b):
+        raise TypeMismatchError(f"cannot unify {a} with {b}")
+    return a
+
+
+def _check_enum(t: ArgType) -> None:
+    if not isinstance(t, ArgTypes.Enum):
+        raise TypeMismatchError(f"AnyEnum can only unify with Enum, got {t}")
+
+
+def resolve(graph: "Graph") -> TypeEnv:
+    """Union-find over AnyEnum instances so a concrete enum class propagates across
+    edges AND across slots that share the same AnyEnum() inside one node."""
+    subst: dict[int, ArgType] = {}
+
+    def find(t: ArgType) -> ArgType:
+        while isinstance(t, ArgTypes.AnyEnum) and id(t) in subst:
+            t = subst[id(t)]
+        return t
+
+    def union(a: ArgType, b: ArgType) -> None:
+        ra, rb = find(a), find(b)
+        a_var = isinstance(ra, ArgTypes.AnyEnum)
+        b_var = isinstance(rb, ArgTypes.AnyEnum)
+        if a_var and b_var:
+            if ra is not rb:
+                subst[id(ra)] = rb
+        elif a_var:
+            _check_enum(rb)
+            subst[id(ra)] = rb
+        elif b_var:
+            _check_enum(ra)
+            subst[id(rb)] = ra
+        elif type(ra) is not type(rb):
+            raise TypeMismatchError(f"cannot unify {ra} with {rb}")
+
+    for node in graph.get_nodes().values():
+        for output in node.get_value_outputs():
+            for input_endpoint in output.get_connections():
+                union(output.get_type(), input_endpoint.get_type())
+
+    env = TypeEnv()
+    for node in graph.get_nodes().values():
+        for output in node.get_value_outputs():
+            env.bind(node.get_name(), output.get_name(), find(output.get_type()))
+        for input_endpoint in node.get_value_inputs():
+            env.bind(node.get_name(), input_endpoint.get_name(), find(input_endpoint.get_type()))
+    return env

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -256,6 +256,7 @@ class Node(ABC):
         self._nb_runned_input_flow: int = 0
         self._nb_available_input_values: int = 0
         self._run_requested: bool = False
+        self._on_run_scheduled: bool = False
 
     def is_pure(self) -> bool:
         return len(self._flow_inputs) == 0 and len(self._flow_outputs) == 0
@@ -345,13 +346,31 @@ class Node(ABC):
         return ImmediateResultTask()
 
     def _schedule_run_if_needed(self) -> None:
+        # Idempotent: counter can hit the threshold from both run()'s sync pull
+        # and a later on_set_value_input cascade. Without this guard, on_run
+        # fires twice and replays flow-output transitions like ok.run().
+        # When already scheduled, re-broadcast the pure cache so consumers
+        # that linked after the first dispatch still get their input set.
+        if self._on_run_scheduled:
+            if self.is_pure():
+                for vo in self._value_outputs:
+                    if vo.has_been_set():
+                        vo.use_cached_value()
+            return
         if self._nb_available_input_values >= len(self._value_inputs):
+            self._on_run_scheduled = True
             self.get_graph().schedule_run_node(self)
 
     def run(self) -> None:
         if self._run_requested:
-            # Multi-consumer pure outputs schedule one pull per consumer; the
-            # first run already populated and propagated the cache.
+            # Pure node already ran. Re-broadcast its cache: consumers that
+            # were linked AFTER the original run (e.g. set_value-triggered
+            # eager schedule during graph construction) need the value pushed
+            # down, and idempotent returns must not silently drop the chain.
+            if self.is_pure():
+                for vo in self._value_outputs:
+                    if vo.has_been_set():
+                        vo.use_cached_value()
             return
         self._run_requested = True
 
@@ -394,6 +413,7 @@ class Node(ABC):
         self._nb_runned_input_flow = 0
         self._nb_available_input_values = 0
         self._run_requested = False
+        self._on_run_scheduled = False
         for value_input in self._value_inputs:
             value_input.reset()
         for value_output in self._value_outputs:

--- a/src/evo_lib/graph/nodes/compare.py
+++ b/src/evo_lib/graph/nodes/compare.py
@@ -2,7 +2,10 @@
 
 F32: Eq, Ne, Lt, Le, Gt, Ge.
 String: EqStr, NeStr.
+Enum:  EqEnum, NeEnum (polymorphic over any enum class).
 """
+
+from typing import Any
 
 from evo_lib.argtypes import ArgTypes
 from evo_lib.graph.node import Node, NodeDefinition
@@ -125,3 +128,53 @@ class NeStrNode(_CompareStrNode):
 class NeStrNodeDefinition(_CompareStrNodeDefinition):
     def __init__(self):
         super().__init__(NeStrNode, "compare/ne_str", "Ne (str)")
+
+
+def _enum_equal(a: Any, b: Any) -> bool:
+    # Enum members compare equal to their int value (IntEnum) but NOT to their
+    # name string. The editor stores the constant as the enum name to keep the
+    # combo UX (display "Blue", not "5"), so we fall back to name comparison.
+    if a == b:
+        return True
+    a_name = a.name if hasattr(a, "name") else (a if isinstance(a, str) else None)
+    b_name = b.name if hasattr(b, "name") else (b if isinstance(b, str) else None)
+    return a_name is not None and a_name == b_name
+
+
+class _CompareEnumNode(Node):
+    def _op(self, a: Any, b: Any) -> bool:
+        raise NotImplementedError
+
+    def on_run(self) -> Task[()]:
+        a = self.get_value_input("a").get_value()
+        b = self.get_value_input("b").get_value()
+        self.get_value_output("result").set_value(self._op(a, b))
+        return ImmediateResultTask()
+
+
+class _CompareEnumNodeDefinition(NodeDefinition):
+    def __init__(self, node_cls: type[Node], name: str, title: str):
+        super().__init__(node_cls, name, title)
+        self.add_value_input("a", ArgTypes.AnyEnum(), 0)
+        self.add_value_input("b", ArgTypes.AnyEnum(), 0)
+        self.add_value_output("result", ArgTypes.Bool())
+
+
+class EqEnumNode(_CompareEnumNode):
+    def _op(self, a: Any, b: Any) -> bool:
+        return _enum_equal(a, b)
+
+
+class EqEnumNodeDefinition(_CompareEnumNodeDefinition):
+    def __init__(self):
+        super().__init__(EqEnumNode, "compare/eq_enum", "Eq (enum)")
+
+
+class NeEnumNode(_CompareEnumNode):
+    def _op(self, a: Any, b: Any) -> bool:
+        return not _enum_equal(a, b)
+
+
+class NeEnumNodeDefinition(_CompareEnumNodeDefinition):
+    def __init__(self):
+        super().__init__(NeEnumNode, "compare/ne_enum", "Ne (enum)")

--- a/src/evo_lib/graph/nodes/compare.py
+++ b/src/evo_lib/graph/nodes/compare.py
@@ -155,8 +155,10 @@ class _CompareEnumNode(Node):
 class _CompareEnumNodeDefinition(NodeDefinition):
     def __init__(self, node_cls: type[Node], name: str, title: str):
         super().__init__(node_cls, name, title)
-        self.add_value_input("a", ArgTypes.AnyEnum(), 0)
-        self.add_value_input("b", ArgTypes.AnyEnum(), 0)
+        # Shared T so a and b are unified to the same enum class at resolve time.
+        T = ArgTypes.AnyEnum()
+        self.add_value_input("a", T, 0)
+        self.add_value_input("b", T, 0)
         self.add_value_output("result", ArgTypes.Bool())
 
 

--- a/src/evo_lib/interfaces/gpio.py
+++ b/src/evo_lib/interfaces/gpio.py
@@ -1,7 +1,7 @@
 """Abstract interface for digital GPIO pins."""
 
 from abc import abstractmethod
-from enum import Enum
+from enum import IntEnum
 from typing import TYPE_CHECKING
 
 from evo_lib.argtypes import ArgTypes
@@ -13,19 +13,15 @@ if TYPE_CHECKING:
     from evo_lib.task import Task
 
 
-class GPIODirection(Enum):
-    """Pin direction."""
-
-    INPUT = "input"
-    OUTPUT = "output"
+class GPIODirection(IntEnum):
+    INPUT = 0
+    OUTPUT = 1
 
 
-class GPIOEdge(Enum):
-    """Edge type for interrupt triggers."""
-
-    RISING = "rising"
-    FALLING = "falling"
-    BOTH = "both"
+class GPIOEdge(IntEnum):
+    RISING = 0
+    FALLING = 1
+    BOTH = 2
 
 
 class GPIO(Interface):

--- a/src/evo_lib/interfaces/gpio.py
+++ b/src/evo_lib/interfaces/gpio.py
@@ -30,16 +30,12 @@ class GPIO(Interface):
     commands = DriverCommands()
 
     @abstractmethod
-    @commands.register(args = [], result = [
-        ("state", ArgTypes.Bool(help = "The current state"))
-    ])
+    @commands.register(args=[], result=[("state", ArgTypes.Bool(help="The current state"))])
     def read(self) -> Task[bool]:
         """Read current pin state (True = high, False = low)."""
 
     @abstractmethod
-    @commands.register(args = [
-        ("state", ArgTypes.Bool(help = "The state to set"))
-    ], result = [])
+    @commands.register(args=[("state", ArgTypes.Bool(help="The state to set"))], result=[])
     def write(self, state: bool) -> Task[()]:
         """Set the output state (True = high, False = low)."""
 

--- a/src/evo_lib/path_finding.py
+++ b/src/evo_lib/path_finding.py
@@ -416,7 +416,7 @@ class PathFindingMap:
                 previous[current_point_index] = previous_point_index
 
             visiteds[current_point_index] = True
-            # distances[current_point_index] = current_distance + current_point.distance(destination)
+            # distances[current_point_index] = current_distance + current_point.distance(destination)  # noqa: E501
 
             if current_point_index == destination_index:
                 break
@@ -429,14 +429,14 @@ class PathFindingMap:
                 shape_start_index = shapes_start_index[shape_index]
 
                 for outermost_point_index in outermost_points_index:
-                    outermost_point_index += shape_start_index
-                    if not visiteds[outermost_point_index]:
-                        d = current_distance + current_point.distance(points[outermost_point_index])
+                    abs_index = outermost_point_index + shape_start_index
+                    if not visiteds[abs_index]:
+                        d = current_distance + current_point.distance(points[abs_index])
                         heapq.heappush(
                             queue,
                             (
-                                d + heuristics[outermost_point_index],
-                                outermost_point_index,
+                                d + heuristics[abs_index],
+                                abs_index,
                                 current_point_index,
                             ),
                         )
@@ -448,11 +448,11 @@ class PathFindingMap:
                 shape_start_index = shapes_start_index[current_shape_index]
 
                 for next_index in nexts:
-                    next_index += shape_start_index
-                    if not visiteds[next_index]:
-                        d = current_distance + current_point.distance(points[next_index])
+                    abs_index = next_index + shape_start_index
+                    if not visiteds[abs_index]:
+                        d = current_distance + current_point.distance(points[abs_index])
                         heapq.heappush(
-                            queue, (d + heuristics[next_index], next_index, current_point_index)
+                            queue, (d + heuristics[abs_index], abs_index, current_point_index)
                         )
 
             heapq.heappush(
@@ -464,7 +464,7 @@ class PathFindingMap:
                 ),
             )
 
-        # print(f"Line of sight check done: {int(nb_line_of_sign_checks / (nb_points * nb_points) * 100 + 0.5)}% ({nb_line_of_sign_checks})")
+        # print(f"Line of sight check done: {int(nb_line_of_sign_checks / (nb_points * nb_points) * 100 + 0.5)}% ({nb_line_of_sign_checks})")  # noqa: E501
         # print(f"Maximum reached min-heap size: {max_heap_size}")
 
         # Check if a path has been found

--- a/tests/test_graph_pure_nodes.py
+++ b/tests/test_graph_pure_nodes.py
@@ -142,6 +142,44 @@ def test_chain_pull_propagates_through_pure_nodes():
     assert _pull(scheduler, mul) == 50.0
 
 
+def _instantiate_with_defaults(definition_cls, name: str, **defaults) -> Node:
+    node = _instantiate(definition_cls, name)
+    for k, v in defaults.items():
+        node.get_value_input(k).set_default(v)
+    return node
+
+
+def test_pure_chain_runs_when_only_defaults_set():
+    # Defaults via set_default() leave generation == 0; pre-fix the chain
+    # would short-circuit on cached None and propagate it as the result.
+    graph, scheduler = _make_graph()
+    add = _instantiate_with_defaults(AddNodeDefinition, "add", a=2.0, b=3.0)
+    mul = _instantiate_with_defaults(MulNodeDefinition, "mul", b=10.0)
+    graph.add_node(add)
+    graph.add_node(mul)
+    add.get_value_output("result").link(mul.get_value_input("a"))
+    assert _pull(scheduler, mul) == 50.0
+
+
+def test_multi_consumer_pure_node_pull_is_idempotent():
+    # Two consumers schedule one transitive pull each on the shared upstream;
+    # the second one used to raise RuntimeError("twice").
+    graph, scheduler = _make_graph()
+    src = _instantiate_with_defaults(AddNodeDefinition, "src", a=2.0, b=3.0)
+    c1 = _instantiate_with_defaults(MulNodeDefinition, "c1", b=2.0)
+    c2 = _instantiate_with_defaults(SubNodeDefinition, "c2", b=1.0)
+    graph.add_node(src)
+    graph.add_node(c1)
+    graph.add_node(c2)
+    src.get_value_output("result").link(c1.get_value_input("a"))
+    src.get_value_output("result").link(c2.get_value_input("a"))
+    c1.get_value_output("result").pull()
+    c2.get_value_output("result").pull()
+    scheduler.handle()
+    assert c1.get_value_output("result")._cached_value == 10.0
+    assert c2.get_value_output("result")._cached_value == 4.0
+
+
 def test_loader_registers_all_pure_nodes():
     """Guard against forgetting to register a node in
     GraphLoader.register_base_node_types."""

--- a/tests/test_graph_pure_nodes.py
+++ b/tests/test_graph_pure_nodes.py
@@ -190,10 +190,24 @@ def test_loader_registers_all_pure_nodes():
     exported = loader.export_node_types()
     names = set(exported["nodes"].keys())
     expected = {
-        "math/add", "math/sub", "math/mul", "math/div", "math/mod",
-        "math/min", "math/max", "math/neg", "math/abs",
-        "logic/and", "logic/or", "logic/xor", "logic/not",
-        "compare/eq", "compare/ne", "compare/lt", "compare/le",
-        "compare/gt", "compare/ge",
+        "math/add",
+        "math/sub",
+        "math/mul",
+        "math/div",
+        "math/mod",
+        "math/min",
+        "math/max",
+        "math/neg",
+        "math/abs",
+        "logic/and",
+        "logic/or",
+        "logic/xor",
+        "logic/not",
+        "compare/eq",
+        "compare/ne",
+        "compare/lt",
+        "compare/le",
+        "compare/gt",
+        "compare/ge",
     }
     assert expected.issubset(names)

--- a/tests/test_type_inference.py
+++ b/tests/test_type_inference.py
@@ -1,0 +1,123 @@
+"""Tests for AnyEnum / unify / resolve and the IntEnum binary guard."""
+
+import io
+from enum import IntEnum, StrEnum
+
+import pytest
+
+from evo_lib.argtypes import (
+    ArgTypes,
+    TypeMismatchError,
+    UnresolvedTypeError,
+    argtype_to_stream,
+)
+from evo_lib.config import ConfigObject
+from evo_lib.graph.graph import Graph
+from evo_lib.graph.node import Node, NodeDefinition, unify
+from evo_lib.graph.nodes.compare import EqEnumNodeDefinition
+
+
+class _IntColor(IntEnum):
+    RED = 0
+    GREEN = 1
+
+
+class _StrMode(StrEnum):
+    A = "a"
+    B = "b"
+
+
+def test_unify_concrete_match():
+    assert type(unify(ArgTypes.F32(), ArgTypes.F32())) is ArgTypes.F32
+
+
+def test_unify_concrete_mismatch_raises():
+    with pytest.raises(TypeMismatchError):
+        unify(ArgTypes.F32(), ArgTypes.I32())
+
+
+@pytest.mark.parametrize("enum_cls", [_IntColor, _StrMode])
+def test_unify_var_with_concrete_binds_either_way(enum_cls):
+    var, e = ArgTypes.AnyEnum(), ArgTypes.Enum(enum_cls)
+    assert unify(var, e) is e
+    assert unify(e, var) is e
+
+
+def test_unify_two_vars_returns_left():
+    v1, v2 = ArgTypes.AnyEnum(), ArgTypes.AnyEnum()
+    assert unify(v1, v2) is v1
+
+
+def test_unify_anyenum_with_non_enum_raises():
+    with pytest.raises(TypeMismatchError):
+        unify(ArgTypes.AnyEnum(), ArgTypes.F32())
+
+
+def test_argtype_to_stream_rejects_unresolved_var():
+    with pytest.raises(UnresolvedTypeError):
+        argtype_to_stream(ArgTypes.AnyEnum(), io.BytesIO())
+
+
+def test_enum_value_to_stream_intenum_only():
+    buf = io.BytesIO()
+    ArgTypes.Enum(_IntColor).value_to_stream(_IntColor.GREEN, buf)
+    assert buf.getvalue() == (1).to_bytes(4, "little")
+
+    with pytest.raises(TypeError, match="IntEnum"):
+        ArgTypes.Enum(_StrMode).value_to_stream(_StrMode.A, io.BytesIO())
+
+
+class _Stub(Node):
+    def on_run(self):
+        raise NotImplementedError
+
+
+def _make_node(definition: NodeDefinition, name: str) -> Node:
+    n = definition.instantiate_node(name, ConfigObject())
+    definition.create_node_endpoints(n, ConfigObject())
+    return n
+
+
+def test_resolve_propagates_concrete_type_through_eq_enum():
+    producer_def = NodeDefinition(_Stub, "test/producer", "Producer")
+    producer_def.add_value_output("color", ArgTypes.Enum(_IntColor))
+    producer = _make_node(producer_def, "p")
+
+    eq = _make_node(EqEnumNodeDefinition(), "eq")
+    producer.get_value_output("color").link(eq.get_value_input("a"))
+
+    graph = Graph("g")
+    graph.add_node(producer)
+    graph.add_node(eq)
+    env = graph.resolve_types()
+
+    bound = env.get("eq", "a")
+    assert isinstance(bound, ArgTypes.Enum)
+    assert bound.enum_type is _IntColor
+
+
+def test_resolve_propagates_through_polymorphic_chain():
+    """Producer → Forwarder(AnyEnum→AnyEnum) → eq.a: Enum(C) must reach eq.a."""
+    producer_def = NodeDefinition(_Stub, "test/producer", "Producer")
+    producer_def.add_value_output("color", ArgTypes.Enum(_IntColor))
+    producer = _make_node(producer_def, "p")
+
+    forwarder_def = NodeDefinition(_Stub, "test/forwarder", "Forwarder")
+    T = ArgTypes.AnyEnum()
+    forwarder_def.add_value_input("in", T, 0)
+    forwarder_def.add_value_output("out", T)
+    fwd = _make_node(forwarder_def, "fwd")
+
+    eq = _make_node(EqEnumNodeDefinition(), "eq")
+
+    producer.get_value_output("color").link(fwd.get_value_input("in"))
+    fwd.get_value_output("out").link(eq.get_value_input("a"))
+
+    graph = Graph("g")
+    for n in (producer, fwd, eq):
+        graph.add_node(n)
+
+    env = graph.resolve_types()
+    bound = env.get("eq", "a")
+    assert isinstance(bound, ArgTypes.Enum)
+    assert bound.enum_type is _IntColor


### PR DESCRIPTION
## Stack

```
master
└── this PR — polymorphic enum compare nodes (eq_enum, ne_enum) + first-run cache miss / multi-consumer pull engine fixes
    └── #103 feat(color): multi-repr Color + TCS34725 diagnostics
        └── #104 feat(pilot): RESET + MATCH_BEGIN opcodes
```

Parallel (not chained — independent feature branches): #110 (AX12 sync + load limit), #90 (elevator board driver).

## Changes

- `compare/eq_enum` and `compare/ne_enum`: polymorphic comparison nodes that operate on any enum class via `ArgTypes.AnyEnum()` (slot type `enum_any`)
- Graph engine fix: pure node first-run cache miss + multi-consumer pull dedup (avoids deadlock on chained pure-node fanout)