### PR TITLE
feat(graph): structured debug logs with node type, IO values and flow state

### DIFF
--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -85,7 +85,13 @@ class Graph:
             self._running_nodes_tasks.remove(task)
         self._check_end()
 
-    def _on_node_run_complete(self, task: Task) -> None:
+    def _on_node_run_complete(self, task: Task, node: Node) -> None:
+        runner = self.get_runner()
+        if runner is not None:
+            runner.get_logger().debug(
+                f"Done node '{node.get_name()}' [{node._fmt_type()}]"
+                f"{node._fmt_inputs()}{node._fmt_outputs()}{node._fmt_flow_out()}"
+            )
         self._remove_node_run_task(task)
 
     def _on_node_run_error(self, task: Task, error: Exception) -> None:
@@ -101,7 +107,7 @@ class Graph:
         self._add_node_run_task(task)
         # Task.on_complete spreads the result tuple via *self._result, so the
         # callback must absorb whatever arity the producing node emits.
-        task.on_complete(lambda *_args: self._on_node_run_complete(task))
+        task.on_complete(lambda *_args: self._on_node_run_complete(task, node))
         task.on_error(lambda error: self._on_node_run_error(task, error))
 
     def _do_run_flow_input(self, input_flow: FlowInput) -> None:

--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -95,8 +95,7 @@ class Graph:
                 if fo._state != FlowEndpointState.WAITING or not fo.get_connections():
                     continue
                 targets = ", ".join(
-                    f"{c.get_node().get_name()}.{c.get_name()}"
-                    for c in fo.get_connections()
+                    f"{c.get_node().get_name()}.{c.get_name()}" for c in fo.get_connections()
                 )
                 stale.append(f"{node.get_name()}.{fo.get_name()} → ({targets})")
         if stale:

--- a/src/evo_lib/graph/graph.py
+++ b/src/evo_lib/graph/graph.py
@@ -78,7 +78,32 @@ class Graph:
         if end:
             assert self._running_graph_task is not None
             self._running_graph_task.complete()
+            self._warn_stale_flow_outputs()
             self._runner.get_logger().debug("Graph finished")
+
+    def _warn_stale_flow_outputs(self) -> None:
+        from evo_lib.graph.node import FlowEndpointState
+
+        runner = self.get_runner()
+        if runner is None:
+            return
+        stale: list[str] = []
+        for node in self._nodes.values():
+            if not node._run_requested:
+                continue
+            for fo in node.get_flow_outputs():
+                if fo._state != FlowEndpointState.WAITING or not fo.get_connections():
+                    continue
+                targets = ", ".join(
+                    f"{c.get_node().get_name()}.{c.get_name()}"
+                    for c in fo.get_connections()
+                )
+                stale.append(f"{node.get_name()}.{fo.get_name()} → ({targets})")
+        if stale:
+            runner.get_logger().warning(
+                f"Graph finished with {len(stale)} stale flow_output(s) "
+                f"left dangling: {'; '.join(stale)}"
+            )
 
     def _remove_node_run_task(self, task: Task) -> None:
         with self._lock:

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -389,7 +389,10 @@ class Node(ABC):
             need_to_run = True
 
         if need_to_run:
-            self.get_runner().get_logger().debug(f"Run node '{self.get_name()}'")
+            self.get_runner().get_logger().debug(
+                f"Run node '{self.get_name()}' [{self._fmt_type()}]"
+                f"{self._fmt_flow_in()}"
+            )
             # Reset available input values count because all input are pulled
             self._nb_available_input_values = 0
             # Pull all value inputs to ensure they are up-to-date
@@ -398,15 +401,61 @@ class Node(ABC):
             # Once all inputs are pulled, node is scheduled to be run, but
             self._schedule_run_if_needed()
         else:
-            self.get_runner().get_logger().debug(f"Used cached value for node '{self.get_name()}'")
+            self.get_runner().get_logger().debug(
+                f"Cached node '{self.get_name()}' [{self._fmt_type()}]"
+                f"{self._fmt_outputs()}"
+            )
             # Do not run node and use last computed output value
             for value_output in self._value_outputs:
                 value_output.use_cached_value()
 
     def ignore(self) -> None:
