### PR TITLE
feat(ax12): SYNC_WRITE with cancellable wait + thread_pool starvation fix

### DIFF
--- a/src/evo_lib/drivers/perception/__init__.py
+++ b/src/evo_lib/drivers/perception/__init__.py
@@ -1,0 +1,11 @@
+"""Perception aggregators: helpers that fuse data from several drivers."""
+
+from evo_lib.drivers.perception.multi_camera import (
+    MultiCamera,
+    MultiCameraDefinition,
+)
+
+__all__ = [
+    "MultiCamera",
+    "MultiCameraDefinition",
+]

--- a/src/evo_lib/drivers/perception/multi_camera.py
+++ b/src/evo_lib/drivers/perception/multi_camera.py
@@ -1,0 +1,174 @@
+"""Multi-camera ArUco aggregator: fuses detections from N cameras."""
+
+import math
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from evo_lib.argtypes import ArgTypes
+from evo_lib.driver_definition import (
+    DriverCommands,
+    DriverDefinition,
+    DriverInitArgs,
+    DriverInitArgsDefinition,
+)
+from evo_lib.interfaces.camera import ArucoMarker, Camera
+from evo_lib.peripheral import Peripheral
+from evo_lib.registry import Registry
+from evo_lib.task import ImmediateResultTask, Task
+from evo_lib.types.pose import Pose3D
+
+
+_BRICK_STRUCT = ArgTypes.Struct(
+    [
+        ("id", ArgTypes.U32()),
+        ("x_mm", ArgTypes.F32()),
+        ("y_mm", ArgTypes.F32()),
+        ("z_mm", ArgTypes.F32()),
+        ("qw", ArgTypes.F32()),
+        ("qx", ArgTypes.F32()),
+        ("qy", ArgTypes.F32()),
+        ("qz", ArgTypes.F32()),
+        ("yaw_deg", ArgTypes.F32()),
+        ("source_camera", ArgTypes.String()),
+    ]
+)
+
+
+def _squared_distance_robot(m: ArucoMarker) -> float:
+    # Squared, not sqrt — comparison only.
+    p = m.position_robot_mm
+    return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
+
+
+def _safe_detect(cam: Camera) -> list[ArucoMarker]:
+    try:
+        return cam.detect()
+    except Exception:
+        return []
+
+
+class MultiCamera(Peripheral):
+    """Aggregates several Cameras into a deduplicated ArUco brick view."""
+
+    commands = DriverCommands()
+
+    def __init__(self, name: str, cameras: list[Camera]):
+        super().__init__(name)
+        self._cameras = list(cameras)
+        # ComponentsManager skips Array-typed deps; wire both directions here.
+        for cam in self._cameras:
+            self.add_dependency(cam)
+            cam.add_dependent(self)
+        self._pool: ThreadPoolExecutor | None = None
+
+    def init(self) -> Task[()]:
+        self._pool = ThreadPoolExecutor(
+            max_workers=max(1, len(self._cameras)),
+            thread_name_prefix=f"multicam-{self.name}",
+        )
+        return ImmediateResultTask()
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.shutdown(wait=True)
+            self._pool = None
+
+    def _detect_fused_robot(self) -> list[ArucoMarker]:
+        """Dedup by id across cameras; closest detection wins."""
+        if self._pool is None:
+            raise RuntimeError(f"MultiCamera '{self.name}' not initialized")
+        futures = [(cam, self._pool.submit(_safe_detect, cam)) for cam in self._cameras]
+        best: dict[int, ArucoMarker] = {}
+        for cam, fut in futures:
+            for m in fut.result():
+                if m.position_robot_mm is None or m.quat_robot is None:
+                    continue
+                m.source_camera = cam.name
+                prev = best.get(m.id)
+                if prev is None or _squared_distance_robot(m) < _squared_distance_robot(prev):
+                    best[m.id] = m
+        return list(best.values())
+
+    @commands.register(
+        args=[],
+        result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
+    )
+    def get_bricks_robot(self) -> "Task[list[dict[str, Any]]]":
+        """Fused ArUco list in the robot frame, deduplicated across cameras."""
+        out: list[dict[str, Any]] = []
+        for m in self._detect_fused_robot():
+            assert m.position_robot_mm is not None and m.quat_robot is not None
+            qw, qx, qy, qz = m.quat_robot
+            px, py, pz = m.position_robot_mm
+            out.append(
+                {
+                    "id": int(m.id),
+                    "x_mm": float(px),
+                    "y_mm": float(py),
+                    "z_mm": float(pz),
+                    "qw": qw,
+                    "qx": qx,
+                    "qy": qy,
+                    "qz": qz,
+                    "yaw_deg": math.degrees(m.yaw_robot_rad) if m.yaw_robot_rad is not None else 0.0,
+                    "source_camera": m.source_camera or "",
+                }
+            )
+        return ImmediateResultTask(out)
+
+    @commands.register(
+        args=[
+            ("x_mm", ArgTypes.F32()),
+            ("y_mm", ArgTypes.F32()),
+            ("yaw_deg", ArgTypes.F32()),
+        ],
+        result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
+    )
+    def get_bricks_table(
+        self, x_mm: float, y_mm: float, yaw_deg: float
+    ) -> "Task[list[dict[str, Any]]]":
+        """Fused ArUco list in the table frame, given the robot pose in the table."""
+        T_table_robot = Pose3D(x_mm, y_mm, 0.0, 0.0, 0.0, math.radians(yaw_deg))
+        out: list[dict[str, Any]] = []
+        for m in self._detect_fused_robot():
+            assert m.position_robot_mm is not None and m.quat_robot is not None
+            xr, yr, zr = (
+                float(m.position_robot_mm[0]),
+                float(m.position_robot_mm[1]),
+                float(m.position_robot_mm[2]),
+            )
+            qw, qx, qy, qz = m.quat_robot
+            T_robot_marker = Pose3D.from_quaternion(xr, yr, zr, qw, qx, qy, qz)
+            T_table_marker = T_table_robot.compose(T_robot_marker)
+            out.append(
+                {
+                    "id": int(m.id),
+                    "x_mm": T_table_marker.x,
+                    "y_mm": T_table_marker.y,
+                    "z_mm": T_table_marker.z,
+                    "qw": T_table_marker.qw,
+                    "qx": T_table_marker.qx,
+                    "qy": T_table_marker.qy,
+                    "qz": T_table_marker.qz,
+                    "yaw_deg": math.degrees(T_table_marker.yaw),
+                    "source_camera": m.source_camera or "",
+                }
+            )
+        return ImmediateResultTask(out)
+
+
+class MultiCameraDefinition(DriverDefinition):
+    def __init__(self, peripherals: Registry[Peripheral]):
+        super().__init__(MultiCamera.commands)
+        self._peripherals = peripherals
+
+    def get_init_args_definition(self) -> DriverInitArgsDefinition:
+        defn = DriverInitArgsDefinition()
+        defn.add_required(
+            "cameras",
+            ArgTypes.Array(ArgTypes.Component(Camera, self._peripherals)),
+        )
+        return defn
+
+    def create(self, args: DriverInitArgs) -> MultiCamera:
+        return MultiCamera(name=args.get_name(), cameras=args.get("cameras"))

