### PR TITLE
fix(graph): defer CallNode subgraph clone + rebind cloned endpoints to clone parent

### DIFF
--- a/src/evo_lib/graph/node.py
+++ b/src/evo_lib/graph/node.py
@@ -81,8 +81,8 @@ class FlowInput(Endpoint):
         self._nb_ignored_input_connections += 1
         self._update_state()
 
-    def clone(self) -> FlowInput:
-        return self.__class__(self._node, self._name)
+    def clone(self, new_node: Node) -> FlowInput:
+        return self.__class__(new_node, self._name)
 
 
 class FlowOutput(Endpoint):
@@ -115,8 +115,8 @@ class FlowOutput(Endpoint):
             inp.ignore(source=self)
         self._state = FlowEndpointState.IGNORED
 
-    def clone(self) -> FlowOutput:
-        return self.__class__(self._node, self._name)
+    def clone(self, new_node: Node) -> FlowOutput:
+        return self.__class__(new_node, self._name)
 
 
 @dataclass
@@ -191,8 +191,8 @@ class ValueInput(ValueEndpoint):
     def get_value(self) -> Any:
         return self._value
 
-    def clone(self) -> ValueInput:
-        return self.__class__(self._node, self._name, self._type, self._default)
+    def clone(self, new_node: Node) -> ValueInput:
+        return self.__class__(new_node, self._name, self._type, self._default)
 
 
 class ValueOutput(ValueEndpoint):
@@ -229,8 +229,8 @@ class ValueOutput(ValueEndpoint):
     def reset(self) -> None:
         self._cached_value = None
 
-    def clone(self) -> ValueOutput:
-        return self.__class__(self._node, self._name, self._type)
+    def clone(self, new_node: Node) -> ValueOutput:
+        return self.__class__(new_node, self._name, self._type)
 
 
 # -- Node --
@@ -262,13 +262,13 @@ class Node(ABC):
         cloned._flow_outputs.clear()
 
         for value_input in self._value_inputs:
-            cloned._value_inputs.append(value_input.clone())
+            cloned._value_inputs.append(value_input.clone(cloned))
         for value_output in self._value_outputs:
-            cloned._value_outputs.append(value_output.clone())
+            cloned._value_outputs.append(value_output.clone(cloned))
         for flow_input in self._flow_inputs:
-            cloned._flow_inputs.append(flow_input.clone())
+            cloned._flow_inputs.append(flow_input.clone(cloned))
         for flow_output in self._flow_outputs:
-            cloned._flow_outputs.append(flow_output.clone())
+            cloned._flow_outputs.append(flow_output.clone(cloned))
 
         return cloned
 

--- a/src/evo_lib/graph/nodes/flow.py
+++ b/src/evo_lib/graph/nodes/flow.py
@@ -81,15 +81,21 @@ class ExitNodeDefinition(NodeDefinition):
 class CallNode(Node):
     def __init__(self, definition: CallNodeDefinition, name: str):
         super().__init__(definition, name)
-        # Clone the called graph because each running graph needs to be a separate instance
-        self._called_graph = definition.get_called_graph().clone()
+        # Lazy: target subgraph isn't fully loaded at instantiation time.
+        self._called_graph: Graph | None = None
+
+    def _get_called_graph(self) -> Graph:
+        if self._called_graph is None:
+            self._called_graph = self.get_definition().get_called_graph().clone()
+        return self._called_graph
 
     def on_run(self) -> Task[()]:
-        entry_node = self._called_graph.get_entry_node()
+        called_graph = self._get_called_graph()
+        entry_node = called_graph.get_entry_node()
         if entry_node is None:
             return ImmediateErrorTask(RuntimeError("No entry node found in called graph"))
 
-        exit_node = self._called_graph.get_exit_node()
+        exit_node = called_graph.get_exit_node()
         if exit_node is not None:
             exit_node.set_caller_node(self)
 
@@ -99,20 +105,17 @@ class CallNode(Node):
             if entry_value_input is not None:
                 entry_value_input.set_value(self_value_input.get_value())
 
-        # Activate the subgraph so it can be run and event nodes can be called
-        self._called_graph.activate(self.get_runner())
-
-        # Run the subgraph
+        called_graph.activate(self.get_runner())
         entry_node.run()
-        running_task = self._called_graph.get_running_task()
+        running_task = called_graph.get_running_task()
         assert running_task is not None
-
         return running_task
 
     @override
     def reset(self) -> None:
         super().reset()
-        self._called_graph.reset()
+        if self._called_graph is not None:
+            self._called_graph.reset()
 
 
 class CallNodeDefinition(NodeDefinition):


### PR DESCRIPTION
- Defer CallNode subgraph clone to first \`on_run\` (was at \`__init__\`, before target subgraph had nodes)
- Endpoint.clone() rebound: pass new parent node so cloned ValueInput/Output and FlowInput/Output route via the clone, not the original
- Surfaced because lazy clone now actually runs subgraph nodes, exposing the cross-binding (set_value cascading into original graph)