-        self.get_runner().get_logger().debug(f"Ignore node '{self.get_name()}'")
+        self.get_runner().get_logger().debug(
+            f"Ignore node '{self.get_name()}' [{self._fmt_type()}]"
+        )
         for flow_output in self._flow_outputs:
             flow_output.ignore()
+
+    # -- Debug log formatters --
+
+    def _fmt_type(self) -> str:
+        return self._definition.get_name()
+
+    def _fmt_inputs(self) -> str:
+        if not self._value_inputs:
+            return ""
+        items = ", ".join(
+            f"{vi.get_name()}={vi.get_value()!r}" for vi in self._value_inputs
+        )
+        return f" inputs={{{items}}}"
+
+    def _fmt_outputs(self) -> str:
+        if not self._value_outputs:
+            return ""
+        items = [
+            f"{vo.get_name()}={vo._cached_value!r}"
+            for vo in self._value_outputs
+            if vo.has_been_set()
+        ]
+        if not items:
+            return ""
+        return f" outputs={{{', '.join(items)}}}"
+
+    def _fmt_flow_in(self) -> str:
+        if not self._flow_inputs:
+            return ""
+        runned = [fi.get_name() for fi in self._flow_inputs if fi._state == FlowEndpointState.RUNNED]
+        if not runned:
+            return ""
+        return f" via flow_in={{{', '.join(runned)}}}"
+
+    def _fmt_flow_out(self) -> str:
+        if not self._flow_outputs:
+            return ""
+        items = ", ".join(
+            f"{fo.get_name()}:{fo._state.name.lower()}" for fo in self._flow_outputs
+        )
+        return f" flow_out={{{items}}}"
 
     def reset(self) -> None:
         self._nb_ignored_input_flow = 0

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -394,8 +394,7 @@ class Node(ABC):
         if need_to_run:
             if not self.is_pure():
                 self.get_runner().get_logger().debug(
-                    f"Run node '{self.get_name()}' [{self._fmt_type()}]"
-                    f"{self._fmt_flow_in()}"
+                    f"Run node '{self.get_name()}' [{self._fmt_type()}]{self._fmt_flow_in()}"
                 )
             # Reset available input values count because all input are pulled
             self._nb_available_input_values = 0
@@ -406,8 +405,7 @@ class Node(ABC):
             self._schedule_run_if_needed()
         else:
             self.get_runner().get_logger().debug(
-                f"Cached node '{self.get_name()}' [{self._fmt_type()}]"
-                f"{self._fmt_outputs()}"
+                f"Cached node '{self.get_name()}' [{self._fmt_type()}]{self._fmt_outputs()}"
             )
             # Do not run node and use last computed output value
             for value_output in self._value_outputs:
@@ -428,9 +426,7 @@ class Node(ABC):
     def _fmt_inputs(self) -> str:
         if not self._value_inputs:
             return ""
-        items = ", ".join(
-            f"{vi.get_name()}={vi.get_value()!r}" for vi in self._value_inputs
-        )
+        items = ", ".join(f"{vi.get_name()}={vi.get_value()!r}" for vi in self._value_inputs)
         return f" inputs={{{items}}}"
 
     def _fmt_outputs(self) -> str:
@@ -464,9 +460,7 @@ class Node(ABC):
     def _fmt_flow_out(self) -> str:
         if not self._flow_outputs:
             return ""
-        items = ", ".join(
-            f"{fo.get_name()}:{fo._state.name.lower()}" for fo in self._flow_outputs
-        )
+        items = ", ".join(f"{fo.get_name()}:{fo._state.name.lower()}" for fo in self._flow_outputs)
         return f" flow_out={{{items}}}"
 
     def reset(self) -> None:

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -50,11 +50,13 @@ class FlowInput(Endpoint):
         self._state: FlowEndpointState = FlowEndpointState.WAITING
         self._nb_ignored_input_connections: int = 0
         self._nb_runned_input_connections: int = 0