--- a/src/evo_lib/drivers/perception/multi_camera.py
+++ b/src/evo_lib/drivers/perception/multi_camera.py
@@ -34,9 +34,9 @@ _BRICK_STRUCT = ArgTypes.Struct(
 )
 
 
-def _squared_distance_robot(m: ArucoMarker) -> float:
-    # Squared, not sqrt — comparison only.
-    p = m.position_robot_mm
+def _squared_distance_camera(m: ArucoMarker) -> float:
+    # Cam→marker distance: best PnP precision wins. Squared, no sqrt.
+    p = m.tvec_camera
     return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
 
 
@@ -85,7 +85,7 @@ class MultiCamera(Peripheral):
                     continue
                 m.source_camera = cam.name
                 prev = best.get(m.id)
-                if prev is None or _squared_distance_robot(m) < _squared_distance_robot(prev):
+                if prev is None or _squared_distance_camera(m) < _squared_distance_camera(prev):
                     best[m.id] = m
         return list(best.values())
 

--- a/src/evo_lib/drivers/perception/multi_camera.py
+++ b/src/evo_lib/drivers/perception/multi_camera.py
@@ -34,12 +34,6 @@ _BRICK_STRUCT = ArgTypes.Struct(
 )
 
 
-def _squared_distance_camera(m: ArucoMarker) -> float:
-    # Cam→marker distance: best PnP precision wins. Squared, no sqrt.
-    p = m.tvec_camera
-    return float(p[0] * p[0] + p[1] * p[1] + p[2] * p[2])
-
-
 def _safe_detect(cam: Camera) -> list[ArucoMarker]:
     try:
         return cam.detect()
