### PR TITLE
feat(perception): MultiCamera ArUco aggregator across N cameras

### DIFF
--- a/src/evo_lib/interfaces/camera.py
+++ b/src/evo_lib/interfaces/camera.py
@@ -31,6 +31,7 @@ class ArucoMarker:
     # (qw, qx, qy, qz) — full rotation; needed for tilted markers where yaw alone loses info.
     quat_robot: "tuple[float, float, float, float] | None" = None
     yaw_robot_rad: "float | None" = None
+    source_camera: "str | None" = None
 
 
 _MARKER_STRUCT = ArgTypes.Struct(

--- a/src/evo_lib/perception/__init__.py
+++ b/src/evo_lib/perception/__init__.py
@@ -1,3 +1,9 @@
 from evo_lib.perception.aruco import ArucoState, CharucoCalibrationSession
+from evo_lib.perception.multi_camera import MultiCamera, MultiCameraDefinition
 
-__all__ = ["ArucoState", "CharucoCalibrationSession"]
+__all__ = [
+    "ArucoState",
+    "CharucoCalibrationSession",
+    "MultiCamera",
+    "MultiCameraDefinition",
+]

--- a/src/evo_lib/perception/multi_camera.py
+++ b/src/evo_lib/perception/multi_camera.py
@@ -1,0 +1,174 @@
+"""Multi-camera ArUco aggregator: fuses detections from N cameras."""
+
+import math
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.interfaces.camera import ArucoMarker, Camera
+from evo_lib.peripheral import Peripheral
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.types.pose import Pose3D
+
+
+_BRICK_STRUCT = ArgTypes.Struct(
+    [
+        ("id", ArgTypes.U32()),
+        ("x_mm", ArgTypes.F32()),
+        ("y_mm", ArgTypes.F32()),
+        ("z_mm", ArgTypes.F32()),
+        ("qw", ArgTypes.F32()),
+        ("qx", ArgTypes.F32()),
+        ("qy", ArgTypes.F32()),
+        ("qz", ArgTypes.F32()),
+        ("yaw_deg", ArgTypes.F32()),
+        ("source_camera", ArgTypes.String()),
+    ]
+)
+
+
+def _squared_distance_robot(m: ArucoMarker) -> float:
+    # Squared, not sqrt — comparison only.
+    p = m.position_robot_mm
+    return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
+
+
+def _safe_detect(cam: Camera) -> list[ArucoMarker]:
+    try:
+        return cam.detect()
+    except Exception:
+        return []
+
+
+class MultiCamera(Peripheral):
+    """Aggregates several Cameras into a deduplicated ArUco brick view."""
+
+    commands = DriverCommands()
+
+    def __init__(self, name: str, cameras: list[Camera]):
+        super().__init__(name)
+        self._cameras = list(cameras)
+        # ComponentsManager skips Array-typed deps; wire both directions here.
+        for cam in self._cameras:
+            self.add_dependency(cam)
+            cam.add_dependent(self)
+        self._pool: ThreadPoolExecutor | None = None
+
+    def init(self) -> Task[()]:
+        self._pool = ThreadPoolExecutor(
+            max_workers=max(1, len(self._cameras)),
+            thread_name_prefix=f"multicam-{self.name}",
+        )
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.shutdown(wait=True)
+            self._pool = None
+
+    def _detect_fused_robot(self) -> list[ArucoMarker]:
+        """Dedup by id across cameras; closest detection wins."""
+        if self._pool is None:
+            raise RuntimeError(f"MultiCamera '{self.name}' not initialized")
+        futures = [(cam, self._pool.submit(_safe_detect, cam)) for cam in self._cameras]
+        best: dict[int, ArucoMarker] = {}
+        for cam, fut in futures:
+            for m in fut.result():
+                if m.position_robot_mm is None or m.quat_robot is None:
+                    continue
+                m.source_camera = cam.name
+                prev = best.get(m.id)
+                if prev is None or _squared_distance_robot(m) < _squared_distance_robot(prev):
+                    best[m.id] = m
+        return list(best.values())
+
+    @commands.register(
+        args=[],
+        result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
+    )
+    def get_bricks_robot(self) -> "Task[list[dict[str, Any]]]":
+        """Fused ArUco list in the robot frame, deduplicated across cameras."""
+        out: list[dict[str, Any]] = []
+        for m in self._detect_fused_robot():
+            assert m.position_robot_mm is not None and m.quat_robot is not None
+            qw, qx, qy, qz = m.quat_robot
+            px, py, pz = m.position_robot_mm
+            out.append(
+                {
+                    "id": int(m.id),
+                    "x_mm": float(px),
+                    "y_mm": float(py),
+                    "z_mm": float(pz),
+                    "qw": qw,
+                    "qx": qx,
+                    "qy": qy,
+                    "qz": qz,
+                    "yaw_deg": math.degrees(m.yaw_robot_rad) if m.yaw_robot_rad is not None else 0.0,
+                    "source_camera": m.source_camera or "",
+                }
+            )
+        return ImmediateResultTask(out)
+
+    @commands.register(
+        args=[
+            ("x_mm", ArgTypes.F32()),
+            ("y_mm", ArgTypes.F32()),
+            ("yaw_deg", ArgTypes.F32()),
+        ],
+        result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
+    )
+    def get_bricks_table(
+        self, x_mm: float, y_mm: float, yaw_deg: float
+    ) -> "Task[list[dict[str, Any]]]":
+        """Fused ArUco list in the table frame, given the robot pose in the table."""
+        T_table_robot = Pose3D(x_mm, y_mm, 0.0, 0.0, 0.0, math.radians(yaw_deg))
+        out: list[dict[str, Any]] = []
+        for m in self._detect_fused_robot():
+            assert m.position_robot_mm is not None and m.quat_robot is not None
+            xr, yr, zr = (
+                float(m.position_robot_mm[0]),
+                float(m.position_robot_mm[1]),
+                float(m.position_robot_mm[2]),
+            )
+            qw, qx, qy, qz = m.quat_robot
+            T_robot_marker = Pose3D.from_quaternion(xr, yr, zr, qw, qx, qy, qz)
+            T_table_marker = T_table_robot.compose(T_robot_marker)
+            out.append(
+                {
+                    "id": int(m.id),
+                    "x_mm": T_table_marker.x,
+                    "y_mm": T_table_marker.y,
+                    "z_mm": T_table_marker.z,
+                    "qw": T_table_marker.qw,
+                    "qx": T_table_marker.qx,
+                    "qy": T_table_marker.qy,
+                    "qz": T_table_marker.qz,
+                    "yaw_deg": math.degrees(T_table_marker.yaw),
+                    "source_camera": m.source_camera or "",
+                }
+            )
+        return ImmediateResultTask(out)
+
+
+class MultiCameraDefinition(DriverDefinition):
+    def __init__(self, peripherals: Registry[Peripheral]):
+        super().__init__(MultiCamera.commands)
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required(
+            "cameras",
+            ArgTypes.Array(ArgTypes.Component(Camera, self._peripherals)),
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> MultiCamera:
+        return MultiCamera(name=args.get_name(), cameras=args.get("cameras"))

--- a/src/evo_lib/perception/multi_camera.py
+++ b/src/evo_lib/perception/multi_camera.py
@@ -34,9 +34,9 @@ _BRICK_STRUCT = ArgTypes.Struct(
 )
 
 
-def _squared_distance_robot(m: ArucoMarker) -> float:
-    # Squared, not sqrt — comparison only.
-    p = m.position_robot_mm
+def _squared_distance_camera(m: ArucoMarker) -> float:
+    # Cam→marker distance: best PnP precision wins. Squared, no sqrt.
+    p = m.tvec_camera
     return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
 
 
@@ -85,7 +85,7 @@ class MultiCamera(Peripheral):
                     continue
                 m.source_camera = cam.name
                 prev = best.get(m.id)
-                if prev is None or _squared_distance_robot(m) < _squared_distance_robot(prev):
+                if prev is None or _squared_distance_camera(m) < _squared_distance_camera(prev):
                     best[m.id] = m
         return list(best.values())
 

--- a/src/evo_lib/perception/multi_camera.py
+++ b/src/evo_lib/perception/multi_camera.py
@@ -34,12 +34,6 @@ _BRICK_STRUCT = ArgTypes.Struct(
 )
 
 
-def _squared_distance_camera(m: ArucoMarker) -> float:
-    # Cam→marker distance: best PnP precision wins. Squared, no sqrt.
-    p = m.tvec_camera
-    return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
-
-
 def _safe_detect(cam: Camera) -> list[ArucoMarker]:
     try:
         return cam.detect()
@@ -48,7 +42,7 @@ def _safe_detect(cam: Camera) -> list[ArucoMarker]:
 
 
 class MultiCamera(Peripheral):
-    """Aggregates several Cameras into a deduplicated ArUco brick view."""
+    """Aggregates several Cameras: one row per (camera, marker) observation."""
 
     commands = DriverCommands()
 
@@ -73,30 +67,27 @@ class MultiCamera(Peripheral):
             self._pool.shutdown(wait=True)
             self._pool = None
 
-    def _detect_fused_robot(self) -> list[ArucoMarker]:
-        """Dedup by id across cameras; closest detection wins."""
+    def _detect_all_robot(self) -> list[ArucoMarker]:
         if self._pool is None:
             raise RuntimeError(f"MultiCamera '{self.name}' not initialized")
         futures = [(cam, self._pool.submit(_safe_detect, cam)) for cam in self._cameras]
-        best: dict[int, ArucoMarker] = {}
+        out: list[ArucoMarker] = []
         for cam, fut in futures:
             for m in fut.result():
                 if m.position_robot_mm is None or m.quat_robot is None:
                     continue
                 m.source_camera = cam.name
-                prev = best.get(m.id)
-                if prev is None or _squared_distance_camera(m) < _squared_distance_camera(prev):
-                    best[m.id] = m
-        return list(best.values())
+                out.append(m)
+        return out
 
     @commands.register(
         args=[],
         result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
     )
     def get_bricks_robot(self) -> "Task[list[dict[str, Any]]]":
-        """Fused ArUco list in the robot frame, deduplicated across cameras."""
+        """All ArUco observations in the robot frame, one row per (camera, marker)."""
         out: list[dict[str, Any]] = []
-        for m in self._detect_fused_robot():
+        for m in self._detect_all_robot():
             assert m.position_robot_mm is not None and m.quat_robot is not None
             qw, qx, qy, qz = m.quat_robot
             px, py, pz = m.position_robot_mm
@@ -127,10 +118,10 @@ class MultiCamera(Peripheral):
     def get_bricks_table(
         self, x_mm: float, y_mm: float, yaw_deg: float
     ) -> "Task[list[dict[str, Any]]]":
-        """Fused ArUco list in the table frame, given the robot pose in the table."""
+        """All ArUco observations in the table frame, given the robot pose in the table."""
         T_table_robot = Pose3D(x_mm, y_mm, 0.0, 0.0, 0.0, math.radians(yaw_deg))
         out: list[dict[str, Any]] = []
-        for m in self._detect_fused_robot():
+        for m in self._detect_all_robot():
             assert m.position_robot_mm is not None and m.quat_robot is not None
             xr, yr, zr = (
                 float(m.position_robot_mm[0]),


### PR DESCRIPTION
- Adds `MultiCamera` peripheral: aggregates N `Camera` peripherals with parallel `_safe_detect` calls via a `ThreadPoolExecutor`.
- Returns one row per `(camera, marker)` observation tagged with `source_camera` — no dedup at the library layer. Lets the caller decide whether to fuse, vote, or display raw observations.
- Exposes `get_bricks_robot()` and `get_bricks_table(x_mm, y_mm, yaw_deg)` REPL commands; the latter applies the robot→table transform.

Chained on top of #123. Depends on the per-id marker size table (`tag_sizes_mm`) being injected at the application layer — the omnissiah-side wiring lands in a separate PR.