+        self._last_run_source: FlowOutput | None = None
 
     def reset(self) -> None:
         self._state = FlowEndpointState.WAITING
         self._nb_ignored_input_connections = 0
         self._nb_runned_input_connections = 0
+        self._last_run_source = None
 
     def get_connections(self) -> list[FlowOutput]:
         return self._connections
@@ -75,6 +77,7 @@ class FlowInput(Endpoint):
 
     def run(self, source: FlowOutput) -> None:
         self._nb_runned_input_connections += 1
+        self._last_run_source = source
         self._update_state()
 
     def ignore(self, source: FlowOutput) -> None:
@@ -389,10 +392,11 @@ class Node(ABC):
             need_to_run = True
 
         if need_to_run:
-            self.get_runner().get_logger().debug(
-                f"Run node '{self.get_name()}' [{self._fmt_type()}]"
-                f"{self._fmt_flow_in()}"
-            )
+            if not self.is_pure():
+                self.get_runner().get_logger().debug(
+                    f"Run node '{self.get_name()}' [{self._fmt_type()}]"
+                    f"{self._fmt_flow_in()}"
+                )
             # Reset available input values count because all input are pulled
             self._nb_available_input_values = 0
             # Pull all value inputs to ensure they are up-to-date
@@ -444,10 +448,18 @@ class Node(ABC):
     def _fmt_flow_in(self) -> str:
         if not self._flow_inputs:
             return ""
-        runned = [fi.get_name() for fi in self._flow_inputs if fi._state == FlowEndpointState.RUNNED]
-        if not runned:
+        parts = []
+        for fi in self._flow_inputs:
+            if fi._state != FlowEndpointState.RUNNED:
+                continue
+            label = fi.get_name()
+            src = fi._last_run_source
+            if src is not None:
+                label += f"←{src.get_node().get_name()}.{src.get_name()}"
+            parts.append(label)
+        if not parts:
             return ""
-        return f" via flow_in={{{', '.join(runned)}}}"
+        return f" via flow_in={{{', '.join(parts)}}}"
 
     def _fmt_flow_out(self) -> str:
         if not self._flow_outputs:

--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -50,13 +50,15 @@ class FlowInput(Endpoint):
         self._state: FlowEndpointState = FlowEndpointState.WAITING
         self._nb_ignored_input_connections: int = 0
         self._nb_runned_input_connections: int = 0
-        self._last_run_source: FlowOutput | None = None
+        # Sources that fired this input, in run order. Last element is the most
+        # recent — useful for debug logs that want to show fan-in provenance.
+        self._run_sources: list[FlowOutput] = []
 
     def reset(self) -> None:
         self._state = FlowEndpointState.WAITING
         self._nb_ignored_input_connections = 0
         self._nb_runned_input_connections = 0
-        self._last_run_source = None
+        self._run_sources = []
 
     def get_connections(self) -> list[FlowOutput]:
         return self._connections
@@ -77,7 +79,7 @@ class FlowInput(Endpoint):
 
     def run(self, source: FlowOutput) -> None:
         self._nb_runned_input_connections += 1
-        self._last_run_source = source
+        self._run_sources.append(source)
         self._update_state()
 
     def ignore(self, source: FlowOutput) -> None:
@@ -449,9 +451,11 @@ class Node(ABC):
             if fi._state != FlowEndpointState.RUNNED:
                 continue
             label = fi.get_name()
-            src = fi._last_run_source
-            if src is not None:
-                label += f"←{src.get_node().get_name()}.{src.get_name()}"
+            if fi._run_sources:
+                srcs = ", ".join(
+                    f"{s.get_node().get_name()}.{s.get_name()}" for s in fi._run_sources
+                )
+                label += f"←[{srcs}]"
             parts.append(label)
         if not parts:
             return ""


### PR DESCRIPTION
- `Run`/`Cached`/`Ignore` log lines now include the node `[<type>]` from the JSON5 config
- New `Done node` line (from `Graph._on_node_run_complete`) shows `inputs={…} outputs={…} flow_out={…}`
- Stacked on `feat/pilot-reset` (#104)