@@ -48,7 +42,7 @@ def _safe_detect(cam: Camera) -> list[ArucoMarker]:
 
 
 class MultiCamera(Peripheral):
-    """Aggregates several Cameras into a deduplicated ArUco brick view."""
+    """Aggregates several Cameras: one row per (camera, marker) observation."""
 
     commands = DriverCommands()
 
@@ -73,30 +67,27 @@ class MultiCamera(Peripheral):
             self._pool.shutdown(wait=True)
             self._pool = None
 
-    def _detect_fused_robot(self) -> list[ArucoMarker]:
-        """Dedup by id across cameras; closest detection wins."""
+    def _detect_all_robot(self) -> list[ArucoMarker]:
         if self._pool is None:
             raise RuntimeError(f"MultiCamera '{self.name}' not initialized")
         futures = [(cam, self._pool.submit(_safe_detect, cam)) for cam in self._cameras]
-        best: dict[int, ArucoMarker] = {}
+        out: list[ArucoMarker] = []
         for cam, fut in futures:
             for m in fut.result():
                 if m.position_robot_mm is None or m.quat_robot is None:
                     continue
                 m.source_camera = cam.name
-                prev = best.get(m.id)
-                if prev is None or _squared_distance_camera(m) < _squared_distance_camera(prev):
-                    best[m.id] = m
-        return list(best.values())
+                out.append(m)
+        return out
 
     @commands.register(
         args=[],
         result=[("bricks", ArgTypes.Array(_BRICK_STRUCT))],
     )
     def get_bricks_robot(self) -> "Task[list[dict[str, Any]]]":
-        """Fused ArUco list in the robot frame, deduplicated across cameras."""
+        """All ArUco observations in the robot frame, one row per (camera, marker)."""
         out: list[dict[str, Any]] = []
-        for m in self._detect_fused_robot():
+        for m in self._detect_all_robot():
             assert m.position_robot_mm is not None and m.quat_robot is not None
             qw, qx, qy, qz = m.quat_robot
             px, py, pz = m.position_robot_mm
@@ -127,10 +118,10 @@ class MultiCamera(Peripheral):
     def get_bricks_table(
         self, x_mm: float, y_mm: float, yaw_deg: float
     ) -> "Task[list[dict[str, Any]]]":
-        """Fused ArUco list in the table frame, given the robot pose in the table."""
+        """All ArUco observations in the table frame, given the robot pose in the table."""
         T_table_robot = Pose3D(x_mm, y_mm, 0.0, 0.0, 0.0, math.radians(yaw_deg))
         out: list[dict[str, Any]] = []
-        for m in self._detect_fused_robot():
+        for m in self._detect_all_robot():
             assert m.position_robot_mm is not None and m.quat_robot is not None
             xr, yr, zr = (
                 float(m.position_robot_mm[0]),

--- a/src/evo_lib/drivers/pilot/serial_pilot.py
+++ b/src/evo_lib/drivers/pilot/serial_pilot.py
@@ -766,6 +766,7 @@ class HolonomicSerialPilotDefinition(DriverDefinition):
             logger=self._logger,
             bus=args.get("serial"),
             transform=args.get("transform"),
+            config=DifferentialSerialPilotConfig(),
         )
 
 

--- a/src/evo_lib/drivers/smart_servo/ax12.py
+++ b/src/evo_lib/drivers/smart_servo/ax12.py
@@ -38,6 +38,7 @@ from evo_lib.thread_pool import ThreadPoolExecutor
 # Dynamixel 1.0 instructions
 _INST_READ = 0x02
 _INST_WRITE = 0x03
+_INST_SYNC_WRITE = 0x83
 
 # AX-12A factory baudrate (EEPROM default). USB2AX runs the bus at this speed
 # unless explicitly reconfigured — mismatch = silent timeout, not an error.
@@ -54,6 +55,7 @@ _PRESENT_SPEED_L = 38
 _PRESENT_LOAD_L = 40
 _PRESENT_VOLTAGE = 42
 _PRESENT_TEMPERATURE = 43
+_MOVING = 46  # 1 = moving, 0 = stopped (reached or stalled)
 
 # AX-12A constants (datasheet: Dynamixel 1.0 / AX-12A control table)
 _POSITION_MAX = 1023
@@ -166,6 +168,16 @@ class InstructionError(DynamixelServoError):
         super().__init__(servo_id, error_byte, "unknown instruction")
 
 
+class StalledError(OSError):
+    """Servo stopped moving (MOVING=0) without reaching the goal tolerance."""
+
+    def __init__(self, servo_id: int, goal: int, current: int):
+        self.servo_id = servo_id
+        self.goal = goal
+        self.current = current
+        super().__init__(f"AX12 id {servo_id}: stalled at {current}, goal {goal}")
+
+
 # Order matters only for diagnostics when multiple bits are set: we surface
 # the lowest-numbered bit that matched. The error_byte attribute preserves
 # the full mask so callers can inspect all flags.
@@ -237,6 +249,8 @@ class AX12Bus(InterfaceHolder):
         self._queued_requests: Queue[tuple[DelayedTask[Any], Callable[[], Any]]] = Queue()
         self._pending_request: DelayedTask[Any] | None = None
         self._last_request_time = 0
+        # Set by close() so servo poll loops can exit cooperatively.
+        self.close_event = threading.Event()
         # Reusable TX buffer (hot path): avoids per-call bytearray allocation on
         # every write/read. Safe under the bus lock, only one packet is ever
         # being built at a time. Matters on RPi 3 B+ where GC pressure adds up.
@@ -250,6 +264,7 @@ class AX12Bus(InterfaceHolder):
         return ImmediateResultTask()
 
     def close(self) -> None:
+        self.close_event.set()
         self._servos.clear()
         self._log.info(f"AX12Bus '{self.name}' closed")
 
@@ -272,6 +287,33 @@ class AX12Bus(InterfaceHolder):
     def read_register(self, servo_id: int, register: int, count: int) -> Task[bytes]:
         """Send a READ instruction and return the payload bytes."""
         return self._request(lambda: self._do_read(servo_id, register, count))
+
+    def sync_write_register(
+        self,
+        register: int,
+        data_len: int,
+        data_per_id: dict[int, bytes],
+    ) -> Task[()]:
+        """Broadcast a SYNC_WRITE: all servos receive and apply in one frame.
+
+        No status reply (broadcast). Every entry of data_per_id must be of
+        length data_len bytes. Intended for synchronized moves where the
+        wire-time cost of N sequential WRITE+ACK round trips is visible.
+        """
+        return self._request(
+            lambda: self._do_sync_write(register, data_len, data_per_id)
+        )
+
+    def sync_write_word(self, register: int, values: dict[int, int]) -> Task[()]:
+        """Convenience: SYNC_WRITE a 16-bit little-endian value per servo."""
+        data_per_id = {
+            sid: bytes([v & 0xFF, (v >> 8) & 0xFF]) for sid, v in values.items()
+        }
+        return self.sync_write_register(register, 2, data_per_id)
+
+    def sync_write_goal_positions(self, positions: dict[int, int]) -> Task[()]:
+        """SYNC_WRITE goal positions to multiple AX12s — synchronized start."""
+        return self.sync_write_word(_GOAL_POSITION_L, positions)
 
     def _on_request_done(self) -> None:
         #print("AX12 request done")
@@ -375,6 +417,40 @@ class AX12Bus(InterfaceHolder):
         if servo_id != _BROADCAST_ID:
             self._read_status(servo_id)
 
+    def _do_sync_write(
+        self, register: int, data_len: int, data_per_id: dict[int, bytes]
+    ) -> None:
+        n = len(data_per_id)
+        length = (data_len + 1) * n + 4
+        # self._tx_buf is sized for single WRITE; SYNC_WRITE needs more.
+        buf = bytearray(length + 4)
+        buf[0] = _HEADER_B0
+        buf[1] = _HEADER_B1
+        buf[2] = _BROADCAST_ID
+        buf[3] = length
+        buf[4] = _INST_SYNC_WRITE
+        buf[5] = register
+        buf[6] = data_len
+        cs = _BROADCAST_ID + length + _INST_SYNC_WRITE + register + data_len
+        offset = 7
+        for servo_id, data in data_per_id.items():
+            if len(data) != data_len:
+                raise ValueError(
+                    f"sync_write data for id={servo_id} is {len(data)} bytes, expected {data_len}"
+                )
+            buf[offset] = servo_id
+            cs += servo_id
+            offset += 1
+            for b in data:
+                buf[offset] = b
+                cs += b
+                offset += 1
+        buf[offset] = (~cs) & 0xFF
+        size = offset + 1
+        packet = bytes(buf[:size])
+        self._send_and_drop_echo(packet)
+        # SYNC_WRITE is broadcast: no status reply expected.
+
     def _do_read(self, servo_id: int, register: int, count: int) -> bytes:
         length = 4  # instruction + register + count + checksum
         buf = self._tx_buf
@@ -464,6 +540,10 @@ class AX12(SmartServo):
         bus.register_servo(self)
 
     @property
+    def id(self) -> int:
+        return self._id
+
+    @property
     def servo_id(self) -> int:
         return self._id
 
@@ -504,15 +584,24 @@ class AX12(SmartServo):
 
         start_time = time.time()
         while True:
-            if timeout is not None and time.time() - start_time > timeout:
+            if self._bus.close_event.is_set():
+                return
+            elapsed = time.time() - start_time
+            if timeout is not None and elapsed > timeout:
                 raise TimeoutError("Move timed out")
             (current_position,) = self.get_position(ServoAngleUnit.NATIVE).wait()
             remaining_distance = wait_position - current_position
             if abs(remaining_distance) < self._goal_reached_tolerance:
-                break  # If we're close enough, return
+                break
             if remaining_distance * move_direction < 0:
-                break  # If we go beyond the target, return
-            time.sleep(self._poll_interval)
+                break
+            # Skip MOVING on first poll: servo takes a few ms to flip the bit.
+            if elapsed > self._poll_interval:
+                (moving_data,) = self._bus.read_register(self._id, _MOVING, 1).wait()
+                if moving_data[0] == 0:
+                    raise StalledError(self._id, raw_position, current_position)
+            if self._bus.close_event.wait(self._poll_interval):
+                return
 
     def move_to(
         self,
@@ -539,6 +628,22 @@ class AX12(SmartServo):
         if wait_multiplier == 0:
             return ImmediateResultTask()
 
+        return self._thread_pool.exec(
+            lambda: self._wait_move_to_sync(raw_position, wait_multiplier, timeout)
+        )
+
+    def wait_until_position(
+        self,
+        raw_position: int,
+        wait_multiplier: float = 1.0,
+        timeout: float | None = None,
+    ) -> Task[()]:
+        """Poll until the servo reaches raw_position. Does NOT write the goal.
+
+        Companion to AX12Bus.sync_write_goal_positions for synchronized
+        moves: write all goals at once, then wait_until_position on each in
+        parallel.
+        """
         return self._thread_pool.exec(
             lambda: self._wait_move_to_sync(raw_position, wait_multiplier, timeout)
         )

--- a/src/evo_lib/thread_pool.py
+++ b/src/evo_lib/thread_pool.py
@@ -1,5 +1,5 @@
 from queue import Queue
-from threading import Event, Lock, Thread
+from threading import Lock, Thread
 from typing import Callable
 
 from evo_lib.executor import Executor
@@ -15,12 +15,10 @@ class WorkerThread:
     def __init__(self, pool: ThreadPoolExecutor):
         self.pool = pool
         self.thread: Thread = None
-        self.busy = Event()
 
     def start(self) -> None:
         if self.thread is not None:
             return
-        self.busy.clear()
         self.thread = Thread(target=self._loop)
         self.thread.start()
 
@@ -29,19 +27,21 @@ class WorkerThread:
         self.thread = None
 
     def _loop(self) -> None:
+        # First iteration claims the task that triggered this worker's spawn.
+        first = True
         while True:
+            if not first:
+                with self.pool.lock:
+                    self.pool._available_slots += 1
+            first = False
             task = self.pool.queue.get()
             if task is None:
                 break
-
-            self.busy.set()
             result, func, args, kwargs = task
             try:
                 result.complete(func(*args, **kwargs))
             except Exception as e:
                 result.error(e)
-            finally:
-                self.busy.clear()
 
 
 class ThreadPoolExecutor(Executor):
@@ -59,14 +59,16 @@ class ThreadPoolExecutor(Executor):
         self.logger = logger
         self.max_workers = max_workers
         self._stopping = False
+        # Workers about to enter queue.get() with no claim yet.
+        self._available_slots = 0
 
     def set_max_workers(self, max_workers: int) -> None:
         self.max_workers = max_workers
 
     def _create_worker(self) -> WorkerThread:
         worker = WorkerThread(self)
-        worker.start()
         self.workers.append(worker)
+        worker.start()
         return worker
 
     def exec[T](self, callback: Callable[..., T], *args, **kwargs) -> Task[T]:
@@ -74,20 +76,14 @@ class ThreadPoolExecutor(Executor):
             raise RuntimeError("ThreadPoolExecutor is stopping, cannot submit new tasks")
 
         result = DelayedTask()
-        self.queue.put((result, callback, args, kwargs))
-
         with self.lock:
-            # If any worker is idle, it will pick up the task from the queue
-            for worker in self.workers:
-                if not worker.busy.is_set():
-                    return result
-
-            # All workers are busy, create a new one if allowed
-            if self.max_workers == 0 or len(self.workers) < self.max_workers:
+            if self._available_slots > 0:
+                self._available_slots -= 1
+            elif self.max_workers == 0 or len(self.workers) < self.max_workers:
                 self._create_worker()
             else:
                 self.logger.warning("Maximum number of workers reached, the task will be queued")
-
+            self.queue.put((result, callback, args, kwargs))
         return result
 
     def stop(self) -> None:

--- a/tests/test_smart_servo.py
+++ b/tests/test_smart_servo.py
@@ -6,6 +6,7 @@ import pytest
 
 from evo_lib.drivers.serial.virtual import SerialVirtual
 from evo_lib.drivers.smart_servo.ax12 import (
+    _MOVING,
     AX12,
     AngleLimitError,
     AX12Bus,
@@ -17,6 +18,7 @@ from evo_lib.drivers.smart_servo.ax12 import (
     OverloadError,
     PacketChecksumError,
     RangeError,
+    StalledError,
     _checksum,
 )
 from evo_lib.interfaces.smart_servo import ServoAngleUnit, ServoSpeedUnit
@@ -230,6 +232,25 @@ class TestAX12WithVirtualBus:
         bus = self._bus(log, thread_pool)
         servo = AX12("s", log, thread_pool, bus, servo_id=3)
         task = servo.move_to(500, ServoAngleUnit.NATIVE, wait_multiplier=0)
+        assert task.is_done()
+
+    def test_wait_raises_stalled_when_servo_reports_not_moving(self, log, thread_pool):
+        bus = self._bus(log, thread_pool)
+        servo = AX12("s", log, thread_pool, bus, servo_id=3, poll_frequency=200)
+        bus.inject_position(3, 100)
+        bus.write_register(3, _MOVING, bytes([0])).wait(timeout=1.0)
+        task = servo.move_to(500, ServoAngleUnit.NATIVE, wait_multiplier=1.0)
+        with pytest.raises(StalledError):
+            task.wait(timeout=1.0)
+
+    def test_close_event_aborts_wait(self, log, thread_pool):
+        bus = self._bus(log, thread_pool)
+        servo = AX12("s", log, thread_pool, bus, servo_id=3, poll_frequency=10)
+        bus.inject_position(3, 100)
+        bus.write_register(3, _MOVING, bytes([1])).wait(timeout=1.0)
+        task = servo.move_to(500, ServoAngleUnit.NATIVE, wait_multiplier=1.0)
+        bus.close()
+        task.wait(timeout=1.0)
         assert task.is_done()
 
     def test_registered_in_subcomponents(self, log, thread_pool):


### PR DESCRIPTION
## Summary
- `AX12Bus.sync_write_*` : émet une frame Dynamixel 1.0 SYNC_WRITE (0x83) pour démarrer N servos sur le même cycle bus ; companion `AX12.wait_until_position` pour attendre chacun en parallèle via `Task.wait_all`.
- `_wait_move_to_sync` est désormais interruptible (`AX12Bus.close_event` set par `close()` → sleep annulable) et lève `StalledError` si le registre MOVING (0x2E) retombe à 0 avant d'atteindre la tolérance.
- `ThreadPoolExecutor` : fix d'un bug de starvation où le check racy `worker.busy.is_set()` voyait un worker fraîchement spawné comme idle entre `start()` et `queue.get()`, ce qui empêchait le spawn de workers supplémentaires sur N submits rapides (typique de `Task.wait_all` sur 4 fingers). Remplacé par un compteur `_available_slots` explicite décrémenté atomiquement.

## Bug observé sans le fix thread_pool
`/script move 1 half` (4 fingers en SYNC_WRITE + 4 `wait_until_position` parallèles) → REPL bloquée indéfiniment. `py-spy dump` sur le process figé montrait 2 workers en `_wait_move_to_sync.get_position.wait()` et **aucun worker** sur le bus : 2 tasks coincées dans la queue FIFO sans worker pour les piocher.